### PR TITLE
Make ScanPrompt, QRDialog, QRInput visible

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/scanner/QrScanningScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/scanner/QrScanningScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
@@ -339,7 +341,9 @@ private fun Content(
             SecondaryButton(
                 text = "Enter QRCode String",
                 onClick = { showDialog = true },
-                modifier = Modifier.testTag("ScanPrompt")
+                modifier = Modifier
+                    .semantics { testTagsAsResourceId = true }
+                    .testTag("ScanPrompt")
             )
             if (showDialog) {
                 AppAlertDialog(
@@ -347,12 +351,16 @@ private fun Content(
                     confirmText = stringResource(R.string.common__yes_proceed),
                     onConfirm = { onSubmitDebug(debugValue) },
                     onDismiss = { showDialog = false },
-                    modifier = Modifier.testTag("QRDialog")
+                    modifier = Modifier
+                        .semantics { testTagsAsResourceId = true }
+                        .testTag("QRDialog")
                 ) {
                     TextInput(
                         value = debugValue,
                         onValueChange = { debugValue = it },
-                        modifier = Modifier.testTag("QRInput")
+                        modifier = Modifier
+                            .semantics { testTagsAsResourceId = true }
+                            .testTag("QRInput")
                     )
                 }
             }


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Make ScanPrompt, QRDialog, QRInput visible as resource-id. Similar case as in https://github.com/synonymdev/bitkit-android/pull/320.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
