### PR TITLE
String formmating error lint

### DIFF
--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -447,7 +447,7 @@
     <string name="wallet__send_swipe">Deslizar para pagar</string>
     <string name="wallet__send_yes">Sí, enviar</string>
     <string name="wallet__send_dialog1">Parece que está enviando más de 100 dólares. ¿Desea continuar?</string>
-    <string name="wallet__send_dialog2">Parece que está enviando más del 50% de su saldo total. ¿Desea continuar?</string>
+    <string name="wallet__send_dialog2">Parece que está enviando más del 50%% de su saldo total. ¿Desea continuar?</string>
     <string name="wallet__send_dialog3">La comisión de transacción parece ser superior al 50% del importe que está enviando. ¿Desea continuar?</string>
     <string name="wallet__send_dialog4">La tasa de transacción parece ser superior a 10 dólares. ¿Desea continuar?</string>
     <string name="wallet__send_dialog5_title">La tasa es potencialmente demasiado baja</string>

--- a/app/src/main/res/values-b+pt+BR/strings.xml
+++ b/app/src/main/res/values-b+pt+BR/strings.xml
@@ -768,8 +768,8 @@
     <string name="wallet__send_swipe">Passe o dedo para Pagar</string>
     <string name="wallet__send_yes">Sim, Enviar</string>
     <string name="wallet__send_dialog1">Parece que você está enviando mais de US$ 100. Deseja continuar?</string>
-    <string name="wallet__send_dialog2">Parece que você está enviando mais de 50% do seu saldo total. Deseja continuar?</string>
-    <string name="wallet__send_dialog3">A taxa de transação parece ser superior a 50% do valor que você está enviando. Deseja continuar?</string>
+    <string name="wallet__send_dialog2">Parece que você está enviando mais de 50%% do seu saldo total. Deseja continuar?</string>
+    <string name="wallet__send_dialog3">A taxa de transação parece ser superior a 50%% do valor que você está enviando. Deseja continuar?</string>
     <string name="wallet__send_dialog4">A taxa de transação parece ser superior a US$ 10. Deseja continuar?</string>
     <string name="wallet__send_dialog5_title">A taxa é potencialmente muito baixa</string>
     <string name="wallet__send_dialog5_description">As condições atuais da rede exigem que sua taxa seja maior que {minimumFee} ₿/vbyte. Essa transação pode falhar, demorar um pouco para ser confirmada ou ser excluída da mempool. Deseja prosseguir?</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -505,8 +505,8 @@
     <string name="wallet__send_swipe">Desplaça per pagar</string>
     <string name="wallet__send_yes">Sí, Enviar</string>
     <string name="wallet__send_dialog1">Sembla que estàs enviant més de 100 $. Vols continuar?</string>
-    <string name="wallet__send_dialog2">Sembla que estàs enviant més del 50% del teu saldo total. Vols continuar?</string>
-    <string name="wallet__send_dialog3">La comissió de la transacció sembla ser més del 50% de l\'import que estàs enviant. Vols continuar?</string>
+    <string name="wallet__send_dialog2">Sembla que estàs enviant més del 50%% del teu saldo total. Vols continuar?</string>
+    <string name="wallet__send_dialog3">La comissió de la transacció sembla ser més del 50%% de l\'import que estàs enviant. Vols continuar?</string>
     <string name="wallet__send_dialog4">La comissió de la transacció sembla ser superior a 10 $. Vols continuar?</string>
     <string name="wallet__send_dialog5_title">La comissió és massa baixa</string>
     <string name="wallet__send_sent">Bitcoin Enviat</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -870,8 +870,8 @@
     <string name="wallet__send_swipe">Zaplatit přejetím prstem</string>
     <string name="wallet__send_yes">Ano, odeslat</string>
     <string name="wallet__send_dialog1">Zdá se, že posíláte více než $100. Přejete si pokračovat?</string>
