### PR TITLE
fix: re-enable button edit widgets

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -237,7 +237,7 @@ fun HomeScreen(
                 rootNavController.navigate(Routes.AddWidget)
             }
         },
-        onClickConfirmEdit = homeViewModel::onClickEditWidget,
+        onClickEditWidgetList = homeViewModel::onClickEditWidgetList,
         onClickEditWidget = { widgetType ->
             when (widgetType) {
                 WidgetType.BLOCK -> rootNavController.navigate(Routes.BlocksPreview)
@@ -275,7 +275,7 @@ private fun Content(
     onRemoveSuggestion: (Suggestion) -> Unit = {},
     onClickSuggestion: (Suggestion) -> Unit = {},
     onClickAddWidget: () -> Unit = {},
-    onClickConfirmEdit: () -> Unit = {},
+    onClickEditWidgetList: () -> Unit = {},
     onClickEditWidget: (WidgetType) -> Unit = {},
     onClickDeleteWidget: (WidgetType) -> Unit = {},
     onMoveWidget: (Int, Int) -> Unit = { _, _ -> },
@@ -407,7 +407,7 @@ private fun Content(
                             )
 
                             IconButton(
-                                onClick = onClickConfirmEdit,
+                                onClick = onClickEditWidgetList,
                                 modifier = Modifier.testTag("WidgetsEdit")
                             ) {
                                 Icon(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -237,8 +237,7 @@ fun HomeScreen(
                 rootNavController.navigate(Routes.AddWidget)
             }
         },
-        onClickEnableEdit = homeViewModel::enableEditMode,
-        onClickConfirmEdit = homeViewModel::confirmWidgetOrder,
+        onClickConfirmEdit = homeViewModel::onClickEditWidget,
         onClickEditWidget = { widgetType ->
             when (widgetType) {
                 WidgetType.BLOCK -> rootNavController.navigate(Routes.BlocksPreview)
@@ -276,7 +275,6 @@ private fun Content(
     onRemoveSuggestion: (Suggestion) -> Unit = {},
     onClickSuggestion: (Suggestion) -> Unit = {},
     onClickAddWidget: () -> Unit = {},
-    onClickEnableEdit: () -> Unit = {},
     onClickConfirmEdit: () -> Unit = {},
     onClickEditWidget: (WidgetType) -> Unit = {},
     onClickDeleteWidget: (WidgetType) -> Unit = {},

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -220,7 +220,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun onClickEditWidget() {
+    fun onClickEditWidgetList() {
         if (_uiState.value.isEditingWidgets) {
             viewModelScope.launch {
                 val widgets = _uiState.value.widgetsWithPosition

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -205,14 +205,6 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun enableEditMode() {
-        _uiState.update { it.copy(isEditingWidgets = true) }
-    }
-
-    fun disableEditMode() {
-        _uiState.update { it.copy(isEditingWidgets = false) }
-    }
-
     fun moveWidget(fromIndex: Int, toIndex: Int) {
         val currentWidgets = _uiState.value.widgetsWithPosition.toMutableList()
         if (fromIndex in currentWidgets.indices && toIndex in currentWidgets.indices) {
@@ -228,11 +220,15 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun confirmWidgetOrder() {
-        viewModelScope.launch {
-            val widgets = _uiState.value.widgetsWithPosition
-            widgetsRepo.updateWidgets(widgets)
-            disableEditMode()
+    fun onClickEditWidget() {
+        if (_uiState.value.isEditingWidgets) {
+            viewModelScope.launch {
+                val widgets = _uiState.value.widgetsWithPosition
+                widgetsRepo.updateWidgets(widgets)
+                disableEditMode()
+            }
+        } else {
+            enableEditMode()
         }
     }
 
@@ -253,6 +249,14 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(deleteWidgetAlert = null) }
         }
+    }
+
+    private fun enableEditMode() {
+        _uiState.update { it.copy(isEditingWidgets = true) }
+    }
+
+    private fun disableEditMode() {
+        _uiState.update { it.copy(isEditingWidgets = false) }
     }
 
     private fun createSuggestionsFlow() = combine(


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

<!-- Extended summary of the changes, can be a list. -->
This PR re-enables the edit widgtet button
### Preview

<!-- Insert relevant screenshot / recording -->

https://github.com/user-attachments/assets/a7169bf6-054f-4f39-858e-c7a35744bc66

### QA Notes

1. Go to settings -> enable widgets
2. Navigate to home -> click in edit widgets -> click in the confirm button

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
