### PR TITLE
fix(wallet): fix savings & spending screens ui logic

### DIFF
--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -537,7 +537,7 @@ private fun RootNavHost(
                     onAdvanced = { navController.navigate(Routes.FundingAdvanced) },
                     onBackClick = { navController.popBackStack() },
                     onCloseClick = { navController.navigateToHome() },
-                    isGeoBlocked = isGeoBlocked
+                    isGeoBlocked = isGeoBlocked,
                 )
             }
             composableWithDefaultTransitions<Routes.FundingAdvanced> {

--- a/app/src/main/java/to/bitkit/ui/components/TabBar.kt
+++ b/app/src/main/java/to/bitkit/ui/components/TabBar.kt
@@ -3,6 +3,7 @@ package to.bitkit.ui.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -51,7 +52,7 @@ private val buttonRightShape = RoundedCornerShape(topEndPercent = 50, bottomEndP
 
 @OptIn(ExperimentalHazeMaterialsApi::class)
 @Composable
-fun TabBar(
+fun BoxScope.TabBar(
     modifier: Modifier = Modifier,
     hazeState: HazeState = rememberHazeState(),
     onSendClick: () -> Unit = {},
@@ -61,6 +62,7 @@ fun TabBar(
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
+            .align(Alignment.BottomCenter)
             .fillMaxWidth()
             .background(
                 Brush.verticalGradient(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeNav.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeNav.kt
@@ -125,7 +125,12 @@ private fun NavContent(
             exitTransition = { Transitions.slideOutHorizontally },
         ) {
             val hasSeenSpendingIntro by settingsViewModel.hasSeenSpendingIntro.collectAsStateWithLifecycle()
+            val isGeoBlocked by appViewModel.isGeoBlocked.collectAsStateWithLifecycle()
+            val onchainActivities by activityListViewModel.onchainActivities.collectAsStateWithLifecycle()
+
             SavingsWalletScreen(
+                isGeoBlocked = isGeoBlocked,
+                onchainActivities = onchainActivities.orEmpty(),
                 onAllActivityButtonClick = { walletNavController.navigate(HomeRoutes.AllActivity) },
                 onActivityItemClick = { rootNavController.navigateToActivityItem(it) },
                 onEmptyActivityRowClick = { appViewModel.showSheet(Sheet.Receive) },

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeNav.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeNav.kt
@@ -79,7 +79,6 @@ fun HomeNav(
             onSendClick = { appViewModel.showSheet(Sheet.Send()) },
             onReceiveClick = { appViewModel.showSheet(Sheet.Receive) },
             onScanClick = { rootNavController.navigateToScanner() },
-            modifier = Modifier.align(Alignment.BottomCenter)
         )
 
         DrawerMenu(
@@ -149,8 +148,10 @@ private fun NavContent(
             exitTransition = { Transitions.slideOutHorizontally },
         ) {
             val hasSeenSavingsIntro by settingsViewModel.hasSeenSavingsIntro.collectAsStateWithLifecycle()
+            val lightningActivities by activityListViewModel.lightningActivities.collectAsStateWithLifecycle()
             SpendingWalletScreen(
                 uiState = mainUiState,
+                lightningActivities = lightningActivities.orEmpty(),
                 onAllActivityButtonClick = { walletNavController.navigate(HomeRoutes.AllActivity) },
                 onActivityItemClick = { rootNavController.navigateToActivityItem(it) },
                 onEmptyActivityRowClick = { appViewModel.showSheet(Sheet.Receive) },

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -693,7 +693,7 @@ private fun Preview() {
                     totalSats = 200_000u,
                 ),
             )
-            TabBar(modifier = Modifier.align(Alignment.BottomCenter))
+            TabBar()
         }
     }
 }
@@ -712,13 +712,9 @@ private fun PreviewEmpty() {
                 walletNavController = rememberNavController(),
                 drawerState = rememberDrawerState(initialValue = DrawerValue.Closed),
                 latestActivities = previewActivityItems.take(3),
-                balances = BalanceState(
-                    totalOnchainSats = 165_000u,
-                    totalLightningSats = 45_000u,
-                    totalSats = 200_000u,
-                )
+                balances = BalanceState(totalSats = 0u)
             )
-            TabBar(modifier = Modifier.align(Alignment.BottomCenter))
+            TabBar()
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
@@ -32,6 +32,7 @@ import to.bitkit.ui.LocalBalances
 import to.bitkit.ui.components.BalanceHeaderView
 import to.bitkit.ui.components.EmptyStateView
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.TabBar
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.ScreenColumn
 import to.bitkit.ui.screens.wallets.activity.components.ActivityListGrouped
@@ -134,16 +135,19 @@ fun SavingsWalletScreen(
 @Composable
 private fun Preview() {
     AppThemeSurface {
-        SavingsWalletScreen(
-            isGeoBlocked = false,
-            onchainActivities = previewOnchainActivityItems(),
-            onAllActivityButtonClick = {},
-            onActivityItemClick = {},
-            onEmptyActivityRowClick = {},
-            onTransferToSpendingClick = {},
-            onBackClick = {},
-            balances = BalanceState(totalOnchainSats = 50_000u),
-        )
+        Box {
+            SavingsWalletScreen(
+                isGeoBlocked = false,
+                onchainActivities = previewOnchainActivityItems(),
+                onAllActivityButtonClick = {},
+                onActivityItemClick = {},
+                onEmptyActivityRowClick = {},
+                onTransferToSpendingClick = {},
+                onBackClick = {},
+                balances = BalanceState(totalOnchainSats = 50_000u),
+            )
+            TabBar()
+        }
     }
 }
 
@@ -151,16 +155,19 @@ private fun Preview() {
 @Composable
 private fun PreviewNoActivity() {
     AppThemeSurface {
-        SavingsWalletScreen(
-            isGeoBlocked = false,
-            onchainActivities = emptyList(),
-            onAllActivityButtonClick = {},
-            onActivityItemClick = {},
-            onEmptyActivityRowClick = {},
-            onTransferToSpendingClick = {},
-            onBackClick = {},
-            balances = BalanceState(totalOnchainSats = 50_000u),
-        )
+        Box {
+            SavingsWalletScreen(
+                isGeoBlocked = false,
+                onchainActivities = emptyList(),
+                onAllActivityButtonClick = {},
+                onActivityItemClick = {},
+                onEmptyActivityRowClick = {},
+                onTransferToSpendingClick = {},
+                onBackClick = {},
+                balances = BalanceState(totalOnchainSats = 50_000u),
+            )
+            TabBar()
+        }
     }
 }
 
@@ -168,16 +175,19 @@ private fun PreviewNoActivity() {
 @Composable
 private fun PreviewGeoBlocked() {
     AppThemeSurface {
-        SavingsWalletScreen(
-            isGeoBlocked = true,
-            onchainActivities = previewOnchainActivityItems(),
-            onAllActivityButtonClick = {},
-            onActivityItemClick = {},
-            onEmptyActivityRowClick = {},
-            onTransferToSpendingClick = {},
-            onBackClick = {},
-            balances = BalanceState(totalOnchainSats = 50_000u),
-        )
+        Box {
+            SavingsWalletScreen(
+                isGeoBlocked = true,
+                onchainActivities = previewOnchainActivityItems(),
+                onAllActivityButtonClick = {},
+                onActivityItemClick = {},
+                onEmptyActivityRowClick = {},
+                onTransferToSpendingClick = {},
+                onBackClick = {},
+                balances = BalanceState(totalOnchainSats = 50_000u),
+            )
+            TabBar()
+        }
     }
 }
 
@@ -185,14 +195,17 @@ private fun PreviewGeoBlocked() {
 @Composable
 private fun PreviewEmpty() {
     AppThemeSurface {
-        SavingsWalletScreen(
-            isGeoBlocked = false,
-            onchainActivities = emptyList(),
-            onAllActivityButtonClick = {},
-            onActivityItemClick = {},
-            onEmptyActivityRowClick = {},
-            onTransferToSpendingClick = {},
-            onBackClick = {},
-        )
+        Box {
+            SavingsWalletScreen(
+                isGeoBlocked = false,
+                onchainActivities = emptyList(),
+                onAllActivityButtonClick = {},
+                onActivityItemClick = {},
+                onEmptyActivityRowClick = {},
+                onTransferToSpendingClick = {},
+                onBackClick = {},
+            )
+            TabBar()
+        }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -59,7 +59,6 @@ fun SpendingWalletScreen(
     val canTransfer by remember(balances.totalLightningSats, uiState.channels.size) {
         val hasLnBalance = balances.totalLightningSats > 0uL
         val hasChannels = uiState.channels.isNotEmpty()
-
         mutableStateOf(hasLnBalance && hasChannels)
     }
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/utils/PreviewItems.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/utils/PreviewItems.kt
@@ -125,3 +125,4 @@ val previewActivityItems = buildList {
 }
 
 fun previewOnchainActivityItems() = previewActivityItems.filter { it is Activity.Onchain }
+fun previewLightningActivityItems() = previewActivityItems.filter { it is Activity.Lightning }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/utils/PreviewItems.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/utils/PreviewItems.kt
@@ -123,3 +123,5 @@ val previewActivityItems = buildList {
         )
     )
 }
+
+fun previewOnchainActivityItems() = previewActivityItems.filter { it is Activity.Onchain }


### PR DESCRIPTION
This PR fixes the logic to determine when to display the empty view on the savings & spending wallet screens so it doesn't show if there is existing activity, even if the respective balance is zero. It also hides the transfer-to-spending button if geo blocked.

### Description
Changes:
+ feat(spending): do not show empty view for 0 balance with existing activity
+ feat(savings): hide transfer to spending if geo blocked
+ feat(savings): do not show empty view for 0 balance with existing activity

### Preview
<img alt="Android Studio 2025-09-15 000361" src="https://github.com/user-attachments/assets/66066f28-14c2-4422-8496-0cc9740e6707" />

### QA Notes

Test:
- Regression test with fresh wallet that the empty views are shown as expected on savings and spendings screen, then check that they're hidden once there is balance and/or activity.