### PR TITLE
FIX: move spacer to below balance header

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
@@ -68,6 +68,8 @@ fun SendAmountScreen(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
+                Spacer(modifier = Modifier.weight(1f))
+
                 Text13Up(
                     text = stringResource(R.string.wallet__send_available),
                     color = Colors.White64,
@@ -111,8 +113,6 @@ fun SendAmountScreen(
                         modifier = Modifier.height(28.dp)
                     )
                 }
-
-                Spacer(modifier = Modifier.weight(1f))
 
                 HorizontalDivider(modifier = Modifier.padding(vertical = 24.dp))
 


### PR DESCRIPTION
[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=29144-211397&t=jTGlMYXLZtIMDJdm-4)

Move `Spacer(modifier = Modifier.weight(1f))` to below balance header

![image](https://github.com/user-attachments/assets/ccdb92a6-aac8-4a29-97ed-bbe22def5dfa)
