### PR TITLE
feat: e2e setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ The build config supports building 3 different apps for the 3 bitcoin networks (
 - `mainnet` flavour = mainnet
 - `tnet` flavour = testnet
 
+### Build for E2E Testing
+Simply pass `E2E=true` as environment variable and build any flavor.
+
+```sh
+E2E=true ./gradlew assembleDevRelease
+```
+
 ### Build for Release
 
 **Prerequisites**  

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        buildConfigField("boolean", "E2E", System.getenv("E2E")?.toBoolean()?.toString() ?: "false")
     }
 
     flavorDimensions += "network"

--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -13,9 +13,10 @@ import to.bitkit.utils.Logger
 import java.io.File
 import kotlin.io.path.Path
 
-@Suppress("ConstPropertyName")
+@Suppress("ConstPropertyName", "KotlinConstantConditions")
 internal object Env {
     val isDebug = BuildConfig.DEBUG
+    const val isE2eTest = BuildConfig.E2E
     val network = Network.valueOf(BuildConfig.NETWORK)
     val walletSyncIntervalSecs = 10_uL // TODO review
     val platform = "Android ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})"
@@ -162,14 +163,23 @@ internal object Env {
             ssl = 18484,
             protocol = ElectrumProtocol.TCP,
         )
+        val E2E = ElectrumServer(
+            host = "127.0.0.1",
+            tcp = 60001,
+            ssl = 60002,
+            protocol = ElectrumProtocol.TCP,
+        )
     }
 
     val defaultElectrumServer: ElectrumServer
-        get() = when (network) {
-            Network.REGTEST -> ElectrumServers.REGTEST
-            Network.TESTNET -> ElectrumServers.TESTNET
-            Network.BITCOIN -> ElectrumServers.BITCOIN
-            else -> TODO("${network.name} network not implemented")
+        get() {
+            if (isE2eTest) return ElectrumServers.E2E
+            return when (network) {
+                Network.REGTEST -> ElectrumServers.REGTEST
+                Network.TESTNET -> ElectrumServers.TESTNET
+                Network.BITCOIN -> ElectrumServers.BITCOIN
+                else -> TODO("${network.name} network not implemented")
+            }
         }
 
     const val PIN_LENGTH = 4


### PR DESCRIPTION
This PR adds configuration to build the app for e2e tests ran in docker via github workflows.

### Description
- Add e2e build config and electrum server

Instructions added in README file.

With this setup we should be able to configure anything else that might be needed for e2e tests, while currently we only configure the electrum server to be the same as it is expected by the Bitkit RN e2e tests in:
- [env.test.template](https://github.com/synonymdev/bitkit/blob/master/.env.test.template#L15-L18)
- [bitkit/e2e/helpers.js](https://github.com/synonymdev/bitkit/blob/master/e2e/helpers.js#L6-L8)