### PR TITLE
fix: Display LN amount in send success sheet

### DIFF
--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.synonym.bitkitcore.Activity
 import com.synonym.bitkitcore.ActivityFilter
 import com.synonym.bitkitcore.FeeRates
 import com.synonym.bitkitcore.LightningInvoice
@@ -993,7 +992,7 @@ class AppViewModel @Inject constructor(
                             type = NewTransactionSheetType.LIGHTNING,
                             direction = NewTransactionSheetDirection.SENT,
                             paymentHashOrTxId = paymentHash,
-                            sats = paymentAmount.toLong(), //TODO Add fee when available
+                            sats = paymentAmount.toLong(), // TODO Add fee when available
                         ),
                     )
                 }.onFailure { e ->
@@ -1465,7 +1464,6 @@ class AppViewModel @Inject constructor(
     }
 
     private fun handlePaymentSuccess(details: NewTransactionSheetDetails) {
-
         details.paymentHashOrTxId?.let {
             if (!processedPayments.add(it)) {
                 Logger.debug("Payment $it already processed, skipping duplicate", context = TAG)


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
Related to #49
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

- The `Event.PaymentSuccessful` doesn't  return the amount sent, so as a temporary solution, the app can get it from the activity list
- Use sendLightning data to display the success screen with the correct amount
- Save the payment hash in processedPayments so it doesn't display the same success sheet twice
- reset processedPayments on next payment

<!-- Extended summary of the changes, can be a list. -->

### Preview

https://github.com/user-attachments/assets/d875c3a5-3736-433d-b007-f3a5768b9d71

<!-- Insert relevant screenshot / recording -->

### QA Notes
Tested:
- [x] Send an LN payment -> Success -> Display success screen
- [x] Wait for Event.PaymentSuccessful -> Should not retrigger the success screen if already displayed

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
