### PR TITLE
fix: Widgets default settings

### DIFF
--- a/app/src/main/java/to/bitkit/data/SettingsStore.kt
+++ b/app/src/main/java/to/bitkit/data/SettingsStore.kt
@@ -88,7 +88,7 @@ data class SettingsData(
     val isPinOnIdleEnabled: Boolean = false,
     val isPinForPaymentsEnabled: Boolean = false,
     val isDevModeEnabled: Boolean = false,
-    val showWidgets: Boolean = false,
+    val showWidgets: Boolean = true,
     val showWidgetTitles: Boolean = false,
     val lastUsedTags: List<String> = emptyList(),
     val enableSwipeToHideBalance: Boolean = true,

--- a/app/src/main/java/to/bitkit/data/WidgetsStore.kt
+++ b/app/src/main/java/to/bitkit/data/WidgetsStore.kt
@@ -51,6 +51,7 @@ class WidgetsStore @Inject constructor(
             it.copy(calculatorValues = calculatorValues)
         }
     }
+
     suspend fun updateArticles(articles: List<ArticleDTO>) {
         store.updateData {
             it.copy(articles = articles)
@@ -147,7 +148,11 @@ class WidgetsStore @Inject constructor(
 
 @Serializable
 data class WidgetsData(
-    val widgets: List<WidgetWithPosition> = emptyList(),
+    val widgets: List<WidgetWithPosition> = listOf(
+        WidgetWithPosition(type = WidgetType.PRICE, position = 0),
+        WidgetWithPosition(type = WidgetType.BLOCK, position = 1),
+        WidgetWithPosition(type = WidgetType.NEWS, position = 2),
+    ),
     val headlinePreferences: HeadlinePreferences = HeadlinePreferences(),
     val factsPreferences: FactsPreferences = FactsPreferences(),
     val blocksPreferences: BlocksPreferences = BlocksPreferences(),


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
Closes #314 
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->
[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=33495-110336&t=zYKPFgSGRa7q2J0F-4)
### Description

- Set default visibility as true
- Display Prices, Blocks, and Headlines as default in a fresh wallet

<!-- Extended summary of the changes, can be a list. -->

### Preview

https://github.com/user-attachments/assets/855eee57-6360-48d0-be73-05a5bb4cea34


<!-- Insert relevant screenshot / recording -->

### QA Notes
How to reproduce: 

1. Create a fresh wallet
2. Should display the widgets Prices, Blocks, and Headlines

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
