### PR TITLE
Keep the node running when the app is in background

### DIFF
--- a/app/src/androidTest/java/to/bitkit/ui/screens/wallets/send/SendAmountContentTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/wallets/send/SendAmountContentTest.kt
@@ -10,7 +10,7 @@ import to.bitkit.models.BitcoinDisplayUnit
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.PrimaryDisplay
 import to.bitkit.viewmodels.CurrencyUiState
-import to.bitkit.viewmodels.MainUiState
+import to.bitkit.viewmodels.WalletState
 import to.bitkit.viewmodels.SendEvent
 import to.bitkit.viewmodels.SendMethod
 import to.bitkit.viewmodels.SendUiState
@@ -27,7 +27,7 @@ class SendAmountContentTest {
         isUnified = true
     )
 
-    private val testWalletState = MainUiState(
+    private val testWalletState = WalletState(
         nodeLifecycleState = NodeLifecycleState.Running
     )
 
@@ -61,7 +61,7 @@ class SendAmountContentTest {
             SendAmountContent(
                 input = "100",
                 uiState = testUiState,
-                walletUiState = MainUiState(
+                walletUiState = WalletState(
                     nodeLifecycleState = NodeLifecycleState.Initializing
                 ),
                 displayUnit = BitcoinDisplayUnit.MODERN,

--- a/app/src/main/java/to/bitkit/ui/screens/DevSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/DevSettingsScreen.kt
@@ -37,7 +37,7 @@ import to.bitkit.ui.shared.FullWidthTextButton
 import to.bitkit.ui.shared.InfoField
 import to.bitkit.ui.shared.Payments
 import to.bitkit.ui.shared.Peers
-import to.bitkit.viewmodels.MainUiState
+import to.bitkit.viewmodels.WalletState
 import to.bitkit.viewmodels.WalletViewModel
 
 @Composable
@@ -111,7 +111,7 @@ private fun debugPushNotification() {
 }
 
 @Composable
-fun NodeDetails(contentState: MainUiState) {
+fun NodeDetails(contentState: WalletState) {
     OutlinedCard(modifier = Modifier.fillMaxWidth()) {
         Row(
             verticalAlignment = Alignment.Bottom,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -71,7 +71,7 @@ import to.bitkit.ui.utils.screenSlideIn
 import to.bitkit.ui.utils.screenSlideOut
 import to.bitkit.ui.utils.withAccent
 import to.bitkit.viewmodels.AppViewModel
-import to.bitkit.viewmodels.MainUiState
+import to.bitkit.viewmodels.WalletState
 import to.bitkit.viewmodels.WalletViewModel
 
 @Composable
@@ -80,7 +80,7 @@ fun HomeScreen(
     appViewModel: AppViewModel,
     rootNavController: NavController,
 ) {
-    val uiState: MainUiState by walletViewModel.uiState.collectAsState()
+    val uiState: WalletState by walletViewModel.uiState.collectAsState()
     val currentSheet by appViewModel.currentSheet
     SheetHost(
         shouldExpand = currentSheet != null,
@@ -175,7 +175,7 @@ fun HomeScreen(
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun HomeContentView(
-    uiState: MainUiState,
+    uiState: WalletState,
     rootNavController: NavController,
     walletNavController: NavController,
     onRefresh: () -> Unit,
@@ -299,7 +299,7 @@ object HomeRoutes {
 private fun HomeContentViewPreview() {
     AppThemeSurface {
         HomeContentView(
-            uiState = MainUiState(),
+            uiState = WalletState(),
             rootNavController = rememberNavController(),
             walletNavController = rememberNavController(),
             onRefresh = {},

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -37,11 +37,11 @@ import to.bitkit.ui.screens.wallets.activity.ActivityListWithHeaders
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.utils.withAccent
-import to.bitkit.viewmodels.MainUiState
+import to.bitkit.viewmodels.WalletState
 
 @Composable
 fun SpendingWalletScreen(
-    uiState: MainUiState,
+    uiState: WalletState,
     onAllActivityButtonClick: () -> Unit,
     onActivityItemClick: (String) -> Unit,
     onTransferToSavingsClick: () -> Unit,
@@ -129,7 +129,7 @@ fun SpendingWalletScreen(
 private fun SpendingWalletScreenPreview() {
     AppThemeSurface {
         SpendingWalletScreen(
-            uiState = MainUiState(),
+            uiState = WalletState(),
             onAllActivityButtonClick = {},
             onActivityItemClick = {},
             onTransferToSavingsClick = {},

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/EditInvoiceScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/EditInvoiceScreen.kt
@@ -54,12 +54,12 @@ import to.bitkit.ui.theme.AppTextFieldDefaults
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.viewmodels.CurrencyUiState
-import to.bitkit.viewmodels.MainUiState
+import to.bitkit.viewmodels.WalletState
 
 @Composable
 fun EditInvoiceScreen(
     currencyUiState: CurrencyUiState = LocalCurrencies.current,
-    walletUiState: MainUiState,
+    walletUiState: WalletState,
     updateInvoice: (ULong?, String) -> Unit,
     onClickAddTag: () -> Unit,
     onClickTag: (String) -> Unit,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveQrScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveQrScreen.kt
@@ -69,7 +69,7 @@ import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.utils.withAccent
 import to.bitkit.ui.walletViewModel
-import to.bitkit.viewmodels.MainUiState
+import to.bitkit.viewmodels.WalletState
 
 private object ReceiveRoutes {
     const val QR = "qr"
@@ -82,7 +82,7 @@ private object ReceiveRoutes {
 
 @Composable
 fun ReceiveQrSheet(
-    walletState: MainUiState,
+    walletState: WalletState,
     modifier: Modifier = Modifier,
 ) {
     val app = appViewModel ?: return
@@ -207,7 +207,7 @@ fun ReceiveQrSheet(
 private fun ReceiveQrScreen(
     cjitInvoice: MutableState<String?>,
     cjitActive: MutableState<Boolean>,
-    walletState: MainUiState,
+    walletState: WalletState,
     onCjitToggle: (Boolean) -> Unit,
     onClickEditInvoice: () -> Unit,
     onClickReceiveOnSpending: () -> Unit,
@@ -540,7 +540,7 @@ private fun ReceiveQrScreenPreview() {
         ReceiveQrScreen(
             cjitInvoice = remember { mutableStateOf(null) },
             cjitActive = remember { mutableStateOf(false) },
-            walletState = MainUiState(
+            walletState = WalletState(
                 nodeLifecycleState = Running,
             ),
             onCjitToggle = { },
@@ -557,7 +557,7 @@ private fun ReceiveQrScreenPreviewSmallScreen() {
         ReceiveQrScreen(
             cjitInvoice = remember { mutableStateOf(null) },
             cjitActive = remember { mutableStateOf(false) },
-            walletState = MainUiState(
+            walletState = WalletState(
                 nodeLifecycleState = Running,
             ),
             onCjitToggle = { },
@@ -574,7 +574,7 @@ private fun ReceiveQrScreenPreviewTablet() {
         ReceiveQrScreen(
             cjitInvoice = remember { mutableStateOf(null) },
             cjitActive = remember { mutableStateOf(false) },
-            walletState = MainUiState(
+            walletState = WalletState(
                 nodeLifecycleState = NodeLifecycleState.Starting,
             ),
             onCjitToggle = { },

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
@@ -42,7 +42,7 @@ import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.viewmodels.CurrencyUiState
-import to.bitkit.viewmodels.MainUiState
+import to.bitkit.viewmodels.WalletState
 import to.bitkit.viewmodels.SendEvent
 import to.bitkit.viewmodels.SendMethod
 import to.bitkit.viewmodels.SendUiState
@@ -50,7 +50,7 @@ import to.bitkit.viewmodels.SendUiState
 @Composable
 fun SendAmountScreen(
     uiState: SendUiState,
-    walletUiState: MainUiState,
+    walletUiState: WalletState,
     currencyUiState: CurrencyUiState = LocalCurrencies.current,
     onBack: () -> Unit,
     onEvent: (SendEvent) -> Unit,
@@ -84,7 +84,7 @@ fun SendAmountScreen(
 @Composable
 fun SendAmountContent(
     input: String,
-    walletUiState: MainUiState,
+    walletUiState: WalletState,
     uiState: SendUiState,
     balances: BalanceState = LocalBalances.current,
     primaryDisplay: PrimaryDisplay,
@@ -243,7 +243,7 @@ private fun PreviewRunningLightning() {
                 isAmountInputValid = true,
                 isUnified = true
             ),
-            walletUiState = MainUiState(
+            walletUiState = WalletState(
                 nodeLifecycleState = NodeLifecycleState.Running
             ),
             onBack = {},
@@ -268,7 +268,7 @@ private fun PreviewRunningOnchain() {
                 isAmountInputValid = true,
                 isUnified = true
             ),
-            walletUiState = MainUiState(
+            walletUiState = WalletState(
                 nodeLifecycleState = NodeLifecycleState.Running
             ),
             onBack = {},
@@ -291,7 +291,7 @@ private fun PreviewInitializing() {
                 payMethod = SendMethod.LIGHTNING,
                 amountInput = "100"
             ),
-            walletUiState = MainUiState(
+            walletUiState = WalletState(
                 nodeLifecycleState = NodeLifecycleState.Initializing
             ),
             onBack = {},

--- a/app/src/main/java/to/bitkit/viewmodels/WalletViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/WalletViewModel.kt
@@ -40,7 +40,7 @@ class WalletViewModel @Inject constructor(
     private val walletRepo: WalletRepo,
     private val lightningRepo: LightningRepo,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(MainUiState())
+    private val _uiState = MutableStateFlow(WalletState())
     val uiState = _uiState.asStateFlow()
 
     private val _balanceState = MutableStateFlow(walletRepo.getBalanceState())
@@ -534,7 +534,7 @@ class WalletViewModel @Inject constructor(
     }
 }
 
-data class MainUiState(
+data class WalletState(
     val nodeId: String = "",
     val balanceDetails: BalanceDetails? = null,
     val onchainAddress: String = "",

--- a/app/src/test/java/to/bitkit/ui/WalletViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/WalletViewModelTest.kt
@@ -19,7 +19,7 @@ import to.bitkit.repositories.LightningRepo
 import to.bitkit.repositories.WalletRepo
 import to.bitkit.test.BaseUnitTest
 import to.bitkit.test.TestApp
-import to.bitkit.viewmodels.MainUiState
+import to.bitkit.viewmodels.WalletState
 import to.bitkit.viewmodels.WalletViewModel
 import kotlin.test.assertEquals
 
@@ -60,7 +60,7 @@ class WalletViewModelTest : BaseUnitTest() {
     @Test
     fun `start should emit Content uiState`() = test {
         setupExistingWalletMocks()
-        val expectedUiState = MainUiState(
+        val expectedUiState = WalletState(
             nodeId = "nodeId",
             onchainAddress = "onchainAddress",
             peers = emptyList(),


### PR DESCRIPTION
Attach the node instance to a foreground service so it keeps running when the app is in background

- [ ] Move `start()` logic from `WalletViewModel` to `WalletRepo`
- [ ] Set LightningRepo as dependency of WalletRepo
- [ ] Implement the WalletService
- [ ] Deprecate WalletViewModel


Related to #50 
Closes #76 