### PR TITLE
feat: use new staging vss auth services

### DIFF
--- a/app/src/main/java/to/bitkit/data/backup/VssBackupClient.kt
+++ b/app/src/main/java/to/bitkit/data/backup/VssBackupClient.kt
@@ -29,28 +29,31 @@ class VssBackupClient @Inject constructor(
     suspend fun setup() = withContext(bgDispatcher) {
         try {
             withTimeout(30.seconds) {
-                val vssServerUrl = Env.vssServerUrl
-                Logger.verbose("VSS client setting up…", context = TAG)
-                if (Env.lnurlAuthSeverUrl.isNotEmpty()) {
+                Logger.debug("VSS client setting up…", context = TAG)
+                val vssUrl = Env.vssServerUrl
+                val lnurlAuthServerUrl = Env.lnurlAuthServerUrl
+                Logger.verbose("Building VSS client with vssUrl: '$vssUrl'")
+                Logger.verbose("Building VSS client with lnurlAuthServerUrl: '$lnurlAuthServerUrl'")
+                if (lnurlAuthServerUrl.isNotEmpty()) {
                     val mnemonic = keychain.loadString(Keychain.Key.BIP39_MNEMONIC.name)
                         ?: throw ServiceError.MnemonicNotFound
                     val passphrase = keychain.loadString(Keychain.Key.BIP39_PASSPHRASE.name)
 
                     vssNewClientWithLnurlAuth(
-                        baseUrl = vssServerUrl,
+                        baseUrl = vssUrl,
                         storeId = vssStoreIdProvider.getVssStoreId(),
                         mnemonic = mnemonic,
                         passphrase = passphrase,
-                        lnurlAuthServerUrl = Env.lnurlAuthSeverUrl,
+                        lnurlAuthServerUrl = lnurlAuthServerUrl,
                     )
                 } else {
                     vssNewClient(
-                        baseUrl = vssServerUrl,
+                        baseUrl = vssUrl,
                         storeId = vssStoreIdProvider.getVssStoreId(),
                     )
                 }
                 isSetup.complete(Unit)
-                Logger.info("VSS client setup with server: '$vssServerUrl'", context = TAG)
+                Logger.info("VSS client setup with server: '$vssUrl'", context = TAG)
             }
         } catch (e: Throwable) {
             isSetup.completeExceptionally(e)

--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -39,15 +39,15 @@ internal object Env {
 
     val vssServerUrl
         get() = when (network) {
-            Network.BITCOIN -> TODO("VSS not implemented for mainnet")
+            Network.BITCOIN -> TODO("VSS server not implemented for mainnet")
             // Network.REGTEST -> "http://localhost:5050/vss"
-            // Network.REGTEST -> "https://bitkit.stag0.blocktank.to/vss_rs_auth"
-            else -> "https://bitkit.stag0.blocktank.to/vss_rs/"
+            else -> "https://bitkit.stag0.blocktank.to/vss_rs_auth"
         }
 
-    val lnurlAuthSeverUrl = when (network) {
+    val lnurlAuthServerUrl = when (network) {
+        Network.BITCOIN -> TODO("LNURL-auth server not implemented for mainnet")
         // Network.REGTEST -> "http://localhost:5005/auth"
-        else -> "" // TODO implement LNURL-auth Server for other networks
+        else -> "https://bitkit.stag0.blocktank.to/lnurl_auth/auth"
     }
 
     val vssStoreIdPrefix get() = "bitkit_v1_${network.name.lowercase()}"

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -113,16 +113,20 @@ class LightningService @Inject constructor(
 
         ServiceQueue.LDK.background {
             node = try {
-                if (Env.lnurlAuthSeverUrl.isNotEmpty()) {
+                val lnurlAuthServerUrl = Env.lnurlAuthServerUrl
+                val vssUrl = Env.vssServerUrl
+                Logger.verbose("Building ldk-node with vssUrl: '$vssUrl'")
+                Logger.verbose("Building ldk-node with lnurlAuthServerUrl: '$lnurlAuthServerUrl'")
+                if (lnurlAuthServerUrl.isNotEmpty()) {
                     builder.buildWithVssStore(
-                        vssUrl = Env.vssServerUrl,
+                        vssUrl = vssUrl,
                         storeId = vssStoreId,
-                        lnurlAuthServerUrl = Env.lnurlAuthSeverUrl,
+                        lnurlAuthServerUrl = lnurlAuthServerUrl,
                         fixedHeaders = emptyMap(),
                     )
                 } else {
                     builder.buildWithVssStoreAndFixedHeaders(
-                        vssUrl = Env.vssServerUrl,
+                        vssUrl = vssUrl,
                         storeId = vssStoreId,
                         fixedHeaders = emptyMap(),
                     )


### PR DESCRIPTION
### Description

This PR uses the new staging services to enable secured backups using [vss-server](https://github.com/ovitrif/vss-server) with JWT authentication enabled by the new [lnurl-auth-server](https://github.com/synonymdev/lnurl-auth-server/) backend service for issuing JWT tokens based on the contract expected by ldk-node and [vss-rust-client](https://github.com/synonymdev/vss-rust-client-ffi).

### QA Notes
#### Tests
- Test with new wallet (do not expect old wallets to work):
  - crate wallet > fund > transfer to spending
  - send onchain once
  - send lightning once
  - remove all suggestion cards but one
  - remove all widgets
  - settings > backup or restore > save seed > reset and restore wallet
  - use seed to restore
  - expect wallet to restore correctly:
    - expect ldk-node restore success: channel + activity history correct
    - expect settings restore success: suggestion cards + widgets removed