### PR TITLE
Create and implement HighlightLabel in Passphrase screen

### DIFF
--- a/app/src/main/java/to/bitkit/ui/components/HighlightLabel.kt
+++ b/app/src/main/java/to/bitkit/ui/components/HighlightLabel.kt
@@ -1,4 +1,4 @@
-package to.bitkit.ui.shared
+package to.bitkit.ui.components
 
 
 import androidx.compose.foundation.Canvas
@@ -20,7 +20,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import to.bitkit.R
-import to.bitkit.ui.components.Caption13Up
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors.Brand
 
@@ -113,14 +112,6 @@ fun HighlightLabel(
 fun FlexibleLogoPreview() {
     AppThemeSurface {
         HighlightLabel(text = stringResource(R.string.onboarding__advanced))
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun ShortTextLogoPreview() {
-    AppThemeSurface {
-        HighlightLabel(text = "GAME")
     }
 }
 

--- a/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletWithPassphraseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletWithPassphraseScreen.kt
@@ -41,9 +41,9 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.HighlightLabel
 import to.bitkit.ui.components.PrimaryButton
-import to.bitkit.ui.shared.HighlightLabel
-import to.bitkit.ui.shared.mainRectHeight
+import to.bitkit.ui.components.mainRectHeight
 import to.bitkit.ui.theme.AppTextFieldDefaults
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors


### PR DESCRIPTION
[FIGMA - Handoff 54](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=29144-206961&t=JeTA0cOvoPhscKvh-4)

- [x] Create the component `HighlightLabel`
- [x] Implement in the screen `CreateWalletWithPassphraseScreen`
closes https://github.com/synonymdev/bitkit/issues/2498#issue-2881785181

![Component](https://github.com/user-attachments/assets/afc1b13e-dadc-4837-a7b7-3a663afba291)

[advanced.webm](https://github.com/user-attachments/assets/28a73d99-534f-4b07-850f-45a132687f86)
