### PR TITLE
feat: use vss client to derive store id

### DIFF
--- a/app/src/main/java/to/bitkit/App.kt
+++ b/app/src/main/java/to/bitkit/App.kt
@@ -55,18 +55,4 @@ class CurrentActivity : ActivityLifecycleCallbacks {
     override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) = Unit
     override fun onActivityDestroyed(activity: Activity) = Unit
 }
-
-/**
- * Returns the current activity of the application.
- *
- * **NEVER** store the result to a variable, further calls to such reference can lead to memory leaks.
- *
- * **ALWAYS** retrieve the current activity functionally, processing on the result of this function.
- * */
-internal inline fun <reified T> currentActivity(): T? {
-    return when (val activity = App.currentActivity?.value) {
-        is T -> activity
-        else -> null
-    }
-}
 // endregion

--- a/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
+++ b/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
@@ -101,7 +101,7 @@ class LightningNodeService : Service() {
             ACTION_STOP_SERVICE_AND_APP -> {
                 Logger.debug("ACTION_STOP_SERVICE_AND_APP detected", context = TAG)
                 // Close all activities
-                App.currentActivity?.value?.finishAffinity()
+                App.currentActivity?.value?.finishAndRemoveTask()
                 // Stop the service
                 stopSelf()
                 return START_NOT_STICKY

--- a/app/src/main/java/to/bitkit/data/backup/VssStoreIdProvider.kt
+++ b/app/src/main/java/to/bitkit/data/backup/VssStoreIdProvider.kt
@@ -1,10 +1,8 @@
 package to.bitkit.data.backup
 
-import org.lightningdevkit.ldknode.Network
+import com.synonym.vssclient.vssDeriveStoreId
 import to.bitkit.data.keychain.Keychain
 import to.bitkit.env.Env
-import to.bitkit.ext.toHex
-import to.bitkit.ext.toSha256
 import to.bitkit.utils.Logger
 import to.bitkit.utils.ServiceError
 import javax.inject.Inject
@@ -14,21 +12,31 @@ import javax.inject.Singleton
 class VssStoreIdProvider @Inject constructor(
     private val keychain: Keychain,
 ) {
+    @Volatile
+    private var cachedStoreId: String? = null
+
     fun getVssStoreId(): String {
-        // TODO Temp fix as we don't have VSS auth yet
-        if (Env.network == Network.BITCOIN) {
-            error(
-                "Do not run this on mainnet until VSS auth is implemented. Below hack is a temporary fix and not safe for mainnet."
+        cachedStoreId?.let { return it }
+
+        return synchronized(this) {
+            cachedStoreId?.let { return it }
+
+            val mnemonic = keychain.loadString(Keychain.Key.BIP39_MNEMONIC.name) ?: throw ServiceError.MnemonicNotFound
+            val passphrase = keychain.loadString(Keychain.Key.BIP39_PASSPHRASE.name)
+
+            val storeId = vssDeriveStoreId(
+                prefix = Env.vssStoreIdPrefix,
+                mnemonic = mnemonic,
+                passphrase = passphrase,
             )
+
+            Logger.info("VSS store id: '$storeId'", context = TAG)
+            cachedStoreId = storeId
+            storeId
         }
+    }
 
-        val mnemonic = keychain.loadString(Keychain.Key.BIP39_MNEMONIC.name) ?: throw ServiceError.MnemonicNotFound
-        val mnemonicData = mnemonic.encodeToByteArray()
-        val hashedMnemonic = mnemonicData.toSha256()
-
-        val storeIdHack = Env.vssStoreId + hashedMnemonic.toHex()
-        Logger.info("storeIdHack: $storeIdHack")
-
-        return storeIdHack
+    companion object {
+        private const val TAG = "VssStoreIdProvider"
     }
 }

--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -46,7 +46,7 @@ internal object Env {
         }
 
     val lnurlAuthSeverUrl = when (network) {
-        // Network.REGTEST -> "http://localhost:3000/auth"
+        // Network.REGTEST -> "http://localhost:5005/auth"
         else -> "" // TODO implement LNURL-auth Server for other networks
     }
 

--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -50,12 +50,7 @@ internal object Env {
         else -> "" // TODO implement LNURL-auth Server for other networks
     }
 
-    val vssStoreId
-        get() = when (network) {
-            Network.REGTEST -> "bitkit_regtest"
-            Network.TESTNET -> "bitkit_testnet"
-            else -> TODO("${network.name} network not implemented")
-        }
+    val vssStoreIdPrefix get() = "bitkit_v1_${network.name.lowercase()}"
 
     val esploraServerUrl
         get() = when (network) {

--- a/app/src/main/java/to/bitkit/ui/components/IsOnlineTracker.kt
+++ b/app/src/main/java/to/bitkit/ui/components/IsOnlineTracker.kt
@@ -3,6 +3,8 @@ package to.bitkit.ui.components
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import to.bitkit.R
@@ -17,7 +19,15 @@ fun IsOnlineTracker(
     val context = LocalContext.current
     val connectivityState by app.isOnline.collectAsStateWithLifecycle(initialValue = ConnectivityState.CONNECTED)
 
+    val (isFirstEmission, setIsFirstEmission) = remember { mutableStateOf(true) }
+
     LaunchedEffect(connectivityState) {
+        // Skip the first emission to prevent toast on startup
+        if (isFirstEmission) {
+            setIsFirstEmission(true)
+            return@LaunchedEffect
+        }
+
         when (connectivityState) {
             ConnectivityState.CONNECTED -> {
                 app.toast(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -109,7 +109,7 @@ test-junit-ext = { module = "androidx.test.ext:junit", version.ref = "junitExt" 
 test-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 test-robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 test-turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
-vss = { module = "com.synonym:vss-client-android", version = "0.2.0" }
+vss = { module = "com.synonym:vss-client-android", version = "0.3.0" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 zxing = { module = "com.google.zxing:core", version.ref = "zxing" }
 lottie = { module = "com.airbnb.android:lottie-compose", version.ref = "lottieVersion" }


### PR DESCRIPTION
Related:
- https://github.com/synonymdev/vss-rust-client-ffi/pull/3

This PR updates to latest vss client version and uses its new api to derive a deterministic vss store id, unique per wallet.

### Description
- chore: update env comment to use new lnurl-auth-server url
- feat: get store id from vss client rust lib
- fix: remove app from recents when stopped via notif buttonminutes ago
- fix: restore IsOnlineTracker startup toast prevention

### QA Notes
Test case:
- wallet create
- fund
- transfer to spending (to add LN channel)
- change settings & widgets data
- backup mnemonic
- reset / wipe / uninstall
- restore wallet
- expect ldk-node & settings + widgets data restored successfully