### PR TITLE
Gradle config cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ android.nonFinalResIds=false
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration.cache=true


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->
This PR enables the gradle configuration cache.

### Description

<!-- Extended summary of the changes, can be a list. -->
This feature focuses on an earlier part of the build process: the configuration phase. During this phase, Gradle reads your build.gradle files, determines the project structure, and creates the graph of tasks to be executed.

With the configuration cache enabled, Gradle saves a snapshot of this task graph.

On subsequent builds, if your build scripts or project settings haven't changed, Gradle can skip the entire configuration phase and reuse the cached task graph. This can lead to a significant time savings, especially in large, multi-module projects where the configuration phase can be time-consuming.

[Reference](https://docs.gradle.org/current/userguide/configuration_cache.html)
### Preview

<!-- Insert relevant screenshot / recording -->
`n/a`
### QA Notes
`n/a`
<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
