### PR TITLE
Feat/spend intro

### DIFF
--- a/app/src/main/java/to/bitkit/data/SettingsStore.kt
+++ b/app/src/main/java/to/bitkit/data/SettingsStore.kt
@@ -74,9 +74,9 @@ class SettingsStore @Inject constructor(
         store.edit { it[HAS_SEEN_SPENDING_INTRO] = value }
     }
 
-    val hasSeenSpendingOnboardingIntro: Flow<Boolean> = store.data.map { it[HAS_SEEN_SPENDING_ONBOARDING_INTRO] == true }
-    suspend fun setHasSeenSpendingOnboardingIntro(value: Boolean) {
-        store.edit { it[HAS_SEEN_SPENDING_ONBOARDING_INTRO] = value }
+    val hasSeenTransferIntro: Flow<Boolean> = store.data.map { it[HAS_SEEN_TRANSFER_INTRO] == true }
+    suspend fun setHasSeenTransferIntro(value: Boolean) {
+        store.edit { it[HAS_SEEN_TRANSFER_INTRO] = value }
     }
 
     val hasSeenSavingsIntro: Flow<Boolean> = store.data.map { it[HAS_SEEN_SAVINGS_INTRO] == true }
@@ -119,7 +119,7 @@ class SettingsStore @Inject constructor(
         private val DEFAULT_TX_SPEED = stringPreferencesKey("default_tx_speed")
         private val SHOW_EMPTY_STATE = booleanPreferencesKey("show_empty_state")
         private val HAS_SEEN_SPENDING_INTRO = booleanPreferencesKey("has_seen_spending_intro")
-        private val HAS_SEEN_SPENDING_ONBOARDING_INTRO = booleanPreferencesKey("has_seen_spending_onboarding_intro")
+        private val HAS_SEEN_TRANSFER_INTRO = booleanPreferencesKey("has_seen_transfer_intro")
         private val HAS_SEEN_SAVINGS_INTRO = booleanPreferencesKey("has_seen_savings_intro")
         private val LIGHTNING_SETUP_STEP = intPreferencesKey("lightning_setup_step")
         private val IS_PIN_ENABLED = booleanPreferencesKey("is_pin_enabled")

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -1,6 +1,5 @@
 package to.bitkit.ui
 
-import androidx.compose.material.icons.Icons
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -74,11 +73,8 @@ import to.bitkit.ui.settings.LocalCurrencySettingsScreen
 import to.bitkit.ui.settings.LogDetailScreen
 import to.bitkit.ui.settings.LogsScreen
 import to.bitkit.ui.settings.OrderDetailScreen
-import to.bitkit.ui.settings.support.ReportIssueScreen
 import to.bitkit.ui.settings.SecuritySettingsScreen
 import to.bitkit.ui.settings.SettingsScreen
-import to.bitkit.ui.settings.support.SupportScreen
-import to.bitkit.ui.settings.transactionSpeed.TransactionSpeedSettingsScreen
 import to.bitkit.ui.settings.backups.BackupWalletScreen
 import to.bitkit.ui.settings.backups.RestoreWalletScreen
 import to.bitkit.ui.settings.pin.ChangePinConfirmScreen
@@ -87,7 +83,10 @@ import to.bitkit.ui.settings.pin.ChangePinResultScreen
 import to.bitkit.ui.settings.pin.ChangePinScreen
 import to.bitkit.ui.settings.pin.DisablePinScreen
 import to.bitkit.ui.settings.support.ReportIssueResultScreen
+import to.bitkit.ui.settings.support.ReportIssueScreen
+import to.bitkit.ui.settings.support.SupportScreen
 import to.bitkit.ui.settings.transactionSpeed.CustomFeeSettingsScreen
+import to.bitkit.ui.settings.transactionSpeed.TransactionSpeedSettingsScreen
 import to.bitkit.ui.utils.composableWithDefaultTransitions
 import to.bitkit.ui.utils.screenSlideIn
 import to.bitkit.ui.utils.screenSlideOut
@@ -268,7 +267,7 @@ fun ContentView(
                         TransferIntroScreen(
                             onContinueClick = {
                                 navController.navigateToTransferFunding()
-                                appViewModel.setHasSeenSpendingOnboardingIntro(true)
+                                appViewModel.setHasSeenTransferIntro(true)
                             },
                             onCloseClick = { navController.navigateToHome() },
                         )

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -156,7 +156,7 @@ fun HomeScreen(
                     val homeViewModel: HomeViewModel = hiltViewModel()
                     val suggestions by homeViewModel.suggestions.collectAsStateWithLifecycle()
                     val context = LocalContext.current
-                    val hasSeenSpendingOnboardingIntro by appViewModel.hasSeenSpendingOnboardingIntro.collectAsState()
+                    val hasSeenTransferIntro by appViewModel.hasSeenTransferIntro.collectAsState()
 
                     HomeContentView(
                         uiState = uiState,
@@ -177,7 +177,7 @@ fun HomeScreen(
                                 }
 
                                 Suggestion.SPEND -> {
-                                    if (!hasSeenSpendingOnboardingIntro) {
+                                    if (!hasSeenTransferIntro) {
                                         rootNavController.navigateToTransferIntro()
                                     } else {
                                         rootNavController.navigateToTransferFunding()

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -110,12 +110,12 @@ class AppViewModel @Inject constructor(
             settingsStore.setHasSeenSpendingIntro(value)
         }
     }
-    val hasSeenSpendingOnboardingIntro: StateFlow<Boolean> = settingsStore.hasSeenSpendingOnboardingIntro
+    val hasSeenTransferIntro: StateFlow<Boolean> = settingsStore.hasSeenTransferIntro
         .stateIn(viewModelScope, SharingStarted.Lazily, false)
 
-    fun setHasSeenSpendingOnboardingIntro(value: Boolean) {
+    fun setHasSeenTransferIntro(value: Boolean) {
         viewModelScope.launch {
-            settingsStore.setHasSeenSpendingOnboardingIntro(value)
+            settingsStore.setHasSeenTransferIntro(value)
         }
     }
 


### PR DESCRIPTION
[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=31760-199736&t=nORwqGJSNIm0jKSp-4)

- [x] Create a variable to check save is the user has seen the spending onboarding from suggestions
- [x] Check `hasSeenSpendingOnboardingIntro` to handle navigation

Related to #149 

https://github.com/user-attachments/assets/95d16bbc-d82d-4223-b924-61f2f7d74fc8
