### PR TITLE
Smooth default transition

### DIFF
--- a/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -40,16 +41,38 @@ inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
     typeMap: Map<KType, NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
     noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = {
-        Transitions.slideInHorizontally
+        // New screen slides in from the right
+        slideInHorizontally(
+            initialOffsetX = { fullWidth -> fullWidth },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        )
     },
     noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = {
-        Transitions.scaleOut
+        // Current screen slides out to the left (partially visible behind new screen)
+        slideOutHorizontally(
+            targetOffsetX = { fullWidth -> -fullWidth / 3 },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        ) + fadeOut(
+            animationSpec = tween(300, easing = FastOutSlowInEasing),
+            targetAlpha = 0.8f
+        )
     },
     noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = {
-        Transitions.scaleIn
+        // Previous screen slides in from the left (was partially visible)
+        slideInHorizontally(
+            initialOffsetX = { fullWidth -> -fullWidth / 3 },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        ) + fadeIn(
+            animationSpec = tween(300, easing = FastOutSlowInEasing),
+            initialAlpha = 0.8f
+        )
     },
     noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = {
-        Transitions.slideOutHorizontally
+        // Current screen slides out to the right
+        slideOutHorizontally(
+            targetOffsetX = { fullWidth -> fullWidth },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        )
     },
     noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {

--- a/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
@@ -36,7 +36,7 @@ object Transitions {
 /**
  * Adds the [Composable] to the [NavGraphBuilder] with the default screen transitions.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList","MagicNumber")
 inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
     typeMap: Map<KType, NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),

--- a/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
@@ -36,7 +36,7 @@ object Transitions {
 /**
  * Adds the [Composable] to the [NavGraphBuilder] with the default screen transitions.
  */
-@Suppress("LongParameterList","MagicNumber")
+@Suppress("LongParameterList", "MagicNumber")
 inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
     typeMap: Map<KType, NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),

--- a/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
@@ -90,22 +90,44 @@ inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
 /**
  * Construct a nested [NavGraph] with the default screen transitions.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "MagicNumber")
 inline fun <reified T : Any> NavGraphBuilder.navigationWithDefaultTransitions(
     startDestination: Any,
     typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
     noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = {
-        Transitions.slideInHorizontally
+        // New screen slides in from the right
+        slideInHorizontally(
+            initialOffsetX = { fullWidth -> fullWidth },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        )
     },
     noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = {
-        Transitions.scaleOut
+        // Current screen slides out to the left (partially visible behind new screen)
+        slideOutHorizontally(
+            targetOffsetX = { fullWidth -> -fullWidth / 3 },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        ) + fadeOut(
+            animationSpec = tween(300, easing = FastOutSlowInEasing),
+            targetAlpha = 0.8f
+        )
     },
     noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = {
-        Transitions.scaleIn
+        // Previous screen slides in from the left (was partially visible)
+        slideInHorizontally(
+            initialOffsetX = { fullWidth -> -fullWidth / 3 },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        ) + fadeIn(
+            animationSpec = tween(300, easing = FastOutSlowInEasing),
+            initialAlpha = 0.8f
+        )
     },
     noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = {
-        Transitions.slideOutHorizontally
+        // Current screen slides out to the right
+        slideOutHorizontally(
+            targetOffsetX = { fullWidth -> fullWidth },
+            animationSpec = tween(300, easing = FastOutSlowInEasing)
+        )
     },
     noinline builder: NavGraphBuilder.() -> Unit,
 ) {

--- a/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
@@ -71,19 +71,15 @@ object Transitions {
 /**
  * Construct a nested [NavGraph] with the default screen transitions.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "MaxLineLength")
 inline fun <reified T : Any> NavGraphBuilder.navigationWithDefaultTransitions(
     startDestination: Any,
     typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
-    noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?
-    = defaultEnterTrans,
-    noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?
-    = defaultExitTrans,
-    noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?
-    = defaultPopEnterTrans,
-    noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?
-    = defaultPopExitTrans,
+    noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = defaultEnterTrans,
+    noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = defaultExitTrans,
+    noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = defaultPopEnterTrans,
+    noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = defaultPopExitTrans,
     noinline builder: NavGraphBuilder.() -> Unit,
 ) {
     navigation<T>(
@@ -101,18 +97,14 @@ inline fun <reified T : Any> NavGraphBuilder.navigationWithDefaultTransitions(
 /**
  * Adds the [Composable] to the [NavGraphBuilder] with the default screen transitions.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "MaxLineLength")
 inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
     typeMap: Map<KType, NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
-    noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?
-    = defaultEnterTrans,
-    noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?
-    = defaultExitTrans,
-    noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?
-    = defaultPopEnterTrans,
-    noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?
-    = defaultPopExitTrans,
+    noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = defaultEnterTrans,
+    noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = defaultExitTrans,
+    noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = defaultPopEnterTrans,
+    noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = defaultPopExitTrans,
     noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
     composable<T>(

--- a/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/Transitions.kt
@@ -8,8 +8,6 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
@@ -22,33 +20,27 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
+import to.bitkit.ui.utils.Transitions.defaultEnterTrans
+import to.bitkit.ui.utils.Transitions.defaultExitTrans
+import to.bitkit.ui.utils.Transitions.defaultPopEnterTrans
+import to.bitkit.ui.utils.Transitions.defaultPopExitTrans
 import kotlin.reflect.KType
 
+@Suppress("MagicNumber")
 object Transitions {
     val slideInHorizontally = slideInHorizontally(animationSpec = tween(), initialOffsetX = { it })
     val slideOutHorizontally = slideOutHorizontally(animationSpec = tween(), targetOffsetX = { it })
-    val scaleIn = scaleIn(animationSpec = tween(), initialScale = 0.95f) + fadeIn()
-    val scaleOut = scaleOut(animationSpec = tween(), targetScale = 0.95f) + fadeOut()
     val slideInVertically = slideInVertically(animationSpec = tween(), initialOffsetY = { it })
     val slideOutVertically = slideOutVertically(animationSpec = tween(), targetOffsetY = { it })
-}
 
-/**
- * Adds the [Composable] to the [NavGraphBuilder] with the default screen transitions.
- */
-@Suppress("LongParameterList", "MagicNumber")
-inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
-    typeMap: Map<KType, NavType<*>> = emptyMap(),
-    deepLinks: List<NavDeepLink> = emptyList(),
-    noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = {
-        // New screen slides in from the right
+    val defaultEnterTrans: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?) = {
         slideInHorizontally(
             initialOffsetX = { fullWidth -> fullWidth },
             animationSpec = tween(300, easing = FastOutSlowInEasing)
         )
-    },
-    noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = {
-        // Current screen slides out to the left (partially visible behind new screen)
+    }
+
+    val defaultExitTrans: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?) = {
         slideOutHorizontally(
             targetOffsetX = { fullWidth -> -fullWidth / 3 },
             animationSpec = tween(300, easing = FastOutSlowInEasing)
@@ -56,9 +48,9 @@ inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
             animationSpec = tween(300, easing = FastOutSlowInEasing),
             targetAlpha = 0.8f
         )
-    },
-    noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = {
-        // Previous screen slides in from the left (was partially visible)
+    }
+
+    val defaultPopEnterTrans: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?) = {
         slideInHorizontally(
             initialOffsetX = { fullWidth -> -fullWidth / 3 },
             animationSpec = tween(300, easing = FastOutSlowInEasing)
@@ -66,69 +58,32 @@ inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
             animationSpec = tween(300, easing = FastOutSlowInEasing),
             initialAlpha = 0.8f
         )
-    },
-    noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = {
-        // Current screen slides out to the right
+    }
+
+    val defaultPopExitTrans: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?) = {
         slideOutHorizontally(
             targetOffsetX = { fullWidth -> fullWidth },
             animationSpec = tween(300, easing = FastOutSlowInEasing)
         )
-    },
-    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
-) {
-    composable<T>(
-        typeMap = typeMap,
-        deepLinks = deepLinks,
-        enterTransition = enterTransition,
-        exitTransition = exitTransition,
-        popEnterTransition = popEnterTransition,
-        popExitTransition = popExitTransition,
-        content = content,
-    )
+    }
 }
 
 /**
  * Construct a nested [NavGraph] with the default screen transitions.
  */
