### PR TITLE
Don't trigger repeated payment events

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -100,6 +100,7 @@ class ActivityRepo @Inject constructor(
         paymentHashOrTxId: String,
         type: ActivityFilter,
         txType: PaymentType,
+        retry: Boolean = true,
     ): Result<Activity> = withContext(bgDispatcher) {
         if (paymentHashOrTxId.isEmpty()) {
             return@withContext Result.failure(
@@ -115,7 +116,7 @@ class ActivityRepo @Inject constructor(
             ).getOrNull()?.firstOrNull { it.matchesPaymentId(paymentHashOrTxId) }
 
             var activity = findActivity()
-            if (activity == null) {
+            if (activity == null && retry) {
                 Logger.warn(
                     "activity with paymentHashOrTxId:$paymentHashOrTxId not found, trying again after sync",
                     context = TAG

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -183,7 +183,7 @@ fun ContentView(
 
                     val pendingTransaction = NewTransactionSheetDetails.load(context)
                     if (pendingTransaction != null) {
-                        appViewModel.showNewTransactionSheet(pendingTransaction)
+                        appViewModel.showNewTransactionSheet(details = pendingTransaction, event = null)
                         NewTransactionSheetDetails.clear(context)
                     }
 
@@ -329,7 +329,7 @@ fun ContentView(
                                 onComplete = { txSheet ->
                                     appViewModel.hideSheet()
                                     appViewModel.clearClipboardForAutoRead()
-                                    txSheet?.let { appViewModel.showNewTransactionSheet(it) }
+                                    txSheet?.let { appViewModel.showNewTransactionSheet(details = it, event = null) }
                                 }
                             )
                         }

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -191,7 +191,7 @@ class AppViewModel @Inject constructor(
         viewModelScope.launch {
             ldkNodeEventBus.events.collect { event ->
                 try {
-                    when (event) { //TODO Create individual sheet for each type of event
+                    when (event) { // TODO Create individual sheet for each type of event
                         is Event.PaymentReceived -> {
                             handleTags(event)
                             showNewTransactionSheet(

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -1222,9 +1222,9 @@ class AppViewModel @Inject constructor(
                 retry = false
             ).getOrNull()
 
-            //TODO Temporary fix while ldk-node bug is not fixed https://github.com/synonymdev/bitkit-android/pull/297
+            // TODO Temporary fix while ldk-node bug is not fixed https://github.com/synonymdev/bitkit-android/pull/297
             if (activity != null) {
-                Logger.warn("Activity already exists, skipping sheet", context = TAG)
+                Logger.warn("Activity ${activity.rawId()} already exists, skipping sheet", context = TAG)
                 return@launch
             }
         }

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -192,7 +192,7 @@ class AppViewModel @Inject constructor(
             ldkNodeEventBus.events.collect { event ->
                 try {
                     when (event) {
-                        is Event.PaymentReceived -> { //TODO COMMING FROM HERE
+                        is Event.PaymentReceived -> {
                             handleTags(event)
                             showNewTransactionSheet(
                                 NewTransactionSheetDetails(

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -191,7 +191,7 @@ class AppViewModel @Inject constructor(
         viewModelScope.launch {
             ldkNodeEventBus.events.collect { event ->
                 try {
-                    when (event) {
+                    when (event) { //TODO Create individual sheet for each type of event
                         is Event.PaymentReceived -> {
                             handleTags(event)
                             showNewTransactionSheet(
@@ -1222,8 +1222,9 @@ class AppViewModel @Inject constructor(
                 retry = false
             ).getOrNull()
 
+            //TODO Temporary fix while ldk-node bug is not fixed https://github.com/synonymdev/bitkit-android/pull/297
             if (activity != null) {
-                Logger.verbose("Activity already exists, skipping sheet", context = TAG)
+                Logger.warn("Activity already exists, skipping sheet", context = TAG)
                 return@launch
             }
         }

--- a/app/src/test/java/to/bitkit/ui/sheets/BoostTransactionViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/sheets/BoostTransactionViewModelTest.kt
@@ -216,7 +216,8 @@ class BoostTransactionViewModelTest : BaseUnitTest() {
             activityRepo.findActivityByPaymentId(
                 paymentHashOrTxId = any(),
                 type = any(),
-                txType = any()
+                txType = any(),
+                retry = any(),
             )
         ).thenReturn(Result.success(Activity.Onchain(v1 = newActivity)))
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description
The LDK-node re-triggers the last event at startup. This checks if the activity is not already saved before displaying the receive sheet.
<!-- Extended summary of the changes, can be a list. -->

### Preview

<!-- Insert relevant screenshot / recording -->

https://github.com/user-attachments/assets/3dff55aa-3f39-4628-8ecb-26e8b2f1f270


https://github.com/user-attachments/assets/c9bd2273-1f48-46e3-8105-0d018738b355


### QA Notes
Tested flows:

- Send bitcoin -> should display the sheet -> restart the app -> shouldn't display the sheet
- Receive bitcoin -> should display the sheet -> restart the app -> shouldn't display the sheet

OBS: I noticed that the sheets are not displaying the amount. I'll investigate it in the next PR
<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
