### PR TITLE
Button Advanced Visibility

### DIFF
--- a/app/src/main/java/to/bitkit/ui/onboarding/RestoreWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/RestoreWalletScreen.kt
@@ -287,6 +287,7 @@ fun RestoreWalletView(
                     BodyS(
                         text = stringResource(R.string.onboarding__restore_passphrase_meaning),
                         color = Colors.White64,
+                        modifier = Modifier.padding(bottom = 16.dp)
                     )
                 }
 


### PR DESCRIPTION
[Figma - Handoff 54](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=29144-207589&t=s9yanRdHA5D5BMli-4)

- [x] Hide button advanced when the input is visible
- [x] fix: Add padding bottom in passphrase hint

[advanved_button_visibility.webm](https://github.com/user-attachments/assets/422543bb-1482-469a-ac8c-ee6d0937c636)