### PR TITLE
E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
@@ -52,6 +53,7 @@ jobs:
           path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
 
   e2e-tests:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     needs: build
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

This PR introduces a GitHub Actions workflow for running end-to-end tests.
It can be triggered manually from the Actions UI or automatically on `pull_request`.

For now, it includes only a single test case:
**`Onboarding - Can start onboarding`** — mainly due to the current lack of `testID`s in the app.

The e2e workflow:
 - builds apk with E2E=true
 - pulls e2e tests and regtest docker-compose config from https://github.com/synonymdev/bitkit-e2e-tests
 - starts regtest and runs tests against built apk
 - on failure, uploads a video and screenshot of test 

~To make the test work in the Android emulator environment I changed the Electrum server host to `10.0.2.2` (which maps to the host machine's `127.0.0.1` in the emulator).
It turns out that using `127.0.0.1` didn’t work after all in the GitHub Actions environment.
See: 53ba0a1b19bb437e3a53b286c4e72186e961c906 @ovitrif 🤷~
Worked with b466ed903c92ed1a3f3f0703ae6ad0f45bbb3c88. :tada:

Future PRs will expand test coverage as more `testIDs` are added.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

Workflow run manually several times to make sure it is stable. 
See: https://github.com/synonymdev/bitkit-android/actions/workflows/e2e.yml
