### PR TITLE
Boost UX improvements

### DIFF
--- a/app/src/main/java/to/bitkit/data/dto/PendingBoostActivity.kt
+++ b/app/src/main/java/to/bitkit/data/dto/PendingBoostActivity.kt
@@ -5,8 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PendingBoostActivity(
     val txId: String,
-    val feeRate: ULong,
-    val fee: ULong,
     val updatedAt: ULong,
     val activityToDelete: String?
 )

--- a/app/src/main/java/to/bitkit/ext/Activities.kt
+++ b/app/src/main/java/to/bitkit/ext/Activities.kt
@@ -1,6 +1,7 @@
 package to.bitkit.ext
 
 import com.synonym.bitkitcore.Activity
+import com.synonym.bitkitcore.PaymentState
 import com.synonym.bitkitcore.PaymentType
 
 fun Activity.rawId(): String = when (this) {
@@ -19,7 +20,7 @@ fun Activity.rawId(): String = when (this) {
  *
  * @return The total value as an `ULong`.
  */
-fun Activity.totalValue() = when(this) {
+fun Activity.totalValue() = when (this) {
     is Activity.Lightning -> v1.value + (v1.fee ?: 0u)
     is Activity.Onchain -> when (v1.txType) {
         PaymentType.SENT -> v1.value + v1.fee
@@ -35,6 +36,11 @@ fun Activity.canBeBoosted() = when (this) {
 fun Activity.isBoosted() = when (this) {
     is Activity.Onchain -> v1.isBoosted
     else -> false
+}
+
+fun Activity.isFinished() = when (this) {
+    is Activity.Onchain -> v1.confirmed
+    is Activity.Lightning -> v1.status != PaymentState.PENDING
 }
 
 fun Activity.matchesPaymentId(paymentHashOrTxId: String): Boolean = when (this) {

--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -320,8 +320,6 @@ class ActivityRepo @Inject constructor(
                 val updatedActivity = Activity.Onchain(
                     v1 = newOnChainActivity.v1.copy(
                         isBoosted = true,
-                        feeRate = pendingBoostActivity.feeRate,
-                        fee = pendingBoostActivity.fee,
                         updatedAt = pendingBoostActivity.updatedAt
                     )
                 )

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/BoostTransactionViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/BoostTransactionViewModel.kt
@@ -322,19 +322,6 @@ class BoostTransactionViewModel @Inject constructor(
     }
 
     /**
-     * Creates a boosted version of the given activity with current fee data
-     */
-    private fun createBoostedActivity(currentActivity: OnchainActivity): Activity.Onchain {
-        return Activity.Onchain(
-            v1 = currentActivity.copy(
-                isBoosted = true,
-                feeRate = _uiState.value.feeRate,
-                updatedAt = nowTimestamp().toEpochMilli().toULong()
-            )
-        )
-    }
-
-    /**
      * Finds the new activity and replaces the old one, handling failures gracefully
      */
     private suspend fun findAndReplaceWithNewActivity(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/BoostTransactionViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/BoostTransactionViewModel.kt
@@ -81,9 +81,13 @@ class BoostTransactionViewModel @Inject constructor(
                     PaymentType.RECEIVED -> lightningRepo.calculateCpfpFeeRate(activityContent.txId)
                 }
 
-                // TODO ideally include utxos for a better fee estimate
+                val sortedUtxos = lightningRepo.listSpendableOutputs()
+                    .getOrDefault(emptyList())
+                    .sortedByDescending { it.valueSats }
+
                 val totalFeeResult = lightningRepo.calculateTotalFee(
                     amountSats = activityContent.value,
+                    utxosToSpend = sortedUtxos,
                     speed = TransactionSpeed.Custom(feeRateResult.getOrDefault(0u).toUInt()),
                 )
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityIcon.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityIcon.kt
@@ -23,6 +23,8 @@ import com.synonym.bitkitcore.OnchainActivity
 import com.synonym.bitkitcore.PaymentState
 import com.synonym.bitkitcore.PaymentType
 import to.bitkit.R
+import to.bitkit.ext.isBoosted
+import to.bitkit.ext.isFinished
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 
@@ -43,49 +45,63 @@ fun ActivityIcon(
     }
     val arrowIcon = painterResource(if (txType == PaymentType.SENT) R.drawable.ic_sent else R.drawable.ic_received)
 
-    if (isLightning) {
-        when (status) {
-            PaymentState.FAILED -> {
-                CircularIcon(
-                    icon = painterResource(R.drawable.ic_x),
-                    iconColor = Colors.Purple,
-                    backgroundColor = Colors.Purple16,
-                    size = size,
-                    modifier = modifier,
-                )
-            }
+    when {
+        activity.isBoosted() && !activity.isFinished() -> {
+            CircularIcon(
+                icon = painterResource(R.drawable.ic_timer_alt),
+                iconColor = Colors.Yellow,
+                backgroundColor = Colors.Yellow16,
+                size = size,
+                modifier = modifier,
+            )
+        }
 
-            PaymentState.PENDING -> {
-                CircularIcon(
-                    icon = painterResource(R.drawable.ic_hourglass_simple),
-                    iconColor = Colors.Purple,
-                    backgroundColor = Colors.Purple16,
-                    size = size,
-                    modifier = modifier,
-                )
-            }
+        isLightning -> {
+            when (status) {
+                PaymentState.FAILED -> {
+                    CircularIcon(
+                        icon = painterResource(R.drawable.ic_x),
+                        iconColor = Colors.Purple,
+                        backgroundColor = Colors.Purple16,
+                        size = size,
+                        modifier = modifier,
+                    )
+                }
 
-            else -> {
-                CircularIcon(
-                    icon = arrowIcon,
-                    iconColor = Colors.Purple,
-                    backgroundColor = Colors.Purple16,
-                    size = size,
-                    modifier = modifier,
-                )
+                PaymentState.PENDING -> {
+                    CircularIcon(
+                        icon = painterResource(R.drawable.ic_hourglass_simple),
+                        iconColor = Colors.Purple,
+                        backgroundColor = Colors.Purple16,
+                        size = size,
+                        modifier = modifier,
+                    )
+                }
+
+                else -> {
+                    CircularIcon(
+                        icon = arrowIcon,
+                        iconColor = Colors.Purple,
+                        backgroundColor = Colors.Purple16,
+                        size = size,
+                        modifier = modifier,
+                    )
+                }
             }
         }
-    } else {
-        val isTransfer = (activity as? Activity.Onchain)?.v1?.isTransfer == true
-        val onChainIcon = if (isTransfer) painterResource(R.drawable.ic_transfer) else arrowIcon
 
-        CircularIcon(
-            icon = onChainIcon,
-            iconColor = Colors.Brand,
-            backgroundColor = Colors.Brand16,
-            size = size,
-            modifier = modifier,
-        )
+        else -> {
+            val isTransfer = (activity as? Activity.Onchain)?.v1?.isTransfer == true
+            val onChainIcon = if (isTransfer) painterResource(R.drawable.ic_transfer) else arrowIcon
+
+            CircularIcon(
+                icon = onChainIcon,
+                iconColor = Colors.Brand,
+                backgroundColor = Colors.Brand16,
+                size = size,
+                modifier = modifier,
+            )
+        }
     }
 }
 
@@ -191,6 +207,56 @@ private fun Preview() {
                         confirmed = true,
                         timestamp = (System.currentTimeMillis() / 1000).toULong(),
                         isBoosted = false,
+                        isTransfer = false,
+                        doesExist = true,
+                        confirmTimestamp = (System.currentTimeMillis() / 1000).toULong(),
+                        channelId = null,
+                        transferTxId = null,
+                        createdAt = null,
+                        updatedAt = null,
+                    )
+                )
+            )
+
+            // Onchain BOOST CPFP
+            ActivityIcon(
+                activity = Activity.Onchain(
+                    v1 = OnchainActivity(
+                        id = "test-onchain-1",
+                        txType = PaymentType.RECEIVED,
+                        txId = "abc123",
+                        value = 100000uL,
+                        fee = 500uL,
+                        feeRate = 8uL,
+                        address = "bc1...",
+                        confirmed = false,
+                        timestamp = (System.currentTimeMillis() / 1000).toULong(),
+                        isBoosted = true,
+                        isTransfer = false,
+                        doesExist = true,
+                        confirmTimestamp = (System.currentTimeMillis() / 1000).toULong(),
+                        channelId = null,
+                        transferTxId = null,
+                        createdAt = null,
+                        updatedAt = null,
+                    )
+                )
+            )
+
+            // Onchain BOOST RBF
+            ActivityIcon(
+                activity = Activity.Onchain(
+                    v1 = OnchainActivity(
+                        id = "test-onchain-1",
+                        txType = PaymentType.SENT,
+                        txId = "abc123",
+                        value = 100000uL,
+                        fee = 500uL,
+                        feeRate = 8uL,
+                        address = "bc1...",
+                        confirmed = false,
+                        timestamp = (System.currentTimeMillis() / 1000).toULong(),
+                        isBoosted = true,
                         isTransfer = false,
                         doesExist = true,
                         confirmTimestamp = (System.currentTimeMillis() / 1000).toULong(),

--- a/app/src/test/java/to/bitkit/repositories/ActivityRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/ActivityRepoTest.kt
@@ -452,8 +452,6 @@ class ActivityRepoTest : BaseUnitTest() {
     fun `addActivityToPendingBoost adds to cache`() = test {
         val pendingBoost = PendingBoostActivity(
             txId = "tx123",
-            feeRate = 20u,
-            fee = 2000u,
             updatedAt = 2000u,
             activityToDelete = null
         )

--- a/app/src/test/java/to/bitkit/ui/screens/wallets/activity/BoostTransactionViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/wallets/activity/BoostTransactionViewModelTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
 import to.bitkit.models.TransactionSpeed
 import to.bitkit.repositories.ActivityRepo
 import to.bitkit.repositories.LightningRepo
@@ -23,7 +24,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class BoostTransactionViewModelSimplifiedTest : BaseUnitTest() {
+class BoostTransactionViewModelTest : BaseUnitTest() {
 
     private lateinit var sut: BoostTransactionViewModel
     private val lightningRepo: LightningRepo = mock()
@@ -68,6 +69,7 @@ class BoostTransactionViewModelSimplifiedTest : BaseUnitTest() {
             walletRepo = walletRepo,
             activityRepo = activityRepo
         )
+        wheneverBlocking { lightningRepo.listSpendableOutputs()}.thenReturn(Result.success(emptyList()))
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/ui/screens/wallets/activity/BoostTransactionViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/wallets/activity/BoostTransactionViewModelTest.kt
@@ -69,7 +69,7 @@ class BoostTransactionViewModelTest : BaseUnitTest() {
             walletRepo = walletRepo,
             activityRepo = activityRepo
         )
-        wheneverBlocking { lightningRepo.listSpendableOutputs()}.thenReturn(Result.success(emptyList()))
+        wheneverBlocking { lightningRepo.listSpendableOutputs() }.thenReturn(Result.success(emptyList()))
     }
 
     @Test


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->
Related to #268 
This PR implements some changes to the Boost logic to give the user faster feedback

### Description

<!-- Extended summary of the changes, can be a list. -->
- [x] CPFP: set the parent Activity as `boosting` instead of the child
- [x] CPFP: Move activity update code out of `findActivityByPaymentId`
- [x] RBF: Also update the old activity as `boosting` while the app hasn't received the new transaction
- [x] Fix: set the boosting icon in the home screen

### Preview

<!-- Insert relevant screenshot / recording -->
https://github.com/user-attachments/assets/0f25194e-101e-4e87-a760-518c3fd5d9b9


https://github.com/user-attachments/assets/9c87c609-2bce-4857-8634-5f21f3bc5eee


### QA Notes


<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
- RBF flow
- CPFP flow