-    <string name="wallet__send_dialog2">Zdá se, že posíláte více než 50 % svého celkového zůstatku. Přejete si pokračovat?</string>
-    <string name="wallet__send_dialog3">Zdá se, že transakční poplatek přesahuje 50 % částky, kterou odesíláte. Přejete si pokračovat?</string>
+    <string name="wallet__send_dialog2">Zdá se, že posíláte více než 50 %% svého celkového zůstatku. Přejete si pokračovat?</string>
+    <string name="wallet__send_dialog3">Zdá se, že transakční poplatek přesahuje 50 %% částky, kterou odesíláte. Přejete si pokračovat?</string>
     <string name="wallet__send_dialog4">Transakční poplatek se zdá být vyšší než $10. Přejete si pokračovat?</string>
     <string name="wallet__send_dialog5_title">Poplatek je potenciálně příliš nízký</string>
     <string name="wallet__send_dialog5_description">Současné síťové podmínky vyžadují, aby váš poplatek byl vyšší než {minimumFee} ₿/vbyte. Tato transakce může selhat, chvíli trvat, než se potvrdí nebo může být z mempoolu odstraněna. Přejete si pokračovat?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -860,7 +860,7 @@
     <string name="wallet__send_swipe">Zum Bezahlen wischen</string>
     <string name="wallet__send_yes">Ja, senden</string>
     <string name="wallet__send_dialog1">Es scheint, dass du über $100 sendest. Möchtest du fortfahren?</string>
-    <string name="wallet__send_dialog2">Es scheint, dass du über 50% deines Gesamtguthabens sendest. Möchtest du fortfahren?</string>
+    <string name="wallet__send_dialog2">Es scheint, dass du über 50%% deines Gesamtguthabens sendest. Möchtest du fortfahren?</string>
     <string name="wallet__send_dialog3">Die Transaktionsgebühr scheint über 50% des gesendeten Betrags zu liegen. Möchtest du fortfahren?</string>
     <string name="wallet__send_dialog4">Die Transaktionsgebühr scheint über $10 zu liegen. Möchtest du fortfahren?</string>
     <string name="wallet__send_dialog5_title">Gebühr ist möglicherweise zu niedrig</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -604,8 +604,8 @@
     <string name="wallet__send_swipe">Deslizar para pagar</string>
     <string name="wallet__send_yes">Sí, enviar</string>
     <string name="wallet__send_dialog1">Parece que está enviando más de 100 dólares. ¿Desea continuar?</string>
-    <string name="wallet__send_dialog2">Parece que está enviando más del 50% de su saldo total. ¿Desea continuar?</string>
-    <string name="wallet__send_dialog3">La comisión de transacción parece ser superior al 50% del importe que está enviando. ¿Desea continuar?</string>
+    <string name="wallet__send_dialog2">Parece que está enviando más del 50%% de su saldo total. ¿Desea continuar?</string>
+    <string name="wallet__send_dialog3">La comisión de transacción parece ser superior al 50%% del importe que está enviando. ¿Desea continuar?</string>
     <string name="wallet__send_dialog4">La comisión de transacción parece ser superior a 10 dólares. ¿Desea continuar?</string>
     <string name="wallet__send_dialog5_title">La comisión es potencialmente muy baja</string>
     <string name="wallet__send_sent">Bitcoin Enviado</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -770,7 +770,7 @@
     <string name="wallet__send_swipe">Scorri per Pagare</string>
     <string name="wallet__send_yes">Si, Invia</string>
     <string name="wallet__send_dialog1">Sembra che tu stia inviando più di $100. Vuoi continuare?</string>
-    <string name="wallet__send_dialog2">Sembra che tu stia inviando più del 50% del suo saldo totale. Vuoi continuare?</string>
+    <string name="wallet__send_dialog2">Sembra che tu stia inviando più del 50%% del suo saldo totale. Vuoi continuare?</string>
     <string name="wallet__send_dialog3">La commissione della transazione sembra essere superiore al 50% dell\'importo che stai inviando. Vuoi continuare?</string>
     <string name="wallet__send_dialog4">La commissione della transazione sembra essere superiore a $10. Vuoi continuare?</string>
     <string name="wallet__send_dialog5_title">Le commissione è potenzialmente troppo bassa</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -623,8 +623,8 @@
     <string name="wallet__send_swipe">Veeg Om Te Betalen</string>
     <string name="wallet__send_yes">Ja, Verstuur</string>
     <string name="wallet__send_dialog1">Het lijkt er op dat u meer dan $100 wilt versturen. Wilt u doorgaan?</string>
