### PR TITLE
Get transaction detail by tx id

### DIFF
--- a/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
+++ b/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
@@ -118,6 +118,7 @@ class WakeNodeWorker @AssistedInject constructor(
                     NewTransactionSheetDetails(
                         type = NewTransactionSheetType.LIGHTNING,
                         direction = NewTransactionSheetDirection.RECEIVED,
+                        paymentHashOrTxId = event.paymentHash,
                         sats = sats.toLong(),
                     )
                 )

--- a/app/src/main/java/to/bitkit/models/NewTransactionSheetDetails.kt
+++ b/app/src/main/java/to/bitkit/models/NewTransactionSheetDetails.kt
@@ -15,6 +15,7 @@ private const val APP_PREFS = "bitkit_prefs"
 data class NewTransactionSheetDetails(
     val type: NewTransactionSheetType,
     val direction: NewTransactionSheetDirection,
+    val paymentHashOrTxId: String? = null,
     val sats: Long,
 ) {
     companion object {

--- a/app/src/main/java/to/bitkit/models/NewTransactionSheetDetails.kt
+++ b/app/src/main/java/to/bitkit/models/NewTransactionSheetDetails.kt
@@ -17,6 +17,7 @@ data class NewTransactionSheetDetails(
     val direction: NewTransactionSheetDirection,
     val paymentHashOrTxId: String? = null,
     val sats: Long,
+    val isLoadingDetails: Boolean = false
 ) {
     companion object {
         private const val BACKGROUND_TRANSACTION_KEY = "backgroundTransaction"

--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -40,9 +40,10 @@ class ActivityRepo @Inject constructor(
         Logger.debug("syncActivities called", context = TAG)
 
         return@withContext runCatching {
-            if (isSyncingLdkNodePayments) {
-                Logger.warn("LDK-node payments are already being synced, skipping", context = TAG)
-                return@withContext Result.failure(Exception())
+
+            while (isSyncingLdkNodePayments) {
+                Logger.debug("LDK-node payments are already being synced, waiting for completion", context = TAG)
+                delay(1.seconds)
             }
 
             deletePendingActivities()
@@ -63,6 +64,7 @@ class ActivityRepo @Inject constructor(
                     return@withContext Result.failure(e)
                 }.map { Unit }
         }.onFailure { e ->
+            isSyncingLdkNodePayments = false
             Logger.error("syncLdkNodePayments error", e, context = TAG)
         }
     }

--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -34,8 +34,7 @@ class ActivityRepo @Inject constructor(
     private val lightningRepo: LightningRepo,
     private val cacheStore: CacheStore,
 ) {
-    var isSyncingLdkNodePayments = MutableStateFlow(false)
-        private set
+    val isSyncingLdkNodePayments = MutableStateFlow(false)
 
     val inProgressTransfers = cacheStore.data.map { it.inProgressTransfers }
 
@@ -48,7 +47,7 @@ class ActivityRepo @Inject constructor(
                 isSyncingLdkNodePayments.first { !it }
             }
 
-            isSyncingLdkNodePayments = MutableStateFlow(true)
+            isSyncingLdkNodePayments.value = true
 
             deletePendingActivities()
             return@withContext lightningRepo.getPayments()
@@ -58,22 +57,22 @@ class ActivityRepo @Inject constructor(
                     updateActivitiesMetadata()
                     boostPendingActivities()
                     updateInProgressTransfers()
-                    isSyncingLdkNodePayments = MutableStateFlow(false)
+                    isSyncingLdkNodePayments.value = false
                     return@withContext Result.success(Unit)
                 }.onFailure { e ->
                     Logger.error("Failed to sync ldk-node payments", e, context = TAG)
-                    isSyncingLdkNodePayments = MutableStateFlow(false)
+                    isSyncingLdkNodePayments.value = false
                     return@withContext Result.failure(e)
                 }.map { Unit }
         }.onFailure { e ->
             when (e) {
                 is TimeoutCancellationException -> {
-                    isSyncingLdkNodePayments = MutableStateFlow(false)
+                    isSyncingLdkNodePayments.value = false
                     Logger.error("Timeout waiting for sync to complete, forcing reset", e, context = TAG)
                 }
 
                 else -> {
-                    isSyncingLdkNodePayments = MutableStateFlow(false)
+                    isSyncingLdkNodePayments.value = false
                     Logger.error("syncActivities error", e, context = TAG)
                 }
             }

--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -26,7 +26,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val SYNC_TIMEOUT_MS = 40_000L
-private const val SYNC_CHECK_DELAY_MS = 500L
 
 @Singleton
 class ActivityRepo @Inject constructor(

--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -43,7 +43,6 @@ class ActivityRepo @Inject constructor(
         Logger.debug("syncActivities called", context = TAG)
 
         return@withContext runCatching {
-
             withTimeout(SYNC_TIMEOUT_MS) {
                 Logger.debug("isSyncingLdkNodePayments = ${isSyncingLdkNodePayments.value}", context = TAG)
                 isSyncingLdkNodePayments.first { !it }

--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -27,7 +27,7 @@ import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
 
 private const val SYNC_TIMEOUT_MS = 30_000L
-private const val SYNC_CHECK_DELAY_MS = 100L
+private const val SYNC_CHECK_DELAY_MS = 500L
 
 @Singleton
 class ActivityRepo @Inject constructor(

--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -24,9 +24,8 @@ import to.bitkit.services.CoreService
 import to.bitkit.utils.Logger
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.time.Duration.Companion.seconds
 
-private const val SYNC_TIMEOUT_MS = 30_000L
+private const val SYNC_TIMEOUT_MS = 40_000L
 private const val SYNC_CHECK_DELAY_MS = 500L
 
 @Singleton
@@ -143,9 +142,6 @@ class ActivityRepo @Inject constructor(
                     "activity with paymentHashOrTxId:$paymentHashOrTxId not found, trying again after sync",
                     context = TAG
                 )
-                Logger.debug("5 seconds delay", context = TAG)
-                delay(5.seconds)
-                Logger.debug("Syncing LN node called", context = TAG)
 
                 lightningRepo.sync().onSuccess {
                     Logger.debug("Syncing LN node SUCCESS", context = TAG)

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -258,9 +258,9 @@ class LightningRepo @Inject constructor(
     suspend fun sync(): Result<Unit> = executeWhenNodeRunning("Sync") {
         syncState()
         if (_lightningState.value.isSyncingWallet) {
-            Logger.warn("Sync already in progress, waiting for existing sync.")
-            return@executeWhenNodeRunning Result.success(Unit)
+            Logger.warn("Sync already in progress, waiting for existing sync.", context = TAG)
         }
+        _lightningState.first { !it.isSyncingWallet }
 
         _lightningState.update { it.copy(isSyncingWallet = true) }
         lightningService.sync()

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -6,6 +6,7 @@ import com.synonym.bitkitcore.decode
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
@@ -152,6 +153,9 @@ class WalletRepo @Inject constructor(
             syncBalances()
             return@withContext Result.success(Unit)
         }.onFailure { e ->
+            if (e is TimeoutCancellationException) {
+                syncBalances()
+            }
             return@withContext Result.failure(e)
         }
     }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityDetailScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityDetailScreen.kt
@@ -71,6 +71,7 @@ import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.utils.copyToClipboard
 import to.bitkit.ui.utils.getScreenTitleRes
+import to.bitkit.utils.Logger
 import to.bitkit.viewmodels.ActivityDetailViewModel
 import to.bitkit.viewmodels.ActivityListViewModel
 
@@ -85,7 +86,11 @@ fun ActivityDetailScreen(
 ) {
     val activities by listViewModel.filteredActivities.collectAsStateWithLifecycle()
     val item = activities?.find { it.rawId() == route.id }
-        ?: return
+    if (item == null) {
+        Logger.error("Activity not found")
+        return
+    }
+
 
     val app = appViewModel ?: return
     val copyToastTitle = stringResource(R.string.common__copied)

--- a/app/src/main/java/to/bitkit/ui/sheets/NewTransactionSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/NewTransactionSheet.kt
@@ -170,6 +170,7 @@ fun NewTransactionSheetView(
                     SecondaryButton(
                         text = stringResource(R.string.wallet__send_details),
                         onClick = onDetailClick,
+                        enabled = details.paymentHashOrTxId != null,
                         modifier = Modifier
                             .weight(1f)
                             .testTag("details_button")

--- a/app/src/main/java/to/bitkit/ui/sheets/NewTransactionSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/NewTransactionSheet.kt
@@ -55,6 +55,7 @@ fun NewTransactionSheet(
     settingsViewModel: SettingsViewModel,
 ) {
     val currencies by currencyViewModel.uiState.collectAsState()
+    val newTransaction by appViewModel.newTransaction.collectAsState()
 
     CompositionLocalProvider(
         LocalCurrencyViewModel provides currencyViewModel,
@@ -65,10 +66,9 @@ fun NewTransactionSheet(
             onDismissRequest = { appViewModel.hideNewTransactionSheet() },
         ) {
             NewTransactionSheetView(
-                details = appViewModel.newTransaction,
+                details = newTransaction,
                 onCloseClick = { appViewModel.hideNewTransactionSheet() },
                 onDetailClick = {
-                    appViewModel.hideNewTransactionSheet()
                     appViewModel.onClickActivityDetail()
                 },
             )
@@ -171,6 +171,7 @@ fun NewTransactionSheetView(
                         text = stringResource(R.string.wallet__send_details),
                         onClick = onDetailClick,
                         enabled = details.paymentHashOrTxId != null,
+                        isLoading = details.isLoadingDetails,
                         modifier = Modifier
                             .weight(1f)
                             .testTag("details_button")

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -944,6 +944,7 @@ class AppViewModel @Inject constructor(
                                 )
                             )
                         )
+                        lightningRepo.sync()
                     }.onFailure { e ->
                         Logger.error(msg = "Error sending onchain payment", e = e, context = TAG)
                         toast(

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -1043,10 +1043,10 @@ class AppViewModel @Inject constructor(
                 txType = txType,
                 retry = true
             ).onSuccess { activity ->
+                hideNewTransactionSheet()
                 _newTransaction.update { it.copy(isLoadingDetails = false) }
                 val nextRoute = Routes.ActivityDetail(activity.rawId())
                 mainScreenEffect(MainScreenEffect.Navigate(nextRoute))
-                hideNewTransactionSheet()
             }.onFailure { e ->
                 Logger.error(msg = "Activity not found", context = TAG)
                 toast(e)

--- a/app/src/test/java/to/bitkit/repositories/ActivityRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/ActivityRepoTest.kt
@@ -86,17 +86,7 @@ class ActivityRepoTest : BaseUnitTest() {
         assertTrue(result.isSuccess)
         verify(lightningRepo).getPayments()
         verify(coreService.activity).syncLdkNodePayments(payments, forceUpdate = false)
-        assertFalse(sut.isSyncingLdkNodePayments)
-    }
-
-    @Test
-    fun `syncActivities skips when already syncing`() = test {
-        sut.isSyncingLdkNodePayments = true
-
-        val result = sut.syncActivities()
-
-        assertTrue(result.isFailure)
-        verify(lightningRepo, never()).getPayments()
+        assertFalse(sut.isSyncingLdkNodePayments.value)
     }
 
     @Test
@@ -108,7 +98,7 @@ class ActivityRepoTest : BaseUnitTest() {
 
         assertTrue(result.isFailure)
         assertEquals(exception, result.exceptionOrNull())
-        assertFalse(sut.isSyncingLdkNodePayments)
+        assertFalse(sut.isSyncingLdkNodePayments.value)
     }
 
     @Test


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
Replaces #315 
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->
This PR fixes the bug of the send sheet displaying the data of the previous activity
### Description
The sheet is displayed before the onChain activity is added, so the app can't find the correct data to display.

- [x] Search the activity by the tx id
- [x] Sync the activity list if it is not found
- [x] Add a loading logic
- [x] Improvements in the sync logic

<!-- Extended summary of the changes, can be a list. -->

### Preview

https://github.com/user-attachments/assets/910a7f17-7f8e-4826-ae67-300b97a47125


<!-- Insert relevant screenshot / recording -->

### QA Notes
Tested:

- [x] OnChain transaction
- [x] Lightning transaction

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
