### PR TITLE
Keyboard with ImeAction.Done on entering send address

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAddressScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAddressScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -15,6 +16,8 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -70,6 +73,11 @@ fun SendAddressScreen(
                 value = uiState.addressInput,
                 onValueChange = { onEvent(SendEvent.AddressChange(it)) },
                 minLines = 12,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.None,
+                    imeAction = ImeAction.Done,
+                    autoCorrectEnabled = false
+                ),
                 textStyle = AppTextStyles.Title,
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

This PR changes the keyboard action button on input send address form to `Done` instead default `Enter` which did not incur any action. After the change confirmation closes the keyboard.
This is inline with Bitkit RN.

### Preview

Before:

<img width="210" height="420" alt="Screenshot from 2025-08-26 15-25-08" src="https://github.com/user-attachments/assets/8a660a7c-92cb-4d84-a586-fa9bbeef4803" />

After:

<img width="210" height="420" alt="Screenshot from 2025-08-26 15-58-40" src="https://github.com/user-attachments/assets/906003ac-4306-4740-b3b6-0d6dedfef88f" />





### QA Notes

Tested manually and while preparing e2e test for `onchain` test suite on emulator.
