### PR TITLE
fix(receive): geo block issues with channels to external node

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -248,7 +248,7 @@ class LightningRepo @Inject constructor(
     suspend fun updateGeoBlockState() {
         val (isGeoBlocked, shouldBlockLightning) = coreService.checkGeoBlock()
         _lightningState.update {
-            it.copy(isGeoBlocked = isGeoBlocked, shouldBlockLightning = shouldBlockLightning)
+            it.copy(isGeoBlocked = isGeoBlocked, shouldBlockLightningReceive = shouldBlockLightning)
         }
     }
 
@@ -431,7 +431,7 @@ class LightningRepo @Inject constructor(
         expirySeconds: UInt = 86_400u,
     ): Result<String> = executeWhenNodeRunning("Create invoice") {
         updateGeoBlockState()
-        if (lightningState.value.shouldBlockLightning) {
+        if (lightningState.value.shouldBlockLightningReceive) {
             return@executeWhenNodeRunning Result.failure(ServiceError.GeoBlocked)
         }
 
@@ -858,6 +858,6 @@ data class LightningState(
     val peers: List<LnPeer> = emptyList(),
     val channels: List<ChannelDetails> = emptyList(),
     val isSyncingWallet: Boolean = false,
-    val shouldBlockLightning: Boolean = false,
+    val shouldBlockLightningReceive: Boolean = false,
     val isGeoBlocked: Boolean = false,
 )

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -708,10 +708,9 @@ class LightningRepo @Inject constructor(
     fun getChannels(): List<ChannelDetails>? =
         if (_lightningState.value.nodeLifecycleState.isRunning()) lightningService.channels else null
 
-    fun hasChannelsReady(): Boolean {
+    fun canReceive(): Boolean {
         val isRunning = _lightningState.value.nodeLifecycleState.isRunning()
-        val hasChannelsReady = lightningService.channels?.any { it.isChannelReady } == true
-        return isRunning && hasChannelsReady
+        return isRunning && lightningService.canReceive()
     }
 
     suspend fun registerForNotifications(token: String? = null) = executeWhenNodeRunning("registerForNotifications") {

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -382,8 +382,8 @@ class WalletRepo @Inject constructor(
             updateBip21AmountSats(amountSats)
             updateBip21Description(description)
 
-            val hasChannelsReady = lightningRepo.hasChannelsReady()
-            if (hasChannelsReady && _walletState.value.receiveOnSpendingBalance) {
+            val canReceive = lightningRepo.canReceive()
+            if (canReceive && _walletState.value.receiveOnSpendingBalance) {
                 lightningRepo.createInvoice(
                     amountSats = _walletState.value.bip21AmountSats,
                     description = _walletState.value.bip21Description,

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -102,10 +102,9 @@ class WalletRepo @Inject constructor(
     suspend fun refreshBip21(force: Boolean = false): Result<Unit> = withContext(bgDispatcher) {
         Logger.debug("Refreshing bip21 (force: $force)", context = TAG)
 
-        if (coreService.checkGeoBlock().second) {
-            _walletState.update {
-                it.copy(receiveOnSpendingBalance = false)
-            }
+        val shouldBlockLightning = coreService.checkGeoBlock().second
+        _walletState.update {
+            it.copy(receiveOnSpendingBalance = !shouldBlockLightning)
         }
 
         // Reset invoice state

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -102,9 +102,9 @@ class WalletRepo @Inject constructor(
     suspend fun refreshBip21(force: Boolean = false): Result<Unit> = withContext(bgDispatcher) {
         Logger.debug("Refreshing bip21 (force: $force)", context = TAG)
 
-        val receiveOnSpendingBalance = !coreService.checkGeoBlock().second && lightningRepo.hasChannelsReady()
+        val shouldBlockLightningReceive = coreService.checkGeoBlock().second
         _walletState.update {
-            it.copy(receiveOnSpendingBalance = receiveOnSpendingBalance)
+            it.copy(receiveOnSpendingBalance = !shouldBlockLightningReceive)
         }
 
         // Reset invoice state

--- a/app/src/main/java/to/bitkit/services/CoreService.kt
+++ b/app/src/main/java/to/bitkit/services/CoreService.kt
@@ -58,7 +58,6 @@ import to.bitkit.async.ServiceQueue
 import to.bitkit.data.CacheStore
 import to.bitkit.env.Env
 import to.bitkit.ext.amountSats
-import to.bitkit.models.LnPeer
 import to.bitkit.models.toCoreNetwork
 import to.bitkit.utils.AppError
 import to.bitkit.utils.Logger
@@ -143,25 +142,14 @@ class CoreService @Inject constructor(
         }
     }
 
-    private suspend fun getLspPeers(): List<LnPeer> {
-        val blocktankPeers = Env.trustedLnPeers
-        // TODO get from blocktank info when lightningService.setup sets trustedPeers0conf using BT API
-        // pseudocode idea:
-        // val blocktankPeers = getInfo(refresh = true)?.nodes?.map { LnPeer(nodeId = it.pubkey, address = "TO_DO") }.orEmpty()
-        return blocktankPeers
-    }
-
-    suspend fun getConnectedPeers(): List<LnPeer> = lightningService.peers.orEmpty()
-
-    suspend fun hasExternalNode() = getConnectedPeers().any { connectedPeer -> connectedPeer !in getLspPeers() }
-
     /**
-     * This method checks if the device is geo blocked and if should block lighting features
-     * @return Pair(isGeoBlocked, shouldBlockLightning)*/
+     * This method checks if the device is in a is geo blocked region and if lightning features should be blocked
+     * @return pair of `isGeoBlocked` to `shouldBlockLightning`
+     * */
     suspend fun checkGeoBlock(): Pair<Boolean, Boolean> {
         val geoBlocked = isGeoBlocked()
         val shouldBlockLightning = when {
-            hasExternalNode() -> false
+            lightningService.hasExternalPeers() -> false
             else -> geoBlocked
         }
 

--- a/app/src/main/java/to/bitkit/services/CoreService.kt
+++ b/app/src/main/java/to/bitkit/services/CoreService.kt
@@ -144,16 +144,16 @@ class CoreService @Inject constructor(
 
     /**
      * This method checks if the device is in a is geo blocked region and if lightning features should be blocked
-     * @return pair of `isGeoBlocked` to `shouldBlockLightning`
+     * @return pair of `isGeoBlocked` to `shouldBlockLightningReceive`
      * */
     suspend fun checkGeoBlock(): Pair<Boolean, Boolean> {
         val geoBlocked = isGeoBlocked()
-        val shouldBlockLightning = when {
-            lightningService.hasExternalPeers() -> false
+        val shouldBlockLightningReceive = when {
+            lightningService.hasExternalPeers() -> !lightningService.canReceive()
             else -> geoBlocked
         }
 
-        return Pair(geoBlocked, shouldBlockLightning)
+        return Pair(geoBlocked, shouldBlockLightningReceive)
     }
 }
 

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -57,6 +57,7 @@ import java.util.Locale
 import java.util.TimeZone
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.collections.any
 import kotlin.io.path.Path
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -318,6 +319,17 @@ class LightningService @Inject constructor(
             Logger.warn("Peer disconnect error: $peer", LdkError(e))
         }
     }
+
+    private fun getLspPeers(): List<LnPeer> {
+        val lspPeers = Env.trustedLnPeers
+        // TODO get from blocktank info.nodes[] when setup uses it to set trustedPeers0conf
+        // pseudocode idea:
+        // val lspPeers = getInfo(refresh = true)?.nodes?.map { LnPeer(nodeId = it.pubkey, address = "TO_DO") }
+        return lspPeers
+    }
+
+    fun hasExternalPeers() = peers?.any { it !in getLspPeers() } == true
+
     // endregion
 
     // region channels

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -57,7 +57,6 @@ import java.util.Locale
 import java.util.TimeZone
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.collections.any
 import kotlin.io.path.Path
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -386,6 +385,21 @@ class LightningService @Inject constructor(
     // endregion
 
     // region payments
+    fun canReceive(): Boolean {
+        val channels = this.channels
+        if (channels == null) {
+            Logger.warn("canReceive = false: Channels not available")
+            return false
+        }
+
+        if (channels.none { it.isChannelReady }) {
+            Logger.warn("canReceive = false: Found no LN channel ready to enable receive: $channels")
+            return false
+        }
+
+        return true
+    }
+
     suspend fun receive(sat: ULong? = null, description: String, expirySecs: UInt = 3600u): String {
         val node = this.node ?: throw ServiceError.NodeNotSetup
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
@@ -75,7 +75,7 @@ fun ReceiveSheet(
                     walletState = walletState,
                     onCjitToggle = { isOn ->
                         when {
-                            isOn && lightningState.shouldBlockLightning -> { // TODO SHOULD BLOCK HERE
+                            isOn && lightningState.shouldBlockLightning -> {
                                 navController.navigate(ReceiveRoute.GeoBlock)
                             }
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
@@ -14,11 +14,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import to.bitkit.repositories.LightningState
-import to.bitkit.ui.blocktankViewModel
 import to.bitkit.ui.screens.wallets.send.AddTagScreen
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.utils.composableWithDefaultTransitions
@@ -34,8 +31,6 @@ fun ReceiveSheet(
     editInvoiceAmountViewModel: AmountInputViewModel = hiltViewModel(),
 ) {
     val wallet = requireNotNull(walletViewModel)
-    val blocktank = requireNotNull(blocktankViewModel)
-
     val navController = rememberNavController()
     LaunchedEffect(Unit) { editInvoiceAmountViewModel.clearInput() }
 
@@ -45,13 +40,7 @@ fun ReceiveSheet(
     val lightningState: LightningState by wallet.lightningState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        runCatching {
-            // TODO move to viewModel
-            coroutineScope {
-                launch { wallet.refreshBip21() }
-                launch { blocktank.refreshInfo() }
-            }
-        }
+        wallet.refreshReceiveState()
     }
 
     Column(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
@@ -75,7 +75,7 @@ fun ReceiveSheet(
                     walletState = walletState,
                     onCjitToggle = { isOn ->
                         when {
-                            isOn && lightningState.shouldBlockLightning -> {
+                            isOn && lightningState.shouldBlockLightningReceive -> {
                                 navController.navigate(ReceiveRoute.GeoBlock)
                             }
 

--- a/app/src/main/java/to/bitkit/viewmodels/BlocktankViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/BlocktankViewModel.kt
@@ -41,12 +41,6 @@ class BlocktankViewModel @Inject constructor(
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
-    fun refreshInfo() {
-        viewModelScope.launch {
-            blocktankRepo.refreshInfo()
-        }
-    }
-
     fun refreshOrders() {
         viewModelScope.launch {
             blocktankRepo.refreshOrders()

--- a/app/src/main/java/to/bitkit/viewmodels/WalletViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/WalletViewModel.kt
@@ -26,6 +26,7 @@ import to.bitkit.models.LnPeer
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.Toast
 import to.bitkit.repositories.BackupRepo
+import to.bitkit.repositories.BlocktankRepo
 import to.bitkit.repositories.LightningRepo
 import to.bitkit.repositories.WalletRepo
 import to.bitkit.ui.onboarding.LOADING_MS
@@ -42,6 +43,7 @@ class WalletViewModel @Inject constructor(
     private val lightningRepo: LightningRepo,
     private val settingsStore: SettingsStore,
     private val backupRepo: BackupRepo,
+    private val blocktankRepo: BlocktankRepo,
 ) : ViewModel() {
 
     val lightningState = lightningRepo.lightningState
@@ -238,6 +240,12 @@ class WalletViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    fun refreshReceiveState() = viewModelScope.launch(bgDispatcher) {
+        launch { lightningRepo.updateGeoBlockState() }
+        launch { walletRepo.refreshBip21() }
+        launch { blocktankRepo.refreshInfo() }
     }
 
     fun refreshBip21() {

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -254,25 +254,24 @@ class LightningRepoTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hasChannelsReady should return false when node is not running`() = test {
-        assertFalse(sut.hasChannelsReady())
+    fun `canReceive should return false when node is not running`() = test {
+        assertFalse(sut.canReceive())
     }
 
     @Test
-    fun `hasChannelsReady should return false when having non-ready channels`() = test {
+    fun `canReceive should return false when node is running but cannot receive`() = test {
         startNodeForTesting()
-        whenever(lightningService.channels).thenReturn(listOf(mock()))
+        whenever(lightningService.canReceive()).thenReturn(false)
 
-        assertFalse(sut.hasChannelsReady())
+        assertFalse(sut.canReceive())
     }
 
     @Test
-    fun `hasChannelsReady should return true when having channels ready`() = test {
+    fun `canReceive should return true when node can receive`() = test {
         startNodeForTesting()
-        val channelReady = mock<ChannelDetails> { on { isChannelReady } doReturn true }
-        whenever(lightningService.channels).thenReturn(listOf(channelReady))
+        whenever(lightningService.canReceive()).thenReturn(true)
 
-        assertTrue(sut.hasChannelsReady())
+        assertTrue(sut.canReceive())
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -254,8 +254,25 @@ class LightningRepoTest : BaseUnitTest() {
     }
 
     @Test
-    fun `hasChannels should return false when node is not running`() = test {
-        assertFalse(sut.hasChannels())
+    fun `hasChannelsReady should return false when node is not running`() = test {
+        assertFalse(sut.hasChannelsReady())
+    }
+
+    @Test
+    fun `hasChannelsReady should return false when having non-ready channels`() = test {
+        startNodeForTesting()
+        whenever(lightningService.channels).thenReturn(listOf(mock()))
+
+        assertFalse(sut.hasChannelsReady())
+    }
+
+    @Test
+    fun `hasChannelsReady should return true when having channels ready`() = test {
+        startNodeForTesting()
+        whenever(lightningService.channels)
+            .thenReturn(listOf(mock<ChannelDetails> { on { isChannelReady } doReturn true }))
+
+        assertTrue(sut.hasChannelsReady())
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -269,8 +269,8 @@ class LightningRepoTest : BaseUnitTest() {
     @Test
     fun `hasChannelsReady should return true when having channels ready`() = test {
         startNodeForTesting()
-        whenever(lightningService.channels)
-            .thenReturn(listOf(mock<ChannelDetails> { on { isChannelReady } doReturn true }))
+        val channelReady = mock<ChannelDetails> { on { isChannelReady } doReturn true }
+        whenever(lightningService.channels).thenReturn(listOf(channelReady))
 
         assertTrue(sut.hasChannelsReady())
     }

--- a/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
@@ -136,7 +136,7 @@ class WalletRepoTest : BaseUnitTest() {
     }
 
     @Test
-    fun `refreshBip21 should set receiveOnSpendingBalance as false if shouldBlockLightning is true`() = test {
+    fun `refreshBip21 should set receiveOnSpendingBalance false when shouldBlockLightning is true`() = test {
         wheneverBlocking { coreService.checkGeoBlock() }.thenReturn(Pair(true, true))
         whenever(lightningRepo.newAddress()).thenReturn(Result.success("newAddress"))
         whenever(addressChecker.getAddressInfo(any())).thenReturn(mock())
@@ -145,6 +145,18 @@ class WalletRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         assertEquals(false, sut.walletState.value.receiveOnSpendingBalance)
+    }
+
+    @Test
+    fun `refreshBip21 should set receiveOnSpendingBalance true when shouldBlockLightning is false`() = test {
+        wheneverBlocking { coreService.checkGeoBlock() }.thenReturn(Pair(true, false))
+        whenever(lightningRepo.newAddress()).thenReturn(Result.success("newAddress"))
+        whenever(addressChecker.getAddressInfo(any())).thenReturn(mock())
+
+        val result = sut.refreshBip21()
+
+        assertTrue(result.isSuccess)
+        assertEquals(true, sut.walletState.value.receiveOnSpendingBalance)
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
@@ -258,10 +258,10 @@ class WalletRepoTest : BaseUnitTest() {
     }
 
     @Test
-    fun `updateBip21Invoice should create bolt11 when channels exist`() = test {
+    fun `updateBip21Invoice should create bolt11 when having channels ready`() = test {
         val testInvoice = "testInvoice"
-        whenever(lightningRepo.hasChannels()).thenReturn(true)
-        whenever(lightningRepo.createInvoice(1000uL, description = "test")).thenReturn(Result.success(testInvoice))
+        whenever(lightningRepo.hasChannelsReady()).thenReturn(true)
+        whenever(lightningRepo.createInvoice(anyOrNull(), any(), any())).thenReturn(Result.success(testInvoice))
 
         sut.updateBip21Invoice(amountSats = 1000uL, description = "test").let { result ->
             assertTrue(result.isSuccess)
@@ -271,8 +271,7 @@ class WalletRepoTest : BaseUnitTest() {
 
     @Test
     fun `updateBip21Invoice should not create bolt11 when no channels exist`() = test {
-        whenever(lightningRepo.hasChannels()).thenReturn(false)
-
+        whenever(lightningRepo.hasChannelsReady()).thenReturn(false)
         sut.updateBip21Invoice(amountSats = 1000uL, description = "test").let { result ->
             assertTrue(result.isSuccess)
             assertEquals("", sut.walletState.value.bolt11)
@@ -283,7 +282,8 @@ class WalletRepoTest : BaseUnitTest() {
     fun `updateBip21Invoice should build correct BIP21 URL`() = test {
         val testAddress = "testAddress"
         whenever(cacheStore.data).thenReturn(flowOf(AppCacheData(onchainAddress = testAddress)))
-        whenever(lightningRepo.hasChannels()).thenReturn(false)
+        whenever(lightningRepo.hasChannelsReady()).thenReturn(false)
+        whenever(lightningRepo.createInvoice(anyOrNull(), any(), any())).thenReturn(Result.success("testInvoice"))
         sut = createSut()
 
         sut.updateBip21Invoice(amountSats = 1000uL, description = "test").let { result ->

--- a/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
@@ -258,9 +258,9 @@ class WalletRepoTest : BaseUnitTest() {
     }
 
     @Test
-    fun `updateBip21Invoice should create bolt11 when having channels ready`() = test {
+    fun `updateBip21Invoice should create bolt11 when node can receive`() = test {
         val testInvoice = "testInvoice"
-        whenever(lightningRepo.hasChannelsReady()).thenReturn(true)
+        whenever(lightningRepo.canReceive()).thenReturn(true)
         whenever(lightningRepo.createInvoice(anyOrNull(), any(), any())).thenReturn(Result.success(testInvoice))
 
         sut.updateBip21Invoice(amountSats = 1000uL, description = "test").let { result ->
@@ -270,8 +270,7 @@ class WalletRepoTest : BaseUnitTest() {
     }
 
     @Test
-    fun `updateBip21Invoice should not create bolt11 when no channels exist`() = test {
-        whenever(lightningRepo.hasChannelsReady()).thenReturn(false)
+    fun `updateBip21Invoice should not create bolt11 when node cannot receive`() = test {
         sut.updateBip21Invoice(amountSats = 1000uL, description = "test").let { result ->
             assertTrue(result.isSuccess)
             assertEquals("", sut.walletState.value.bolt11)
@@ -282,7 +281,6 @@ class WalletRepoTest : BaseUnitTest() {
     fun `updateBip21Invoice should build correct BIP21 URL`() = test {
         val testAddress = "testAddress"
         whenever(cacheStore.data).thenReturn(flowOf(AppCacheData(onchainAddress = testAddress)))
-        whenever(lightningRepo.hasChannelsReady()).thenReturn(false)
         whenever(lightningRepo.createInvoice(anyOrNull(), any(), any())).thenReturn(Result.success("testInvoice"))
         sut = createSut()
 

--- a/app/src/test/java/to/bitkit/ui/WalletViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/WalletViewModelTest.kt
@@ -1,34 +1,29 @@
 package to.bitkit.ui
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.robolectric.annotation.Config
 import to.bitkit.data.SettingsStore
 import to.bitkit.models.LnPeer
 import to.bitkit.repositories.BackupRepo
+import to.bitkit.repositories.BlocktankRepo
 import to.bitkit.repositories.LightningRepo
 import to.bitkit.repositories.LightningState
 import to.bitkit.repositories.WalletRepo
 import to.bitkit.repositories.WalletState
 import to.bitkit.test.BaseUnitTest
-import to.bitkit.test.TestApp
 import to.bitkit.viewmodels.RestoreState
 import to.bitkit.viewmodels.WalletViewModel
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApp::class)
 class WalletViewModelTest : BaseUnitTest() {
 
     private lateinit var sut: WalletViewModel
@@ -37,6 +32,7 @@ class WalletViewModelTest : BaseUnitTest() {
     private val lightningRepo: LightningRepo = mock()
     private val settingsStore: SettingsStore = mock()
     private val backupRepo: BackupRepo = mock()
+    private val blocktankRepo: BlocktankRepo = mock()
     private val mockLightningState = MutableStateFlow(LightningState())
     private val mockWalletState = MutableStateFlow(WalletState())
 
@@ -51,6 +47,7 @@ class WalletViewModelTest : BaseUnitTest() {
             lightningRepo = lightningRepo,
             settingsStore = settingsStore,
             backupRepo = backupRepo,
+            blocktankRepo = blocktankRepo,
         )
     }
 
@@ -65,6 +62,15 @@ class WalletViewModelTest : BaseUnitTest() {
         sut.refreshState()
 
         verify(walletRepo).syncNodeAndWallet()
+    }
+
+    @Test
+    fun `refreshReceiveState should refresh receive state`() = test {
+        sut.refreshReceiveState()
+
+        verify(lightningRepo).updateGeoBlockState()
+        verify(walletRepo).refreshBip21()
+        verify(blocktankRepo).refreshInfo()
     }
 
     @Test


### PR DESCRIPTION
This PR fixes all known issues related to geo blocking when node has external (non-LSP) peer connection.

### Description
Changes:
- fix(wallet): hide transfer to spending when geoblocked
- refactor: replace hasChannelsReady with canReceive
- fix(receive): block LN receive when when geoblocked if having no lsp channels ready
- fix(receive): enable LN receive and QR only when having channels ready
- fix(receive): refresh geoblock state on each receive sheet open
- fix(receive): enable LN toggle when having external node even if geoblocked

### Preview

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/77b46365-fc51-49ef-8e44-75fb7438722a"> | <video src="https://github.com/user-attachments/assets/dfa9aec8-3931-45f7-b5eb-3310e894dcea"> |

### QA Notes

**Test:**
1. Use VPN to set location to a geoblocked region (or force return true in `CoreService.isGeoBlocked()`)
2. Use [bitkit-docker: External Node manual setup](https://github.com/ovitrif/bitkit-docker?tab=readme-ov-file#external-node-manual-setup) guide to setup channel to external node
3. Go to Receive > **expect receive on LN switch ON & unified QR**
4. Go back, tap Spending > Transfer to savings > complete flow
5. Go to Receive > **expect receive on LN switch OFF & onchain QR**
6. Tap 'Receive on Spending' switch > expect to see the geoblock screen in the receive sheet