### PR TITLE
Wait for node starts in SpendingAmountScreen

### DIFF
--- a/app/src/main/java/to/bitkit/ui/components/Spacers.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Spacers.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,6 +17,15 @@ import to.bitkit.ui.theme.TopBarHeight
 @Composable
 fun VerticalSpacer(height: Dp) {
     Spacer(modifier = Modifier.height(height))
+}
+
+@Composable
+fun ColumnScope.VerticalSpacer(minHeight: Dp, maxHeight: Dp) {
+    Spacer(
+        modifier = Modifier
+            .weight(1f)
+            .sizeIn(minHeight = minHeight, maxHeight = maxHeight)
+    )
 }
 
 @Composable

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -154,11 +155,14 @@ private fun SpendingAmountNodeRunning(
             .imePadding()
             .testTag("SpendingAmount")
     ) {
-        VerticalSpacer(16.dp)
+        VerticalSpacer(minHeight = 16.dp, maxHeight = 32.dp)
+
         Display(
             text = stringResource(R.string.lightning__spending_amount__title)
                 .withAccent(accentColor = Colors.Purple)
         )
+
+        FillHeight()
 
         NumberPadTextField(
             input = uiState.input,

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
@@ -63,7 +63,7 @@ fun SpendingAmountScreen(
     val isNodeRunning by viewModel.isNodeRunning.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        viewModel.updateLimits(retry = true)
+        viewModel.updateLimits()
     }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -62,6 +63,9 @@ class TransferViewModel @Inject constructor(
 
     val lightningSetupStep: StateFlow<Int> = settingsStore.data.map { it.lightningSetupStep }
         .stateIn(viewModelScope, SharingStarted.Lazily, 0)
+
+    val isNodeRunning = lightningRepo.lightningState.map { it.nodeStatus?.isRunning ?: false }
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
 
     private val _selectedChannelIdsState = MutableStateFlow<Set<String>>(emptySet())
     val selectedChannelIdsState = _selectedChannelIdsState.asStateFlow()
@@ -137,7 +141,7 @@ class TransferViewModel @Inject constructor(
                 _spendingUiState.update { it.copy(overrideSats = minAmount, isLoading = false) }
                 return@launch
             }
-
+            // TODO Collect isNodeRunning here
             blocktankRepo.createOrder(_spendingUiState.value.satsAmount.toULong())
                 .onSuccess { order ->
                     settingsStore.update { it.copy(lightningSetupStep = 0) }


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description
Some Blocktank methods need  the node running to work properly

- [x] Display SyncNodeView on the SpendingAmountScreen when the node is initializing
- [x] Wait for the node run on the required methods
- [x] Removed the now unnecessary retry logic

<!-- Extended summary of the changes, can be a list. -->

### Preview

<!-- Insert relevant screenshot / recording -->

https://github.com/user-attachments/assets/ba02f8ee-82c3-4f8a-9fe8-15b94a2aa216


### QA Notes

Tested:

- [x] Open the transfer amount screen before the node starts
- [x] Perform the full transfer flow

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
