### PR TITLE
Implement UnitButton in SendAmountScreen

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
@@ -19,8 +19,8 @@ import to.bitkit.models.PrimaryDisplay
 import to.bitkit.ui.LocalBalances
 import to.bitkit.ui.LocalCurrencies
 import to.bitkit.ui.components.BalanceHeaderView
-import to.bitkit.ui.components.BodySSB
 import to.bitkit.ui.components.Keyboard
+import to.bitkit.ui.components.MoneySSB
 import to.bitkit.ui.components.OutlinedColorButton
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.Text13Up
@@ -29,7 +29,6 @@ import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.util.DarkModePreview
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
-import to.bitkit.ui.utils.formatStringWithSeparator
 import to.bitkit.viewmodels.CurrencyUiState
 import to.bitkit.viewmodels.SendEvent
 import to.bitkit.viewmodels.SendMethod
@@ -67,21 +66,14 @@ fun SendAmountScreen(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 val balances = LocalBalances.current
-                BodySSB(
-                    text = "₿",
-                    color = Colors.White64,
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-
-                BodySSB(
-                    text = when (uiState.payMethod) {
-                        SendMethod.ONCHAIN -> balances.totalOnchainSats.toLong().formatStringWithSeparator()
-                        SendMethod.LIGHTNING -> balances.totalLightningSats.toLong().formatStringWithSeparator()
-                    },
-                    color = Colors.White
-                )
+                val availableAmount = when (uiState.payMethod) {
+                    SendMethod.ONCHAIN -> balances.totalOnchainSats.toLong()
+                    SendMethod.LIGHTNING -> balances.totalLightningSats.toLong()
+                }
+                MoneySSB(sats = availableAmount.toLong())
 
                 Spacer(modifier = Modifier.weight(1f))
+
                 OutlinedColorButton(
                     onClick = { onEvent(SendEvent.PaymentMethodSwitch) },
                     enabled = uiState.isUnified,

--- a/app/src/main/java/to/bitkit/ui/utils/Text.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/Text.kt
@@ -13,9 +13,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.withStyle
 import to.bitkit.ui.theme.Colors
-import java.text.DecimalFormat
-import java.text.DecimalFormatSymbols
-import java.util.Locale
 
 fun String.withAccent(
     defaultColor: Color = Color.Unspecified,
@@ -124,14 +121,4 @@ fun localizedRandom(@StringRes id: Int): String {
             localizedString
         }
     }
-}
-
-fun Long.formatStringWithSeparator(): String {
-    val symbols = DecimalFormatSymbols(Locale.getDefault()).apply {
-        groupingSeparator = ' '
-    }
-
-    val formatter = DecimalFormat("#,###", symbols)
-
-    return runCatching { formatter.format(this) }.getOrNull() ?: this.toString()
 }


### PR DESCRIPTION
[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=29144-211388&t=WnsA9EUzBarDRdFI-4)

- [x] Implement UnitButton
- [x] Update keyboard according the unit
- [x] Text available balance style

Related to #49 


https://github.com/user-attachments/assets/b15556b1-0502-4eae-b516-c7eaa545f070
