### PR TITLE
Allow specifying e2e branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,11 @@ name: E2E
 
 on:
   workflow_dispatch:
+    inputs:
+      e2e_branch:
+        description: "Branch of synonymdev/bitkit-e2e-tests to use"
+        required: false
+        default: "main"
   pull_request:
 
 env:
@@ -60,11 +65,17 @@ jobs:
     needs: build
 
     steps:
+      - name: Show selected E2E branch
+        env:
+          E2E_BRANCH: ${{ github.event.inputs.e2e_branch || 'main' }}
+        run: echo $E2E_BRANCH
+
       - name: Clone E2E tests
         uses: actions/checkout@v4
         with:
           repository: synonymdev/bitkit-e2e-tests
           path: bitkit-e2e-tests
+          ref: ${{ github.event.inputs.e2e_branch || 'main' }}
 
       - name: Enable KVM
         run: |


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Allow specifying e2e tests branch in e2e workflow in workflow-dispatch. By default `main` should be used from `synonymdev/bitkit-e2e-tests`.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