-@Suppress("LongParameterList", "MagicNumber")
+@Suppress("LongParameterList")
 inline fun <reified T : Any> NavGraphBuilder.navigationWithDefaultTransitions(
     startDestination: Any,
     typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
-    noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = {
-        // New screen slides in from the right
-        slideInHorizontally(
-            initialOffsetX = { fullWidth -> fullWidth },
-            animationSpec = tween(300, easing = FastOutSlowInEasing)
-        )
-    },
-    noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = {
-        // Current screen slides out to the left (partially visible behind new screen)
-        slideOutHorizontally(
-            targetOffsetX = { fullWidth -> -fullWidth / 3 },
-            animationSpec = tween(300, easing = FastOutSlowInEasing)
-        ) + fadeOut(
-            animationSpec = tween(300, easing = FastOutSlowInEasing),
-            targetAlpha = 0.8f
-        )
-    },
-    noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)? = {
-        // Previous screen slides in from the left (was partially visible)
-        slideInHorizontally(
-            initialOffsetX = { fullWidth -> -fullWidth / 3 },
-            animationSpec = tween(300, easing = FastOutSlowInEasing)
-        ) + fadeIn(
-            animationSpec = tween(300, easing = FastOutSlowInEasing),
-            initialAlpha = 0.8f
-        )
-    },
-    noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)? = {
-        // Current screen slides out to the right
-        slideOutHorizontally(
-            targetOffsetX = { fullWidth -> fullWidth },
-            animationSpec = tween(300, easing = FastOutSlowInEasing)
-        )
-    },
+    noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?
+    = defaultEnterTrans,
+    noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?
+    = defaultExitTrans,
+    noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?
+    = defaultPopEnterTrans,
+    noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?
+    = defaultPopExitTrans,
     noinline builder: NavGraphBuilder.() -> Unit,
 ) {
     navigation<T>(
@@ -140,5 +95,33 @@ inline fun <reified T : Any> NavGraphBuilder.navigationWithDefaultTransitions(
         popEnterTransition = popEnterTransition,
         popExitTransition = popExitTransition,
         builder = builder,
+    )
+}
+
+/**
+ * Adds the [Composable] to the [NavGraphBuilder] with the default screen transitions.
+ */
+@Suppress("LongParameterList")
+inline fun <reified T : Any> NavGraphBuilder.composableWithDefaultTransitions(
+    typeMap: Map<KType, NavType<*>> = emptyMap(),
+    deepLinks: List<NavDeepLink> = emptyList(),
+    noinline enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?
+    = defaultEnterTrans,
+    noinline exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?
+    = defaultExitTrans,
+    noinline popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?
+    = defaultPopEnterTrans,
+    noinline popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?
+    = defaultPopExitTrans,
+    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+) {
+    composable<T>(
+        typeMap = typeMap,
+        deepLinks = deepLinks,
+        enterTransition = enterTransition,
+        exitTransition = exitTransition,
+        popEnterTransition = popEnterTransition,
+        popExitTransition = popExitTransition,
+        content = content,
     )
 }


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

<!-- Extended summary of the changes, can be a list. -->

- Forward Navigation (enter/exit):
  - New screen slides in from the right edge (slideInHorizontally with fullWidth offset)
  - Current screen slides out partially to the left (-fullWidth / 3) with a slight fade, mimicking how iOS keeps the previous screen partially visible

- Back Navigation (popEnter/popExit):
  - Previous screen slides back in from its partially visible position
  - Current screen slides out completely to the right

- Animation Specs
  - Uses 300ms duration (closer to iOS timing)
  - FastOutSlowInEasing for more natural iOS-like easing
  - Added fade effects to simulate the iOS layering effect

### Preview


https://github.com/user-attachments/assets/afed249e-7b8a-40f6-a74b-42680bc504fb


### QA Notes
- Browse through the app and look for transition inconsistencies
<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
