### PR TITLE
Make tagInputTestTag and addButtonTestTag visible

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityAddTagSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityAddTagSheet.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -65,6 +67,7 @@ fun ActivityAddTagSheet(
             tagInputTestTag = "TagInput",
             addButtonTestTag = "ActivityTagsSubmit",
             modifier = Modifier
+                .semantics { testTagsAsResourceId = true }
                 .sheetHeight(SheetSize.SMALL, isModal = true)
                 .gradientBackground()
         )


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

The test tags (i.e. `resource-ids`) where not visible in the add tag screen until explicitely adding `.semantics { testTagsAsResourceId = true } ` in this particular component function, that is used on the screen. Probably this component not created/rendered from the main scope where `testTagsAsResourceId = true` is set globally. Maybe there is a better way to do this, but this fixes the problem and `resource-id` is now rendered.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
