### PR TITLE
Create Wallet buttons dimensions in small screen

### DIFF
--- a/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletScreen.kt
@@ -2,20 +2,16 @@ package to.bitkit.ui.onboarding
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource


### PR DESCRIPTION
[FIGMA - Handoff 54
](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=27760-49635&t=haXcXh3NTHUi7lnQ-4)
- [x] fix: component vertical dimensions in short screens

- Closes https://github.com/synonymdev/bitkit/issues/2496#issue-2881775710
- Closes https://github.com/synonymdev/bitkit/issues/2495#issue-2881755091

**Before** 
<div style="display: flex; gap: 20px;">
  <img src="https://github.com/user-attachments/assets/a4ea6f96-4138-4269-8f46-69f2e8f7b014" alt="Light Mode" width="300" height="auto">
</div>

**After** 
<div style="display: flex; gap: 20px;">
  <img src="https://github.com/user-attachments/assets/fa1af7fb-0f1c-4c44-90bd-d51ab3fc2551" alt="Light Mode" width="300" height="auto">
</div>
