### PR TITLE
Create Wallet buttons dimensions in small screens

### DIFF
--- a/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletScreen.kt
@@ -45,13 +45,13 @@ fun CreateWalletScreen(
             contentDescription = null,
             contentScale = ContentScale.Fit,
             modifier = Modifier
-                .padding(top = 125.dp, start = 29.62.dp, end = 29.62.dp)
+                .padding(top = 125.dp)
                 .fillMaxWidth()
         )
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight(.4f)
+                .height(250.dp)
                 .align(Alignment.BottomCenter),
         ) {
             Display(text = stringResource(R.string.onboarding__slide4_header).withAccent())

--- a/app/src/main/java/to/bitkit/ui/onboarding/OnboardingSlidesScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/OnboardingSlidesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -196,13 +197,13 @@ fun OnboardingTab(
             contentDescription = null,
             contentScale = ContentScale.Fit,
             modifier = Modifier
-                .padding(top = 125.dp, start = 29.62.dp, end = 29.62.dp)
+                .padding(top = 125.dp)
                 .fillMaxWidth()
         )
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight(.4f)
+                .height(250.dp)
                 .align(Alignment.BottomCenter),
         ) {
             Display(text = title.withAccent(accentColor = titleAccentColor))


### PR DESCRIPTION
[FIGMA - Handoff 54](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=27760-49635&t=haXcXh3NTHUi7lnQ-4)
- [x] fix: implement a fixed height in the column and reduce the image top padding

- Closes https://github.com/synonymdev/bitkit/issues/2496#issue-2881775710
- Closes https://github.com/synonymdev/bitkit/issues/2495#issue-2881755091
- Closes #47 

**Before** 
<div style="display: flex; gap: 20px;">
  <img src="https://github.com/user-attachments/assets/a4ea6f96-4138-4269-8f46-69f2e8f7b014" alt="Light Mode" width="300" height="auto">
</div>

**After** 

[create_wallet_pixel2.webm](https://github.com/user-attachments/assets/8ef1db50-4136-41a6-a546-7e8efb24b376)

[create_wallet_pixel9.webm](https://github.com/user-attachments/assets/c998153d-978b-414e-8945-3bff471d5802)