-    <string name="wallet__send_dialog2">Het lijkt er op dat u meer dan 50% van uw totale saldo wil versturen. Wilt u doorgaan?</string>
-    <string name="wallet__send_dialog3">De transactiekosten lijken meer dan 50% van het totale bedrag wat u wilt versturen. Wilt u doorgaan?</string>
+    <string name="wallet__send_dialog2">Het lijkt er op dat u meer dan 50%% van uw totale saldo wil versturen. Wilt u doorgaan?</string>
+    <string name="wallet__send_dialog3">De transactiekosten lijken meer dan 50%% van het totale bedrag wat u wilt versturen. Wilt u doorgaan?</string>
     <string name="wallet__send_dialog4">De transactiekosten lijken meer dan $10 te zijn. Wilt u doorgaan?</string>
     <string name="wallet__send_dialog5_title">Vergoeding is mogelijk te laag</string>
     <string name="wallet__send_dialog5_description">De huidige netwerkomstandigheden vereisen dat uw vergoeding groter is dan {minimumFee} ₿/vbyte. Deze transactie kan mislukken, lang duren om te bevestigen, of uit de mempool worden verwijderd. Wilt u doorgaan?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -828,8 +828,8 @@
     <string name="wallet__send_swipe">Отправить</string>
     <string name="wallet__send_yes">Да, Отправить</string>
     <string name="wallet__send_dialog1">Похоже, вы отправляете более 100$. Вы хотите продолжать?</string>
-    <string name="wallet__send_dialog2">Похоже, вы отправляете более 50% от общего баланса. Вы хотите продолжать?</string>
-    <string name="wallet__send_dialog3">Комиссия за транзакцию составляет более 50% от суммы, которую вы отправляете. Вы хотите продолжать?</string>
+    <string name="wallet__send_dialog2">Похоже, вы отправляете более 50%% от общего баланса. Вы хотите продолжать?</string>
+    <string name="wallet__send_dialog3">Комиссия за транзакцию составляет более 50%% от суммы, которую вы отправляете. Вы хотите продолжать?</string>
     <string name="wallet__send_dialog4">Комиссия за транзакцию составляет более 10$. Вы хотите продолжать?</string>
     <string name="wallet__send_dialog5_title">Комиссия может быть слишком низкой</string>
     <string name="wallet__send_dialog5_description">Текущие условия сети требуют, чтобы ваша комиссия была больше {minimumFee} ₿/вбайт. Эта транзакция может не пройти, занять время на подтверждение или быть удалена из мемпула. Вы хотите продолжить?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -870,8 +870,8 @@
     <string name="wallet__send_swipe">Swipe To Pay</string>
     <string name="wallet__send_yes">Yes, Send</string>
     <string name="wallet__send_dialog1">It appears you are sending over $100. Do you want to continue?</string>
-    <string name="wallet__send_dialog2">It appears you are sending over 50% of your total balance. Do you want to continue?</string>
-    <string name="wallet__send_dialog3">The transaction fee appears to be over 50% of the amount you are sending. Do you want to continue?</string>
+    <string name="wallet__send_dialog2">It appears you are sending over 50%% of your total balance. Do you want to continue?</string>
+    <string name="wallet__send_dialog3">The transaction fee appears to be over 50%% of the amount you are sending. Do you want to continue?</string>
     <string name="wallet__send_dialog4">The transaction fee appears to be over $10. Do you want to continue?</string>
     <string name="wallet__send_dialog5_title">Fee is potentially too low</string>
     <string name="wallet__send_dialog5_description">Current network conditions require that your fee should be greater than {minimumFee} ₿/vbyte. This transaction may fail, take a while to confirm, or get trimmed from the mempool. Do you wish to proceed?</string>


### PR DESCRIPTION
Lint error message
https://github.com/synonymdev/bitkit-android/actions/runs/13951941749/job/39053493339?pr=61

```
   Explanation for issues of type "StringFormatInvalid":
   If a string contains a '%' character, then the string may be a formatting
   string which will be passed to String.format from Java code to replace each
   '%' occurrence with specific values.
   This lint warning checks for two related problems:
   (1) Formatting strings that are invalid, meaning that String.format will
   throw exceptions at runtime when attempting to use the format string.
   (2) Strings containing '%' that are not formatting strings getting passed
   to a String.format call. In this case the '%' will need to be escaped as
   '%%'.
   NOTE: Not all Strings which look like formatting strings are intended for
   use by String.format; for example, they may contain date formats intended
   for android.text.format.Time#format(). Lint cannot always figure out that a
   String is a date format, so you may get false warnings in those scenarios.
   See the suppress help topic for information on how to suppress errors in
   that case.
```