### PR TITLE
Add arm64-v8a filter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,9 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        ndk {
+            abiFilters += "arm64-v8a"
+        }
     }
     signingConfigs {
         getByName("debug") {


### PR DESCRIPTION
The ldk-node dependency used so far only works in arm architecture

To avoid crashes, this filter only displays the app to devices with compatible architecture

This will not be a problem because the majority of android phones have arm processors

Related to https://github.com/lightningdevkit/ldk-node/issues/483