### PR TITLE
Simplify requires pin on idle logic

### DIFF
--- a/app/src/main/java/to/bitkit/ui/components/InactivityTracker.kt
+++ b/app/src/main/java/to/bitkit/ui/components/InactivityTracker.kt
@@ -3,26 +3,15 @@ package to.bitkit.ui.components
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import to.bitkit.utils.Logger
 import to.bitkit.viewmodels.AppViewModel
 import to.bitkit.viewmodels.SettingsViewModel
-
-private const val INACTIVITY_DELAY = 90_000L // 90 seconds
 
 @Composable
 fun InactivityTracker(
@@ -31,71 +20,33 @@ fun InactivityTracker(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
     val isPinEnabled by settings.isPinEnabled.collectAsStateWithLifecycle()
     val isPinOnIdleEnabled by settings.isPinOnIdleEnabled.collectAsStateWithLifecycle()
     val isAuthenticated by app.isAuthenticated.collectAsStateWithLifecycle()
 
-    var inactivityJob by remember { mutableStateOf<Job?>(null) }
-
-    fun resetInactivityTimeout() {
-        inactivityJob?.cancel()?.also {
-            inactivityJob = null
-        }
-        if (isPinEnabled && isPinOnIdleEnabled && isAuthenticated) {
-            inactivityJob = scope.launch {
-                delay(INACTIVITY_DELAY)
-                Logger.debug("Inactivity timeout reached after ${INACTIVITY_DELAY / 1000}s, resetting isAuthenticated.")
-                app.setIsAuthenticated(false)
-                resetInactivityTimeout()
-            }
-        }
-    }
-
-    LaunchedEffect(isAuthenticated, isPinEnabled, isPinOnIdleEnabled) {
-        if (isAuthenticated) {
-            resetInactivityTimeout()
-        } else {
-            inactivityJob?.cancel()?.also {
-                inactivityJob = null
-            }
-        }
-    }
-
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_RESUME -> resetInactivityTimeout()
-                Lifecycle.Event.ON_PAUSE -> inactivityJob?.cancel()?.also { inactivityJob = null }
+                Lifecycle.Event.ON_RESUME -> {
+                    if (isPinEnabled && isPinOnIdleEnabled && isAuthenticated) {
+                        Logger.debug("App resumed, resetting isAuthenticated.")
+                        app.setIsAuthenticated(false)
+                    }
+                }
+
                 else -> Unit
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
-            inactivityJob?.cancel()?.also {
-                inactivityJob = null
-            }
         }
     }
 
     Box(
-        modifier = modifier.let { baseModifier ->
-            if (isPinOnIdleEnabled) {
-                baseModifier.pointerInput(Unit) {
-                    while (true) {
-                        awaitPointerEventScope {
-                            awaitPointerEvent()
-                            resetInactivityTimeout()
-                        }
-                    }
-                }
-            } else {
-                baseModifier
-            }
-        }
+        modifier = modifier
     ) {
         content()
     }


### PR DESCRIPTION
closes #332 
Related to #268 

<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

<!-- Extended summary of the changes, can be a list. -->
This PR replaces the "require pin on idle" logic with one that requires it every time the app is resumed
[Slack thread](https://synonymworkspace.slack.com/archives/C07BJ7DNPCG/p1754647706979969)

### Preview

https://github.com/user-attachments/assets/c86cd227-aea6-4e05-9a28-36ced8d1fb92


<!-- Insert relevant screenshot / recording -->

### QA Notes
Tested:

- Enable the feature -> but the app in the background -> should require the pin
- Disables the feature -> but the app in the background -> should not require the pin

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
