### PR TITLE
Reserve a fee amount when trying to sent all on-chain balance

### DIFF
--- a/app/src/main/java/to/bitkit/models/BalanceState.kt
+++ b/app/src/main/java/to/bitkit/models/BalanceState.kt
@@ -7,5 +7,6 @@ data class BalanceState(
     val totalOnchainSats: ULong = 0uL,
     val totalLightningSats: ULong = 0uL,
     val maxSendLightningSats: ULong = 0uL, // TODO use where applicable
+    val maxSendOnchainSats: ULong = 0uL,
     val totalSats: ULong = 0uL,
 )

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -520,6 +520,7 @@ class LightningRepo @Inject constructor(
         feeRates: FeeRates? = null,
         isTransfer: Boolean = false,
         channelId: String? = null,
+        isMaxAmount: Boolean = false
     ): Result<Txid> =
         executeWhenNodeRunning("Send on-chain") {
             val transactionSpeed = speed ?: settingsStore.data.first().defaultTransactionSpeed
@@ -538,6 +539,7 @@ class LightningRepo @Inject constructor(
                 sats = sats,
                 satsPerVByte = satsPerVByte,
                 utxosToSpend = finalUtxosToSpend,
+                isMaxAmount = isMaxAmount
             )
             cacheStore.addTransactionMetadata(
                 TransactionMetadata(

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -700,8 +700,7 @@ class LightningRepo @Inject constructor(
 
     fun getBalances(): BalanceDetails? =
         if (_lightningState.value.nodeLifecycleState.isRunning()) lightningService.balances else null
-
-
+    
     suspend fun getBalancesAsync(): Result<BalanceDetails> = executeWhenNodeRunning("getBalancesAsync") {
         Result.success(checkNotNull(lightningService.balances))
     }

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -520,7 +520,7 @@ class LightningRepo @Inject constructor(
         feeRates: FeeRates? = null,
         isTransfer: Boolean = false,
         channelId: String? = null,
-        isMaxAmount: Boolean = false
+        isMaxAmount: Boolean = false,
     ): Result<Txid> =
         executeWhenNodeRunning("Send on-chain") {
             val transactionSpeed = speed ?: settingsStore.data.first().defaultTransactionSpeed
@@ -700,7 +700,7 @@ class LightningRepo @Inject constructor(
 
     fun getBalances(): BalanceDetails? =
         if (_lightningState.value.nodeLifecycleState.isRunning()) lightningService.balances else null
-    
+
     suspend fun getBalancesAsync(): Result<BalanceDetails> = executeWhenNodeRunning("getBalancesAsync") {
         Result.success(checkNotNull(lightningService.balances))
     }

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -701,6 +701,11 @@ class LightningRepo @Inject constructor(
     fun getBalances(): BalanceDetails? =
         if (_lightningState.value.nodeLifecycleState.isRunning()) lightningService.balances else null
 
+
+    suspend fun getBalancesAsync(): Result<BalanceDetails> = executeWhenNodeRunning("getBalancesAsync") {
+        Result.success(checkNotNull(lightningService.balances))
+    }
+
     fun getStatus(): NodeStatus? =
         if (_lightningState.value.nodeLifecycleState.isRunning()) lightningService.status else null
 

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -175,6 +175,8 @@ class WalletRepo @Inject constructor(
             )
             _balanceState.update { newBalance }
             saveBalanceState(newBalance)
+        }.onFailure {
+            Logger.warn("Could not sync balances", context = TAG)
         }
     }
 

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -464,21 +464,21 @@ class WalletRepo @Inject constructor(
     }
 
     private suspend fun getMaxSendAmount(): ULong = withContext(bgDispatcher) {
-        val totalOnchainSats = walletState.value.balanceDetails?.spendableOnchainBalanceSats ?: 0uL
-        if (totalOnchainSats == 0uL) {
+        val spendableOnchainSats = walletState.value.balanceDetails?.spendableOnchainBalanceSats ?: 0uL
+        if (spendableOnchainSats == 0uL) {
             return@withContext 0uL
         }
-        val fallbackMaxFee = (totalOnchainSats.toDouble() * FALLBACK_FEE_PERCENT).toULong()
+        val fallbackMaxFee = (spendableOnchainSats.toDouble() * FALLBACK_FEE_PERCENT).toULong()
 
         val fee = lightningRepo.calculateTotalFee(
-            amountSats = totalOnchainSats,
+            amountSats = spendableOnchainSats,
             speed = TransactionSpeed.default(),
             utxosToSpend = lightningRepo.listSpendableOutputs().getOrNull()
         ).onFailure {
             Logger.debug("Could not calculate max send fee, using as fallback 10% of total", context = TAG)
         }.getOrDefault(fallbackMaxFee)
 
-        val maxSendable = (totalOnchainSats - fee).coerceAtLeast(0u)
+        val maxSendable = (spendableOnchainSats - fee).coerceAtLeast(0u)
         maxSendable
     }
 

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -468,7 +468,7 @@ class WalletRepo @Inject constructor(
         if (totalOnchainSats == 0uL) {
             return@withContext 0uL
         }
-        val fallbackMaxFee = (totalOnchainSats.toDouble() * 0.1).toULong()
+        val fallbackMaxFee = (totalOnchainSats.toDouble() * FALLBACK_FEE_PERCENT).toULong()
 
         val fee = lightningRepo.calculateTotalFee(
             amountSats = totalOnchainSats,
@@ -498,6 +498,7 @@ class WalletRepo @Inject constructor(
 
     private companion object {
         const val TAG = "WalletRepo"
+        const val FALLBACK_FEE_PERCENT = 0.1
     }
 }
 

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -464,7 +464,7 @@ class WalletRepo @Inject constructor(
     }
 
     private suspend fun getMaxSendAmount(): ULong = withContext(bgDispatcher) {
-        val totalOnchainSats = walletState.value.balanceDetails?.spendableOnchainBalanceSats ?: 0uL
+        val totalOnchainSats = walletState.value.balanceDetails?.totalOnchainBalanceSats ?: 0uL
         if (totalOnchainSats == 0uL) {
             return@withContext 0uL
         }
@@ -473,6 +473,7 @@ class WalletRepo @Inject constructor(
         val fee = lightningRepo.calculateTotalFee(
             amountSats = totalOnchainSats,
             speed = TransactionSpeed.default(),
+            utxosToSpend = lightningRepo.listSpendableOutputs().getOrNull()
         ).onFailure {
             Logger.debug("Could not calculate max send fee, using as fallback 10% of total", context = TAG)
         }.getOrDefault(fallbackMaxFee)

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -161,7 +161,9 @@ class WalletRepo @Inject constructor(
     }
 
     suspend fun syncBalances() {
-        lightningRepo.getBalances()?.let { balance ->
+        lightningRepo.getBalancesAsync().onSuccess { balance ->
+            _walletState.update { it.copy(balanceDetails = balance) }
+
             val totalSats = balance.totalLightningBalanceSats + balance.totalOnchainBalanceSats
 
             val newBalance = BalanceState(
@@ -172,7 +174,6 @@ class WalletRepo @Inject constructor(
                 totalSats = totalSats,
             )
             _balanceState.update { newBalance }
-            _walletState.update { it.copy(balanceDetails = lightningRepo.getBalances()) }
             saveBalanceState(newBalance)
         }
     }

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -464,7 +464,7 @@ class WalletRepo @Inject constructor(
     }
 
     private suspend fun getMaxSendAmount(): ULong = withContext(bgDispatcher) {
-        val totalOnchainSats = walletState.value.balanceDetails?.totalOnchainBalanceSats ?: 0uL
+        val totalOnchainSats = walletState.value.balanceDetails?.spendableOnchainBalanceSats ?: 0uL
         if (totalOnchainSats == 0uL) {
             return@withContext 0uL
         }

--- a/app/src/main/java/to/bitkit/services/CoreService.kt
+++ b/app/src/main/java/to/bitkit/services/CoreService.kt
@@ -414,7 +414,7 @@ class ActivityService(
         }
 
         if (onChain.id in cacheStore.data.first().deletedActivities && !forceUpdate) {
-            Logger.debug("Activity ${onChain.id} was already deleted, skipping", context = TAG)
+            Logger.verbose("Activity ${onChain.id} was already deleted, skipping", context = TAG)
             return
         }
 

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalNodeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalNodeViewModel.kt
@@ -53,7 +53,7 @@ class ExternalNodeViewModel @Inject constructor(
     private fun observeState() {
         viewModelScope.launch {
             walletRepo.balanceState.collect {
-                val maxAmount = walletRepo.getMaxSendAmount()
+                val maxAmount = walletRepo.balanceState.value.maxSendOnchainSats
                 _uiState.update { it.copy(amount = it.amount.copy(max = maxAmount.toLong())) }
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
@@ -102,7 +102,7 @@ fun SendAmountScreen(
         }.takeIf { canGoBack },
         onClickMax = { maxSats ->
             // TODO port the RN sendMax logic if still needed
-            if (uiState.payMethod == SendMethod.LIGHTNING && uiState.lnurl == null) {
+            if (uiState.lnurl == null) {
                 app?.toast(
                     type = Toast.ToastType.WARNING,
                     title = context.getString(R.string.wallet__send_max_spending__title),
@@ -190,7 +190,7 @@ private fun SendAmountNodeRunning(
 
         val availableAmount = when {
             isLnurlWithdraw -> uiState.lnurl.data.maxWithdrawableSat().toLong()
-            uiState.payMethod == SendMethod.ONCHAIN -> balances.totalOnchainSats.toLong()
+            uiState.payMethod == SendMethod.ONCHAIN -> balances.maxSendOnchainSats.toLong()
             else -> balances.maxSendLightningSats.toLong()
         }
 

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -1103,6 +1103,8 @@ class AppViewModel @Inject constructor(
             sats = amount,
             speed = _sendUiState.value.speed,
             utxosToSpend = _sendUiState.value.selectedUtxos,
+            isMaxAmount = _sendUiState.value.payMethod == SendMethod.ONCHAIN &&
+                amount == walletRepo.balanceState.value.maxSendOnchainSats
         )
     }
 

--- a/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
@@ -218,7 +218,7 @@ class TransferViewModel @Inject constructor(
             _spendingUiState.update { it.copy(isLoading = true) }
 
             // Get the max available balance discounting onChain fee
-            val availableAmount = walletRepo.getMaxSendAmount()
+            val availableAmount = walletRepo.balanceState.value.maxSendOnchainSats
 
             withTimeoutOrNull(1.minutes) {
                 isNodeRunning.first { it }

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -388,7 +388,8 @@ class LightningRepoTest : BaseUnitTest() {
                 address = any(),
                 sats = any(),
                 satsPerVByte = any(),
-                utxosToSpend = anyOrNull()
+                utxosToSpend = anyOrNull(),
+                isMaxAmount = any()
             )
         ).thenReturn("testPaymentId")
 

--- a/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
@@ -211,7 +211,7 @@ class WalletRepoTest : BaseUnitTest() {
             on { totalLightningBalanceSats } doReturn 500uL
             on { totalOnchainBalanceSats } doReturn 1000uL
         }
-        wheneverBlocking {lightningRepo.getBalancesAsync()}.thenReturn(Result.success(balanceDetails))
+        wheneverBlocking { lightningRepo.getBalancesAsync() }.thenReturn(Result.success(balanceDetails))
 
         val channels = listOf(
             mock<ChannelDetails> {
@@ -236,7 +236,7 @@ class WalletRepoTest : BaseUnitTest() {
     @Test
     fun `syncBalances should update wallet state with balance details`() = test {
         val balanceDetails = mock<BalanceDetails>()
-        wheneverBlocking {lightningRepo.getBalancesAsync()}.thenReturn(Result.success(balanceDetails))
+        wheneverBlocking { lightningRepo.getBalancesAsync() }.thenReturn(Result.success(balanceDetails))
 
         sut.syncBalances()
 

--- a/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
@@ -211,7 +211,7 @@ class WalletRepoTest : BaseUnitTest() {
             on { totalLightningBalanceSats } doReturn 500uL
             on { totalOnchainBalanceSats } doReturn 1000uL
         }
-        whenever(lightningRepo.getBalances()).thenReturn(balanceDetails)
+        wheneverBlocking {lightningRepo.getBalancesAsync()}.thenReturn(Result.success(balanceDetails))
 
         val channels = listOf(
             mock<ChannelDetails> {
@@ -236,7 +236,7 @@ class WalletRepoTest : BaseUnitTest() {
     @Test
     fun `syncBalances should update wallet state with balance details`() = test {
         val balanceDetails = mock<BalanceDetails>()
-        whenever(lightningRepo.getBalances()).thenReturn(balanceDetails)
+        wheneverBlocking {lightningRepo.getBalancesAsync()}.thenReturn(Result.success(balanceDetails))
 
         sut.syncBalances()
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
Closes #324 
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

- cache available on-chain sendable amount
- use cached value in send and transfer flow
- display reserve amount warning also for on-chain
- implement sendMax in on-chain send

<!-- Extended summary of the changes, can be a list. -->

### Preview
[send.webm](https://github.com/user-attachments/assets/fa0687ad-3799-4a59-8bae-d95e068e4a8b)


[transfer.webm](https://github.com/user-attachments/assets/1ea463b1-7869-4f23-a332-b185eaf8152f)

<!-- Insert relevant screenshot / recording -->

### QA Notes

Make sure you have some confirmed balance, I lost some time debugging until I realized it

 - Send flow > click in available amount
 - Transfer flor > click in max
<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
