### PR TITLE
fix: Fee above 10 USD sanity check and don't skip checks

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendConfirmScreen.kt
@@ -244,7 +244,7 @@ private fun Content(
                 text = stringResource(dialog.message),
                 confirmText = stringResource(R.string.wallet__send_yes),
                 dismissText = stringResource(R.string.common__cancel),
-                onConfirm = { onEvent(SendEvent.ConfirmAmountWarning) },
+                onConfirm = { onEvent(SendEvent.ConfirmAmountWarning(dialog)) },
                 onDismiss = {
                     onEvent(SendEvent.DismissAmountWarning)
                     onBack()

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendConfirmScreen.kt
@@ -74,7 +74,7 @@ import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.utils.rememberBiometricAuthSupported
 import to.bitkit.ui.utils.withAccent
-import to.bitkit.viewmodels.AmountWarning
+import to.bitkit.viewmodels.SanityWarning
 import to.bitkit.viewmodels.LnurlParams
 import to.bitkit.viewmodels.SendEvent
 import to.bitkit.viewmodels.SendMethod
@@ -238,7 +238,7 @@ private fun Content(
             )
         }
 
-        uiState.showAmountWarningDialog?.let { dialog ->
+        uiState.showSanityWarningDialog?.let { dialog ->
             AppAlertDialog(
                 title = stringResource(R.string.common__are_you_sure),
                 text = stringResource(dialog.message),
@@ -660,7 +660,7 @@ private fun PreviewDialog() {
         BottomSheetPreview {
             Content(
                 uiState = sendUiState().copy(
-                    showAmountWarningDialog = AmountWarning.VALUE_OVER_100_USD,
+                    showSanityWarningDialog = SanityWarning.VALUE_OVER_100_USD,
                 ),
                 isLoading = false,
                 showBiometrics = true,

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -838,17 +838,6 @@ class AppViewModel @Inject constructor(
         if (_sendUiState.value.showSanityWarningDialog != null) return
 
         val settings = settingsStore.data.first()
-        val amountInUsd = currencyRepo.convertSatsToFiat(amountSats.toLong(), "USD").getOrNull() ?: return
-        if (
-            amountInUsd.value > BigDecimal(SEND_AMOUNT_WARNING_THRESHOLD) &&
-            settings.enableSendAmountWarning &&
-            SanityWarning.VALUE_OVER_100_USD !in _sendUiState.value.confirmedWarnings
-        ) {
-            _sendUiState.update {
-                it.copy(showSanityWarningDialog = SanityWarning.VALUE_OVER_100_USD)
-            }
-            return
-        }
 
         if (
             amountSats > BigDecimal.valueOf(walletRepo.balanceState.value.totalSats.toLong())
@@ -857,6 +846,18 @@ class AppViewModel @Inject constructor(
         ) {
             _sendUiState.update {
                 it.copy(showSanityWarningDialog = SanityWarning.OVER_HALF_BALANCE)
+            }
+            return
+        }
+
+        val amountInUsd = currencyRepo.convertSatsToFiat(amountSats.toLong(), "USD").getOrNull() ?: return
+        if (
+            amountInUsd.value > BigDecimal(SEND_AMOUNT_WARNING_THRESHOLD) &&
+            settings.enableSendAmountWarning &&
+            SanityWarning.VALUE_OVER_100_USD !in _sendUiState.value.confirmedWarnings
+        ) {
+            _sendUiState.update {
+                it.copy(showSanityWarningDialog = SanityWarning.VALUE_OVER_100_USD)
             }
             return
         }

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -873,8 +873,8 @@ class AppViewModel @Inject constructor(
             return
         }
 
-        val feeInUsd = currencyRepo.convertSatsToFiat(amountSats.toLong(), "USD").getOrNull() ?: return
-        if (feeInUsd.value > BigDecimal(10)) {
+        val feeInUsd = currencyRepo.convertSatsToFiat(totalFee.toLong(), "USD").getOrNull() ?: return
+        if (feeInUsd.value > BigDecimal(TEN_USD)) {
             _sendUiState.update {
                 it.copy(showAmountWarningDialog = AmountWarning.FEE_OVER_10_USD)
             }
@@ -1392,6 +1392,7 @@ class AppViewModel @Inject constructor(
     companion object {
         private const val TAG = "AppViewModel"
         private const val SEND_AMOUNT_WARNING_THRESHOLD = 100.0
+        private const val TEN_USD = 10
     }
 }
 

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -852,7 +852,7 @@ class AppViewModel @Inject constructor(
 
         if (
             amountSats > BigDecimal.valueOf(walletRepo.balanceState.value.totalSats.toLong())
-                .times(BigDecimal(0.5)).toLong().toUInt() &&
+                .times(BigDecimal(MAX_BALANCE_FRACTION)).toLong().toUInt() &&
             SanityWarning.OVER_HALF_BALANCE !in _sendUiState.value.confirmedWarnings
         ) {
             _sendUiState.update {
@@ -873,7 +873,7 @@ class AppViewModel @Inject constructor(
         if (
             totalFee > BigDecimal.valueOf(
                 amountSats.toLong()
-            ).times(BigDecimal(0.5)).toLong().toUInt() &&
+            ).times(BigDecimal(MAX_FEE_AMOUNT_RATIO)).toLong().toUInt() &&
             SanityWarning.FEE_OVER_HALF_VALUE !in _sendUiState.value.confirmedWarnings
         ) {
             _sendUiState.update {
@@ -1406,6 +1406,8 @@ class AppViewModel @Inject constructor(
         private const val TAG = "AppViewModel"
         private const val SEND_AMOUNT_WARNING_THRESHOLD = 100.0
         private const val TEN_USD = 10
+        private const val MAX_BALANCE_FRACTION = 0.5
+        private const val MAX_FEE_AMOUNT_RATIO = 0.5
     }
 }
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
Closes #325, Closes #328
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description
This PR fixes the fee above 10 USD sanity check. The method was using the full sending amount instead of just the fee value.
Also check all the sanity checks instead of skipping the others after confirming the first one
<!-- Extended summary of the changes, can be a list. -->

### Preview

<!-- Insert relevant screenshot / recording -->

https://github.com/user-attachments/assets/96cd3d36-efb1-41f0-9553-c6af05f05120


https://github.com/user-attachments/assets/e54ca921-e766-48b7-b129-a17d0e1b7e60


### QA Notes

Steps to reproduce:

1. Have ₿ 100 000 000 in the wallet.
2. Send ₿ 51 000 000 and swipe to confirm, i.e., over 50% of funds.
3. Notice the sending over 50% of balance warning pop-up appearing.
4. Cancel the tx.
5. Enable the warning for sending over 100$. (Settings > Security and Privacy > Warn when sending over $100)
6. Go back and send again ₿ 51 000 000. Swipe to confirm.
7. Notice the sending over 100$ warning pop-up appearing.
8. Confirm pop-up.
9. Try to send with a fee of above 10 USD
10. Notice the pop-up appearing
11. Confirm pop-up
12. Try to send with a fee of above half the sending amount
13. Notice the pop-up
14. Confirm pop-up
15. No other pop-up should be displayed

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
