### PR TITLE
Parallelize activity syncing

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -5,7 +5,6 @@ import com.synonym.bitkitcore.Activity.Onchain
 import com.synonym.bitkitcore.ActivityFilter
 import com.synonym.bitkitcore.PaymentType
 import com.synonym.bitkitcore.SortDirection
-import com.synonym.bitkitcore.getTags
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
@@ -248,7 +247,7 @@ class ActivityRepo @Inject constructor(
                     context = TAG
                 )
 
-                val tags = getTags(activityIdToDelete)
+                val tags = coreService.activity.tags(activityIdToDelete)
                 addTagsToActivity(activityId = id, tags = tags)
 
                 deleteActivity(activityIdToDelete).onFailure { e ->

--- a/app/src/test/java/to/bitkit/repositories/ActivityRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/ActivityRepoTest.kt
@@ -229,6 +229,27 @@ class ActivityRepoTest : BaseUnitTest() {
     }
 
     @Test
+    fun `replaceActivity updates and deletes successfully`() = test {
+        val activityId = "activity123"
+        val activityToDeleteId = "activity456"
+        val tagsMock = listOf("tag1", "tag2")
+        val cacheData = AppCacheData(deletedActivities = emptyList())
+        whenever(cacheStore.data).thenReturn(flowOf(cacheData))
+
+        wheneverBlocking { coreService.activity.update(activityId, testActivity) }.thenReturn(Unit)
+        wheneverBlocking { coreService.activity.delete(activityToDeleteId) }.thenReturn(true)
+        wheneverBlocking { cacheStore.addActivityToDeletedList(activityToDeleteId) }.thenReturn(Unit)
+
+        whenever(coreService.activity.tags(activityId)).thenAnswer { tagsMock }
+
+        val result = sut.replaceActivity(activityId, activityToDeleteId, testActivity)
+
+        assertTrue(result.isSuccess)
+        verify(coreService.activity).update(activityId, testActivity)
+        verify(coreService.activity).delete(activityToDeleteId)
+    }
+
+    @Test
     fun `deleteActivity deletes successfully`() = test {
         val activityId = "activity123"
         wheneverBlocking { coreService.activity.delete(activityId) }.thenReturn(true)


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
Closes https://github.com/synonymdev/bitkit-android/pull/319#discussion_r2314238452
Closes https://github.com/synonymdev/bitkit-android/pull/319#discussion_r2314244526
Closes https://github.com/synonymdev/bitkit-android/pull/319#discussion_r2314248293

<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description
This Pr implements parallelization to activity syncing and fixes some code style issues


<!-- Extended summary of the changes, can be a list. -->

### Preview

https://github.com/user-attachments/assets/11dbd1e7-0a72-456a-aa90-a4f7efe29d63


https://github.com/user-attachments/assets/31df3b52-bdfa-40ce-80b3-46946077385d


https://github.com/user-attachments/assets/fc10db13-5759-405b-a5cb-5e72927523a9


https://github.com/user-attachments/assets/87d02765-529e-443e-b8dc-c0ba8b66857a


https://github.com/user-attachments/assets/e775ad7d-4e39-4150-a665-d14a3b9af9d5


https://github.com/user-attachments/assets/d26fb705-0e82-4c4e-907a-8b1631f27130


<!-- Insert relevant screenshot / recording -->

### QA Notes

Tested:
- [x] Transfer
- [x] OnChain
  - [x] RBF -> Check if the activity was updated correctly
  - [x] CPFP -> Check if the activity was updated correctly
  - [x] Send -> Check activity details
  - [x] Receive -> Check activity details
  - [x]  Add tags before sending -> send -> check if tags were attached in activity details
  - [x]  Create an invoice -> add tags -> receive -> check if tags were attached in activity details

- [x]  Lightning
  - [x] Send -> Check activity details
  - [x] Receive -> Check activity details
  - [x]  Add tags before sending -> send -> check if tags were attached in activity details
  - [x]  Create an invoice -> add tags -> receive -> check if tags were attached in activity details

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
