### PR TITLE
Fix build dependency resolution when cache is missing

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,6 @@ dependencyResolutionManagement {
         mavenLocal()
         google()
         mavenCentral()
-        maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/")
         maven("https://jitpack.io")
     }
 }


### PR DESCRIPTION
This PR fixes failing builds on new machines which has no dependencies cache.

### Description

This command should work after removing all local gradle/maven dependency caches:
```
./gradlew --refresh-dependencies clean assembleDevDebug
```

It was failing for our own dependencies served via jitpack:
- bitkit-core
- ldk-node (synonym fork)