### PR TITLE
LDK-node JWT auth to VSS rust

### DIFF
--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -40,8 +40,14 @@ internal object Env {
     val vssServerUrl
         get() = when (network) {
             Network.BITCOIN -> TODO("VSS not implemented for mainnet")
+            // Network.REGTEST -> "http://localhost:5050/vss"
             else -> "https://bitkit.stag0.blocktank.to/vss_rs/"
         }
+
+    val lnurlAuthSeverUrl = when (network) {
+        // Network.REGTEST -> "http://localhost:3000/auth"
+        else -> "" // TODO implement LNURL-auth Server for other networks
+    }
 
     val vssStoreId
         get() = when (network) {

--- a/app/src/main/java/to/bitkit/repositories/BlocktankRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BlocktankRepo.kt
@@ -230,6 +230,8 @@ class BlocktankRepo @Inject constructor(
         receivingBalanceSats: ULong,
         channelExpiryWeeks: UInt = DEFAULT_CHANNEL_EXPIRY_WEEKS,
     ): Result<IBtEstimateFeeResponse2> = withContext(bgDispatcher) {
+        Logger.info("Estimating order fee for spendingSats=$spendingBalanceSats, receivingSats=$receivingBalanceSats")
+
         try {
             val options = defaultCreateOrderOptions(clientBalanceSat = spendingBalanceSats)
 
@@ -238,6 +240,8 @@ class BlocktankRepo @Inject constructor(
                 channelExpiryWeeks = channelExpiryWeeks,
                 options = options,
             )
+
+            Logger.debug("Estimated order fee: '$estimate'")
 
             Result.success(estimate)
         } catch (e: Throwable) {

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -322,10 +322,8 @@ class WalletRepo @Inject constructor(
         }
 
         try {
-            val minFeeBuffer = 1000uL
-            val amountSats = (totalOnchainSats - minFeeBuffer).coerceAtLeast(0uL)
-            val fee = lightningRepo.calculateTotalFee(amountSats).getOrThrow()
-            val maxSendable = (totalOnchainSats - fee).coerceAtLeast(0uL)
+            val fee = lightningRepo.calculateTotalFee(totalOnchainSats).getOrThrow()
+            val maxSendable = (totalOnchainSats - fee).coerceAtLeast(0u)
 
             return@withContext maxSendable
         } catch (_: Throwable) {

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -113,11 +113,20 @@ class LightningService @Inject constructor(
 
         ServiceQueue.LDK.background {
             node = try {
-                builder.buildWithVssStoreAndFixedHeaders(
-                    vssUrl = Env.vssServerUrl,
-                    storeId = vssStoreId,
-                    fixedHeaders = emptyMap(),
-                )
+                if (Env.lnurlAuthSeverUrl.isNotBlank()) {
+                    builder.buildWithVssStore(
+                        vssUrl = Env.vssServerUrl,
+                        storeId = vssStoreId,
+                        lnurlAuthServerUrl = Env.lnurlAuthSeverUrl,
+                        fixedHeaders = emptyMap(),
+                    )
+                } else {
+                    builder.buildWithVssStoreAndFixedHeaders(
+                        vssUrl = Env.vssServerUrl,
+                        storeId = vssStoreId,
+                        fixedHeaders = emptyMap(),
+                    )
+                }
             } catch (e: BuildException) {
                 throw LdkError(e)
             }

--- a/app/src/main/java/to/bitkit/ui/components/Spacers.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Spacers.kt
@@ -1,13 +1,11 @@
 package to.bitkit.ui.components
 
 import androidx.annotation.FloatRange
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
@@ -15,10 +13,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import to.bitkit.ui.theme.Colors
 
 @Composable
 fun VerticalSpacer(height: Dp) {
@@ -30,19 +26,25 @@ fun HorizontalSpacer(width: Dp) {
     Spacer(modifier = Modifier.width(width))
 }
 
+@Suppress("ComposeMultipleContentEmitters")
 @Composable
 fun ColumnScope.FillHeight(
     @FloatRange weight: Float = 1f,
-    fill: Boolean = true
+    fill: Boolean = true,
+    min: Dp = 0.dp,
 ) {
+    if (min > 0.dp) Spacer(modifier = Modifier.height(min))
     Spacer(modifier = Modifier.weight(weight, fill = fill))
 }
 
+@Suppress("ComposeMultipleContentEmitters")
 @Composable
 fun RowScope.FillWidth(
     @FloatRange weight: Float = 1f,
-    fill: Boolean = true
+    fill: Boolean = true,
+    min: Dp = 0.dp,
 ) {
+    if (min > 0.dp) Spacer(modifier = Modifier.width(min))
     Spacer(modifier = Modifier.weight(weight, fill = fill))
 }
 

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/external/LnurlChannelScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/external/LnurlChannelScreen.kt
@@ -15,12 +15,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import to.bitkit.R
-import to.bitkit.ext.ellipsisMiddle
 import to.bitkit.models.LnPeer
 import to.bitkit.ui.Routes
 import to.bitkit.ui.components.BodyM
@@ -28,6 +29,7 @@ import to.bitkit.ui.components.Caption13Up
 import to.bitkit.ui.components.CaptionB
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.FillHeight
+import to.bitkit.ui.components.FillWidth
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
@@ -93,7 +95,7 @@ private fun Content(
             VerticalSpacer(8.dp)
 
             val peer = uiState.peer
-            if(peer != null) {
+            if (peer != null) {
                 BodyM(text = stringResource(R.string.other__lnurl_channel_message), color = Colors.White64)
                 VerticalSpacer(48.dp)
 
@@ -102,7 +104,7 @@ private fun Content(
 
                 InfoRow(
                     label = stringResource(R.string.other__lnurl_channel_node),
-                    value = peer.nodeId.ellipsisMiddle(24),
+                    value = peer.nodeId,
                 )
                 InfoRow(
                     label = stringResource(R.string.other__lnurl_channel_host),
@@ -151,14 +153,14 @@ private fun InfoRow(
     value: String,
 ) {
     Row(
-        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 16.dp)
     ) {
         CaptionB(text = label)
-        CaptionB(text = value)
+        FillWidth(min = 24.dp)
+        CaptionB(text = value, maxLines = 1, overflow = TextOverflow.MiddleEllipsis, textAlign = TextAlign.End)
     }
     HorizontalDivider()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "k
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 #ldk-node-android = { module = "org.lightningdevkit:ldk-node-android", version = "0.6.1" } # upstream
-ldk-node-android = { module = "com.github.synonymdev:ldk-node", version = "v0.6.1-rc.4" } # fork
+ldk-node-android = { module = "com.github.synonymdev:ldk-node", version = "v0.6.1-rc.5" } # fork
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 accompanistPermissions = "0.36.0"
 activityCompose = "1.10.1"
-agp = "8.11.1"
+agp = "8.12.0"
 appcompat = "1.7.0"
 barcodeScanning = "17.3.0"
 biometric = "1.4.0-alpha02"


### PR DESCRIPTION
This PR adds configuration to test ldk-node with authenticated VSS implementation using LNURL-auth server endpoint issuing JWT tokens.

### Description
- vss auth config setup

#### Other changes
- update ldk-node and adapt max send amount calculation to use the fixed method
- fix lnurl channel screen spacing
- upgrade agp to latest android-studio version

#### ▶️ Next Steps for VSS auth setup
- deploy [vss-server](https://github.com/ovitrif/vss-server/) and a LNURL-auth JWT-issuing service like the one in [bitkit-docker](https://github.com/ovitrif/bitkit-docker) to staging
- adapt [vss-rust-client-ffi](https://github.com/synonymdev/vss-rust-client-ffi) to manage auth via `lnurlAuthServerUrl` like it’s done by `ldk-node` via `build_with_vss_store`

### QA Notes
#### Test ldk-node with auth to vss-server
- see [bitkit-docker LDK-NODE with JWT auth to VSS](https://github.com/ovitrif/bitkit-docker?tab=readme-ov-file#ldk-node-with-jwt-auth-to-vss)