### PR TITLE
Run whole e2e suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,7 +126,7 @@ jobs:
           script: |
             # adb port forwarding for regtest
             adb reverse tcp:60001 tcp:60001
-            cd bitkit-e2e-tests && npm run e2e:android -- --mochaOpts.grep "Can start onboarding"
+            cd bitkit-e2e-tests && npm run e2e:android
         env:
           RECORD_VIDEO: true
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Drop the temporary grep that only ran a basic onboarding test. CI now executes the full Android E2E suite. In fact atm it is only two onboarding tests. Some numberPad tests are being skipped due to #309, #310.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

https://github.com/synonymdev/bitkit-android/actions/runs/17101652506
