### PR TITLE
Parallel e2e test execution for faster feedback

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
 
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - { name: onboarding_backup_numberpad, grep: "@onboarding|@backup|@numberpad" }
+          - { name: onchain_receive, grep: "@onchain|@receive" }
+          - { name: widgets_settings, grep: "@widgets|@settings" }
+
+    name: e2e-tests - ${{ matrix.shard.name }}
+
     steps:
       - name: Show selected E2E branch
         env:
@@ -125,7 +135,7 @@ jobs:
           sudo bash -c "while [ ! -f docker/lnd/data/chain/bitcoin/regtest/admin.macaroon ]; do sleep 1; done"
           sudo chmod -R 777 docker/lnd
 
-      - name: Run E2E Tests
+      - name: Run E2E Tests (${{ matrix.shard.name }})
         uses: reactivecircus/android-emulator-runner@v2
         with:
           profile: pixel_6
@@ -134,17 +144,17 @@ jobs:
           avd-name: Pixel_6
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-front none
-          script: cd bitkit-e2e-tests && ./ci_run_android.sh
+          script: cd bitkit-e2e-tests && ./ci_run_android.sh --mochaOpts.grep "${{ matrix.shard.grep }}"
         env:
           RECORD_VIDEO: true
 
-      - name: Upload E2E Artifacts
+      - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-artifacts_${{ github.run_number }}
+          name: e2e-artifacts_${{ matrix.shard.name }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/
 
-      - name: Dump docker logs on failure
+      - name: Dump docker logs on failure (${{ matrix.shard.name }})
         if: failure()
         uses: jwalton/gh-docker-logs@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,8 +69,8 @@ jobs:
       matrix:
         shard:
           - { name: onboarding_backup_numberpad, grep: "@onboarding|@backup|@numberpad" }
-          - { name: onchain_receive, grep: "@onchain|@receive" }
-          - { name: widgets_settings, grep: "@widgets|@settings" }
+          - { name: onchain_receive_widgets, grep: "@onchain|@receive|@widgets" }
+          - { name: settings, grep: "@settings" }
 
     name: e2e-tests - ${{ matrix.shard.name }}
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Since e2e test suite has grown running everything sequentially now takes ~20 minutes.
This PR introduces parallelization using a GHA matrix strategy combined with basic test tagging.
 - Splits tests into shards by tag (e.g. `@onchain|@receive|@widgets`).
 - Reduces overall execution time to ~10 minutes.
 - Leaves room for further optimization by balancing shards (e.g. `@settings` currently takes the longest).

This should speed up CI feedback while keeping the setup straightforward.

### Preview

<img width="1319" height="596" alt="image" src="https://github.com/user-attachments/assets/9bc16cd3-3a1a-4b65-9373-5447de952eef" />


### QA Notes

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
