### PR TITLE
fix: Remove backstack on success navigation

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendQuickPayScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendQuickPayScreen.kt
@@ -38,7 +38,7 @@ import to.bitkit.viewmodels.QuickPayViewModel
 @Composable
 fun SendQuickPayScreen(
     quickPayData: QuickPayData,
-    onPaymentComplete: () -> Unit,
+    onPaymentComplete: (String, Long) -> Unit,
     onShowError: (String) -> Unit,
     viewModel: QuickPayViewModel = hiltViewModel(),
 ) {
@@ -60,7 +60,7 @@ fun SendQuickPayScreen(
 
     LaunchedEffect(uiState.result) {
         when (val result = uiState.result) {
-            is QuickPayResult.Success -> onPaymentComplete()
+            is QuickPayResult.Success -> onPaymentComplete(result.paymentHash, result.amountWithFee)
             is QuickPayResult.Error -> onShowError(result.message)
             null -> Unit // continue showing loading state
         }

--- a/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
@@ -15,6 +15,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import kotlinx.serialization.Serializable
+import to.bitkit.ext.totalValue
+import to.bitkit.models.NewTransactionSheetDetails
+import to.bitkit.models.NewTransactionSheetDirection
+import to.bitkit.models.NewTransactionSheetType
 import to.bitkit.ui.screens.scanner.QrScanningScreen
 import to.bitkit.ui.screens.wallets.send.AddTagScreen
 import to.bitkit.ui.screens.wallets.send.PIN_CHECK_RESULT_KEY
@@ -76,6 +80,7 @@ fun SendSheet(
                             popUpTo(startDestination) { inclusive = true }
                         }
                     }
+
                     is SendEffect.NavigateToQuickPay -> navController.navigate(SendRoute.QuickPay)
                     is SendEffect.NavigateToWithdrawConfirm -> navController.navigate(SendRoute.WithdrawConfirm)
                     is SendEffect.NavigateToWithdrawError -> navController.navigate(SendRoute.WithdrawError)
@@ -220,7 +225,16 @@ fun SendSheet(
                 val quickPayData by appViewModel.quickPayData.collectAsStateWithLifecycle()
                 SendQuickPayScreen(
                     quickPayData = requireNotNull(quickPayData),
-                    onPaymentComplete = {
+                    onPaymentComplete = { paymentHash, amountWithFee ->
+                        appViewModel.handlePaymentSuccess(
+                            NewTransactionSheetDetails(
+                                type = NewTransactionSheetType.LIGHTNING,
+                                direction = NewTransactionSheetDirection.SENT,
+                                paymentHashOrTxId = paymentHash,
+                                sats = amountWithFee,
+                            ),
+                        )
+
                         navController.navigate(SendRoute.Success) {
                             popUpTo(startDestination) { inclusive = true }
                         }

--- a/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
@@ -39,7 +39,6 @@ import to.bitkit.viewmodels.AppViewModel
 import to.bitkit.viewmodels.SendEffect
 import to.bitkit.viewmodels.SendEvent
 import to.bitkit.viewmodels.WalletViewModel
-import androidx.navigation.navOptions
 
 @Composable
 fun SendSheet(

--- a/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
@@ -15,7 +15,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import kotlinx.serialization.Serializable
-import to.bitkit.ext.totalValue
 import to.bitkit.models.NewTransactionSheetDetails
 import to.bitkit.models.NewTransactionSheetDirection
 import to.bitkit.models.NewTransactionSheetType

--- a/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
@@ -39,6 +39,7 @@ import to.bitkit.viewmodels.AppViewModel
 import to.bitkit.viewmodels.SendEffect
 import to.bitkit.viewmodels.SendEvent
 import to.bitkit.viewmodels.WalletViewModel
+import androidx.navigation.navOptions
 
 @Composable
 fun SendSheet(
@@ -72,7 +73,9 @@ fun SendSheet(
                     is SendEffect.PopBack -> navController.popBackStack(it.route, inclusive = false)
                     is SendEffect.PaymentSuccess -> {
                         appViewModel.clearClipboardForAutoRead()
-                        navController.navigate(SendRoute.Success)
+                        navController.navigate(SendRoute.Success) {
+                            popUpTo(startDestination) { inclusive = true }
+                        }
                     }
                     is SendEffect.NavigateToQuickPay -> navController.navigate(SendRoute.QuickPay)
                     is SendEffect.NavigateToWithdrawConfirm -> navController.navigate(SendRoute.WithdrawConfirm)
@@ -219,7 +222,9 @@ fun SendSheet(
                 SendQuickPayScreen(
                     quickPayData = requireNotNull(quickPayData),
                     onPaymentComplete = {
-                        navController.navigate(SendRoute.Success)
+                        navController.navigate(SendRoute.Success) {
+                            popUpTo(startDestination) { inclusive = true }
+                        }
                     },
                     onShowError = { errorMessage ->
                         navController.navigate(SendRoute.Error(errorMessage))

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -1463,7 +1463,7 @@ class AppViewModel @Inject constructor(
         }
     }
 
-    private fun handlePaymentSuccess(details: NewTransactionSheetDetails) {
+    fun handlePaymentSuccess(details: NewTransactionSheetDetails) {
         details.paymentHashOrTxId?.let {
             if (!processedPayments.add(it)) {
                 Logger.debug("Payment $it already processed, skipping duplicate", context = TAG)

--- a/app/src/main/java/to/bitkit/viewmodels/QuickPayViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/QuickPayViewModel.kt
@@ -49,9 +49,16 @@ class QuickPayViewModel @Inject constructor(
             }
 
             sendLightning(bolt11, amount)
-                .onSuccess {
+                .onSuccess { paymentHash ->
                     Logger.info("QuickPay lightning payment successful")
-                    _uiState.update { it.copy(result = QuickPayResult.Success) }
+                    _uiState.update {
+                        it.copy(
+                            result = QuickPayResult.Success(
+                                paymentHash = paymentHash,
+                                amountWithFee = amount.toLong() // TODO GET FEE WHEN AVAILABLE
+                            )
+                        )
+                    }
                 }.onFailure { error ->
                     Logger.error("QuickPay lightning payment failed", error)
 
@@ -96,7 +103,11 @@ class QuickPayViewModel @Inject constructor(
 }
 
 sealed class QuickPayResult {
-    data object Success : QuickPayResult()
+    data class Success(
+        val paymentHash: String,
+        val amountWithFee: Long,
+    ) : QuickPayResult()
+
     data class Error(val message: String) : QuickPayResult()
 }
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
Closes https://github.com/synonymdev/bitkit-android/pull/331#pullrequestreview-3175719362
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description
This PR removes backstack on success navigation. Also fix QuickPay success screen
<!-- Extended summary of the changes, can be a list. -->

### Preview

https://github.com/user-attachments/assets/56ecf747-5159-454e-8635-14dad0b8c02e


https://github.com/user-attachments/assets/e75b4c3f-7b9d-4583-8d23-cc50a8ce7b35


https://github.com/user-attachments/assets/ac491371-3210-47de-bb9e-31fbef0f4b2c



<!-- Insert relevant screenshot / recording -->

### QA Notes
Tested:
Try to swipe back in:
- [x] On-chain
- [x] Lightning
- [x] Quickpay
- [x] Set PIN

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
