### PR TITLE
BIP 21 empty lightning invoice

### DIFF
--- a/app/src/main/java/to/bitkit/utils/Bip21Utils.kt
+++ b/app/src/main/java/to/bitkit/utils/Bip21Utils.kt
@@ -30,9 +30,12 @@ object Bip21Utils {
         }
 
         // Add lightning parameter if invoice exists
-        lightningInvoice?.let { invoice ->
+        if (!lightningInvoice.isNullOrBlank()) {
             val separator = if (queryParams.isEmpty()) "?" else "&"
-            builder.append("${separator}lightning=${invoice.encodeToUrl()}")
+            val encodedInvoice = lightningInvoice.encodeToUrl()
+            if (encodedInvoice.isNotBlank()) {
+                builder.append("${separator}lightning=${lightningInvoice.encodeToUrl()}")
+            }
         }
 
         return builder.toString()

--- a/app/src/test/java/to/bitkit/utils/Bip21UrlBuilderTest.kt
+++ b/app/src/test/java/to/bitkit/utils/Bip21UrlBuilderTest.kt
@@ -99,25 +99,6 @@ class Bip21UrlBuilderTest {
     }
 
     @Test
-    fun `address with invalid lightning invoice`() {
-        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
-        val expected = expectedUrl(
-            "bitcoin:$address",
-            "label" to "Donation",
-            "message" to "Thanks for your work!"
-        )
-        Assert.assertEquals(
-            expected,
-            buildBip21Url(
-                address,
-                label = "Donation",
-                message = "Thanks for your work!",
-                lightningInvoice = "aaa"
-            )
-        )
-    }
-
-    @Test
     fun `address with lightning parameter`() {
         val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
         val invoice = "lnbc500n1p3k9v3pp5kzmj..."


### PR DESCRIPTION
This PR removes the empty `lighting=` parameter from BIP 31

Related to #229 