### PR TITLE
refactor: use url string for electrum server config

### DIFF
--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -28,7 +28,6 @@
     <ID>ComposableParamOrder:HomeScreen.kt$Content</ID>
     <ID>ComposableParamOrder:InfoScreenContent.kt$InfoScreenContent</ID>
     <ID>ComposableParamOrder:Money.kt$MoneyCaptionB</ID>
-    <ID>ComposableParamOrder:NumberPadTextField.kt$MoneyAmount</ID>
     <ID>ComposableParamOrder:OnboardingSlidesScreen.kt$OnboardingSlidesScreen</ID>
     <ID>ComposableParamOrder:OnboardingSlidesScreen.kt$OnboardingTab</ID>
     <ID>ComposableParamOrder:PriceCard.kt$PriceCard</ID>
@@ -168,13 +167,11 @@
     <ID>LongMethod:AppViewModel.kt$AppViewModel$private suspend fun proceedWithPayment()</ID>
     <ID>LongMethod:ContentView.kt$private fun NavGraphBuilder.widgets( navController: NavHostController, settingsViewModel: SettingsViewModel, currencyViewModel: CurrencyViewModel, )</ID>
     <ID>LongMethod:CoreService.kt$ActivityService$suspend fun generateRandomTestData(count: Int = 100)</ID>
-    <ID>LongMethod:LightningRepo.kt$LightningRepo$suspend fun start( walletIndex: Int = 0, timeout: Duration? = null, shouldRetry: Boolean = true, eventHandler: NodeEventHandler? = null, customServer: ElectrumServer? = null, customRgsServerUrl: String? = null, ): Result&lt;Unit&gt;</ID>
     <ID>LongMethod:LightningService.kt$LightningService$private fun logEvent(event: Event)</ID>
     <ID>LongMethod:MainActivity.kt$MainActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:WakeNodeWorker.kt$WakeNodeWorker$private suspend fun handleLdkEvent(event: Event)</ID>
     <ID>LongParameterList:ActivityRepo.kt$ActivityRepo$( filter: ActivityFilter? = null, txType: PaymentType? = null, tags: List&lt;String&gt;? = null, search: String? = null, minDate: ULong? = null, maxDate: ULong? = null, limit: UInt? = null, sortDirection: SortDirection? = null, )</ID>
     <ID>LongParameterList:ActivityRepo.kt$ActivityRepo$( id: String, paymentHash: String? = null, txId: String? = null, address: String, isReceive: Boolean, tags: List&lt;String&gt;, )</ID>
-    <ID>LongParameterList:AppViewModel.kt$AppViewModel$( @ApplicationContext private val context: Context, @BgDispatcher private val bgDispatcher: CoroutineDispatcher, private val keychain: Keychain, private val lightningRepo: LightningRepo, private val walletRepo: WalletRepo, private val coreService: CoreService, private val ldkNodeEventBus: LdkNodeEventBus, private val settingsStore: SettingsStore, private val currencyRepo: CurrencyRepo, private val activityRepo: ActivityRepo, private val blocktankRepo: BlocktankRepo, connectivityRepo: ConnectivityRepo, healthRepo: HealthRepo, )</ID>
     <ID>LongParameterList:BiometricPrompt.kt$( activity: Context, title: String, cancelButtonText: String, onAuthSucceed: () -&gt; Unit, onAuthFailed: (() -&gt; Unit), onAuthError: ((errorCode: Int, errString: CharSequence) -&gt; Unit), )</ID>
     <ID>LongParameterList:BiometricPrompt.kt$( activity: Context, title: String, cancelButtonText: String, onAuthSucceeded: () -&gt; Unit, onAuthFailed: (() -&gt; Unit), onAuthError: ((errorCode: Int, errString: CharSequence) -&gt; Unit), onUnsupported: () -&gt; Unit, )</ID>
     <ID>LongParameterList:CoreService.kt$ActivityService$( filter: ActivityFilter? = null, txType: PaymentType? = null, tags: List&lt;String&gt;? = null, search: String? = null, minDate: ULong? = null, maxDate: ULong? = null, limit: UInt? = null, sortDirection: SortDirection? = null, )</ID>
@@ -184,7 +181,6 @@
     <ID>LongParameterList:LightningConnectionsViewModel.kt$LightningConnectionsViewModel$( @ApplicationContext private val context: Context, @BgDispatcher private val bgDispatcher: CoroutineDispatcher, private val lightningRepo: LightningRepo, internal val blocktankRepo: BlocktankRepo, private val logsRepo: LogsRepo, private val addressChecker: AddressChecker, private val ldkNodeEventBus: LdkNodeEventBus, private val walletRepo: WalletRepo, )</ID>
     <ID>LongParameterList:LightningRepo.kt$LightningRepo$( @BgDispatcher private val bgDispatcher: CoroutineDispatcher, private val lightningService: LightningService, private val ldkNodeEventBus: LdkNodeEventBus, private val settingsStore: SettingsStore, private val coreService: CoreService, private val lspNotificationsService: LspNotificationsService, private val firebaseMessaging: FirebaseMessaging, private val keychain: Keychain, private val lnurlService: LnurlService, private val cacheStore: CacheStore, )</ID>
     <ID>LongParameterList:LightningRepo.kt$LightningRepo$( address: Address, sats: ULong, speed: TransactionSpeed? = null, utxosToSpend: List&lt;SpendableUtxo&gt;? = null, feeRates: FeeRates? = null, isTransfer: Boolean = false, channelId: String? = null, )</ID>
-    <ID>LongParameterList:LightningRepo.kt$LightningRepo$( walletIndex: Int = 0, timeout: Duration? = null, shouldRetry: Boolean = true, eventHandler: NodeEventHandler? = null, customServer: ElectrumServer? = null, customRgsServerUrl: String? = null, )</ID>
     <ID>LongParameterList:Notifications.kt$( title: String?, text: String?, extras: Bundle? = null, bigText: String? = null, id: Int = Random.nextInt(), context: Context, )</ID>
     <ID>LongParameterList:TransferViewModel.kt$TransferViewModel$( @ApplicationContext private val context: Context, private val lightningRepo: LightningRepo, private val blocktankRepo: BlocktankRepo, private val walletRepo: WalletRepo, private val currencyRepo: CurrencyRepo, private val settingsStore: SettingsStore, private val cacheStore: CacheStore, )</ID>
     <ID>LongParameterList:WalletRepo.kt$WalletRepo$( @BgDispatcher private val bgDispatcher: CoroutineDispatcher, private val db: AppDb, private val keychain: Keychain, private val coreService: CoreService, private val settingsStore: SettingsStore, private val addressChecker: AddressChecker, private val lightningRepo: LightningRepo, private val cacheStore: CacheStore, )</ID>
@@ -389,7 +385,6 @@
     <ID>MaxLineLength:BlocktankRegtestScreen.kt$"Initiating channel close with fundingTxId: $fundingTxId, vout: $vout, forceCloseAfter: $forceCloseAfter"</ID>
     <ID>MaxLineLength:BlocktankRepo.kt$BlocktankRepo$"Buying channel with lspBalanceSat: $receivingBalanceSats, channelExpiryWeeks: $channelExpiryWeeks, options: $options"</ID>
     <ID>MaxLineLength:ChannelOrdersScreen.kt$lnurl = "LNURL1DP68GURN8GHJ7CTSDYH8XARPVUHXYMR0VD4HGCTWDVH8GME0VFKX7CMTW3SKU6E0V9CXJTMKXGHKCTENVV6NVDP4XUEJ6ETRX33Z6DPEXU6Z6C34XQEZ6DT9XENX2WFNXQ6RXDTXGQAH4MLNURL1DP68GURN8GHJ7CTSDYH8XARPVUHXYMR0VD4HGCTWDVH8GME0VFKX7CMTW3SKU6E0V9CXJTMKXGHKCTENVV6NVDP4XUEJ6ETRX33Z6DPEXU6Z6C34XQEZ6DT9XENX2WFNXQ6RXDTXGQAH4M"</ID>
-    <ID>MaxLineLength:CoreService.kt$CoreService$// val blocktankPeers = getInfo(refresh = true)?.nodes?.map { LnPeer(nodeId = it.pubkey, address = "TO_DO") }.orEmpty()</ID>
     <ID>MaxLineLength:CryptoTest.kt$CryptoTest$val ciphertext = "l2fInfyw64gO12odo8iipISloQJ45Rc4WjFmpe95brdaAMDq+T/L9ZChcmMCXnR0J6BXd8sSIJe/0bmby8uSZZJuVCzwF76XHfY5oq0Y1/hKzyZTn8nG3dqfiLHnAPy1tZFQfm5ALgjwWnViYJLXoGFpXs7kLMA=".fromBase64()</ID>
     <ID>MaxLineLength:CryptoTest.kt$CryptoTest$val decryptedPayload = """{"source":"blocktank","type":"incomingHtlc","payload":{"secretMessage":"hello"},"createdAt":"2024-09-18T13:33:52.555Z"}"""</ID>
     <ID>MaxLineLength:HeadlineCard.kt$headline = "How Bitcoin changed El Salvador in more ways a big headline to test the text overflooooooow"</ID>
@@ -554,14 +549,6 @@
     <ID>PreviewPublic:EmptyWalletView.kt$EmptyStateViewPreview</ID>
     <ID>PreviewPublic:HighlightLabel.kt$FlexibleLogoPreview</ID>
     <ID>PreviewPublic:HighlightLabel.kt$LongTextLogoPreview</ID>
-    <ID>PreviewPublic:NumberPadTextField.kt$PreviewMoneyAmountBitcoinClassicEmpty</ID>
-    <ID>PreviewPublic:NumberPadTextField.kt$PreviewMoneyAmountBitcoinClassicWithValue</ID>
-    <ID>PreviewPublic:NumberPadTextField.kt$PreviewMoneyAmountBitcoinModernEmpty</ID>
-    <ID>PreviewPublic:NumberPadTextField.kt$PreviewMoneyAmountBitcoinModernWithValue</ID>
-    <ID>PreviewPublic:NumberPadTextField.kt$PreviewMoneyAmountBitcoinPartial</ID>
-    <ID>PreviewPublic:NumberPadTextField.kt$PreviewMoneyAmountFiatEmpty</ID>
-    <ID>PreviewPublic:NumberPadTextField.kt$PreviewMoneyAmountFiatPartial</ID>
-    <ID>PreviewPublic:NumberPadTextField.kt$PreviewMoneyAmountFiatWithValue</ID>
     <ID>PreviewPublic:RestoreWalletScreen.kt$RestoreWalletViewPreview</ID>
     <ID>PreviewPublic:SplashScreen.kt$SplashScreenPreview</ID>
     <ID>PrintStackTrace:ShareSheet.kt$e</ID>
@@ -577,7 +564,6 @@
     <ID>TooGenericExceptionCaught:ActivityRepo.kt$ActivityRepo$e: Exception</ID>
     <ID>TooGenericExceptionCaught:AddressChecker.kt$AddressChecker$e: Exception</ID>
     <ID>TooGenericExceptionCaught:AppViewModel.kt$AppViewModel$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:AppViewModel.kt$AppViewModel$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:ArticleModel.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:BackupNavSheetViewModel.kt$BackupNavSheetViewModel$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:BackupRepo.kt$BackupRepo$e: Throwable</ID>

--- a/app/src/main/java/to/bitkit/data/SettingsStore.kt
+++ b/app/src/main/java/to/bitkit/data/SettingsStore.kt
@@ -105,7 +105,7 @@ data class SettingsData(
     val balanceWarningTimes: Int = 0,
     val coinSelectAuto: Boolean = true,
     val coinSelectPreference: CoinSelectionPreference = CoinSelectionPreference.BranchAndBound,
-    val electrumServer: ElectrumServer = Env.defaultElectrumServer,
+    val electrumServer: String = Env.defaultElectrumServer,
     val rgsServerUrl: String? = Env.ldkRgsServerUrl,
 )
 

--- a/app/src/main/java/to/bitkit/data/SettingsStore.kt
+++ b/app/src/main/java/to/bitkit/data/SettingsStore.kt
@@ -11,7 +11,6 @@ import to.bitkit.data.serializers.SettingsSerializer
 import to.bitkit.env.Env
 import to.bitkit.models.BitcoinDisplayUnit
 import to.bitkit.models.CoinSelectionPreference
-import to.bitkit.models.ElectrumServer
 import to.bitkit.models.PrimaryDisplay
 import to.bitkit.models.Suggestion
 import to.bitkit.models.TransactionSpeed

--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -6,8 +6,6 @@ import org.lightningdevkit.ldknode.Network
 import to.bitkit.BuildConfig
 import to.bitkit.ext.ensureDir
 import to.bitkit.models.BlocktankNotificationType
-import to.bitkit.models.ElectrumProtocol
-import to.bitkit.models.ElectrumServer
 import to.bitkit.models.LnPeer
 import to.bitkit.utils.Logger
 import java.io.File

--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -191,6 +191,7 @@ internal object Env {
     const val BITKIT_GITHUB = "https://github.com/synonymdev"
     const val BITKIT_HELP_CENTER = "https://help.bitkit.to"
     const val TERMS_OF_USE_URL = "https://bitkit.to/terms-of-use"
+    const val PRIVACY_POLICY_URL = "https://bitkit.to/privacy-policy"
     const val STORING_BITCOINS_URL = "https://en.bitcoin.it/wiki/Storing_bitcoins"
     const val SUPPORT_EMAIL = "support@synonym.to"
 }

--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -151,33 +151,13 @@ internal object Env {
     }
 
     object ElectrumServers {
-        val BITCOIN = ElectrumServer(
-            host = "35.187.18.233",
-            tcp = 8911,
-            ssl = 8900,
-            protocol = ElectrumProtocol.SSL,
-        )
-        val TESTNET = ElectrumServer(
-            host = "electrum.blockstream.info",
-            tcp = 60001, // or 50001
-            ssl = 60002, // or 50002
-            protocol = ElectrumProtocol.SSL,
-        )
-        val REGTEST = ElectrumServer(
-            host = "34.65.252.32",
-            tcp = 18483,
-            ssl = 18484,
-            protocol = ElectrumProtocol.TCP,
-        )
-        val E2E = ElectrumServer(
-            host = "127.0.0.1",
-            tcp = 60001,
-            ssl = 60002,
-            protocol = ElectrumProtocol.TCP,
-        )
+        const val BITCOIN = "ssl://35.187.18.233:8900"
+        const val TESTNET = "ssl://electrum.blockstream.info:60002"
+        const val REGTEST = "tcp://34.65.252.32:18483"
+        const val E2E = "tcp://127.0.0.1:60001"
     }
 
-    val defaultElectrumServer: ElectrumServer
+    val defaultElectrumServer: String
         get() {
             if (isE2eTest) return ElectrumServers.E2E
             return when (network) {

--- a/app/src/main/java/to/bitkit/models/ElectrumServer.kt
+++ b/app/src/main/java/to/bitkit/models/ElectrumServer.kt
@@ -24,6 +24,8 @@ data class ElectrumServer(
     }
 
     companion object {
+        const val MAX_VALID_PORT = 65535
+
         fun parse(url: String): ElectrumServer {
             val url = url.trim()
             require(url.isNotBlank()) { "URL cannot be blank" }
@@ -45,7 +47,7 @@ data class ElectrumServer(
             require(host.isNotBlank()) { "Host cannot be blank" }
 
             val port = hostPort[1].trim().toIntOrNull()
-            require(port != null && port > 0 && port <= 65535) { "Invalid port: ${hostPort[1]}" }
+            require(port != null && port > 0 && port <= MAX_VALID_PORT) { "Invalid port: ${hostPort[1]}" }
 
             val defaultTcp = ElectrumProtocol.TCP.getDefaultPort()
             val defaultSsl = ElectrumProtocol.SSL.getDefaultPort()

--- a/app/src/main/java/to/bitkit/models/ElectrumServer.kt
+++ b/app/src/main/java/to/bitkit/models/ElectrumServer.kt
@@ -24,6 +24,40 @@ data class ElectrumServer(
     }
 
     companion object {
+        fun parse(url: String): ElectrumServer {
+            val url = url.trim()
+            require(url.isNotBlank()) { "URL cannot be blank" }
+
+            val parts = url.split("://", limit = 2)
+            require(parts.size == 2) { "Invalid URL format, expected 'scheme://host:port'" }
+
+            val scheme = parts[0].lowercase()
+            val protocol = when (scheme) {
+                "tcp" -> ElectrumProtocol.TCP
+                "ssl" -> ElectrumProtocol.SSL
+                else -> throw IllegalArgumentException("Invalid scheme: $scheme, expected 'tcp' or 'ssl'")
+            }
+
+            val hostPort = parts[1].split(":", limit = 2)
+            require(hostPort.size == 2) { "Invalid URL format, expected 'scheme://host:port'" }
+
+            val host = hostPort[0].trim()
+            require(host.isNotBlank()) { "Host cannot be blank" }
+
+            val port = hostPort[1].trim().toIntOrNull()
+            require(port != null && port > 0 && port <= 65535) { "Invalid port: ${hostPort[1]}" }
+
+            val defaultTcp = ElectrumProtocol.TCP.getDefaultPort()
+            val defaultSsl = ElectrumProtocol.SSL.getDefaultPort()
+
+            return ElectrumServer(
+                host = host,
+                tcp = if (protocol == ElectrumProtocol.TCP) port else defaultTcp,
+                ssl = if (protocol == ElectrumProtocol.SSL) port else defaultSsl,
+                protocol = protocol,
+            )
+        }
+
         fun fromUserInput(
             host: String,
             port: Int,

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -159,6 +159,7 @@ class LightningRepo @Inject constructor(
         }
     }
 
+    @Suppress("LongMethod", "LongParameterList")
     suspend fun start(
         walletIndex: Int = 0,
         timeout: Duration? = null,

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -40,7 +40,6 @@ import to.bitkit.di.BgDispatcher
 import to.bitkit.env.Env
 import to.bitkit.ext.getSatsPerVByteFor
 import to.bitkit.models.CoinSelectionPreference
-import to.bitkit.models.ElectrumServer
 import to.bitkit.models.LnPeer
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.TransactionSpeed
@@ -148,11 +147,11 @@ class LightningRepo @Inject constructor(
 
     private suspend fun setup(
         walletIndex: Int,
-        customServer: ElectrumServer? = null,
+        customServerUrl: String? = null,
         customRgsServerUrl: String? = null,
     ) = withContext(bgDispatcher) {
         return@withContext try {
-            lightningService.setup(walletIndex, customServer, customRgsServerUrl)
+            lightningService.setup(walletIndex, customServerUrl, customRgsServerUrl)
             Result.success(Unit)
         } catch (e: Throwable) {
             Logger.error("Node setup error", e, context = TAG)
@@ -165,7 +164,7 @@ class LightningRepo @Inject constructor(
         timeout: Duration? = null,
         shouldRetry: Boolean = true,
         eventHandler: NodeEventHandler? = null,
-        customServer: ElectrumServer? = null,
+        customServerUrl: String? = null,
         customRgsServerUrl: String? = null,
     ): Result<Unit> = withContext(bgDispatcher) {
         val initialLifecycleState = _lightningState.value.nodeLifecycleState
@@ -179,7 +178,7 @@ class LightningRepo @Inject constructor(
 
             // Setup if not already setup
             if (lightningService.node == null) {
-                val setupResult = setup(walletIndex, customServer, customRgsServerUrl)
+                val setupResult = setup(walletIndex, customServerUrl, customRgsServerUrl)
                 if (setupResult.isFailure) {
                     _lightningState.update {
                         it.copy(
@@ -232,7 +231,7 @@ class LightningRepo @Inject constructor(
                     timeout = timeout,
                     shouldRetry = false,
                     eventHandler = eventHandler,
-                    customServer = customServer,
+                    customServerUrl = customServerUrl,
                     customRgsServerUrl = customRgsServerUrl,
                 )
             } else {
@@ -312,8 +311,8 @@ class LightningRepo @Inject constructor(
         }
     }
 
-    suspend fun restartWithElectrumServer(newServer: ElectrumServer): Result<Unit> = withContext(bgDispatcher) {
-        Logger.info("Changing ldk-node electrum server to: $newServer")
+    suspend fun restartWithElectrumServer(newServerUrl: String): Result<Unit> = withContext(bgDispatcher) {
+        Logger.info("Changing ldk-node electrum server to: '$newServerUrl'")
 
         waitForNodeToStop().onFailure { return@withContext Result.failure(it) }
         stop().onFailure {
@@ -321,26 +320,26 @@ class LightningRepo @Inject constructor(
             return@withContext Result.failure(it)
         }
 
-        Logger.debug("Starting node with new electrum server: $newServer")
+        Logger.debug("Starting node with new electrum server: '$newServerUrl'")
 
         start(
             eventHandler = cachedEventHandler,
-            customServer = newServer,
+            customServerUrl = newServerUrl,
             shouldRetry = false,
         ).onFailure { startError ->
             Logger.warn("Failed ldk-node config change, attempting recovery…")
             restartWithPreviousConfig()
             return@withContext Result.failure(startError)
         }.onSuccess {
-            settingsStore.update { it.copy(electrumServer = newServer) }
+            settingsStore.update { it.copy(electrumServer = newServerUrl) }
 
-            Logger.info("Successfully changed electrum server connection")
+            Logger.info("Successfully changed electrum server")
             return@withContext Result.success(Unit)
         }
     }
 
     suspend fun restartWithRgsServer(newRgsUrl: String): Result<Unit> = withContext(bgDispatcher) {
-        Logger.info("Changing ldk-node RGS server to: $newRgsUrl")
+        Logger.info("Changing ldk-node RGS server to: '$newRgsUrl'")
 
         waitForNodeToStop().onFailure { return@withContext Result.failure(it) }
         stop().onFailure {
@@ -348,7 +347,7 @@ class LightningRepo @Inject constructor(
             return@withContext Result.failure(it)
         }
 
-        Logger.debug("Starting node with new RGS server: $newRgsUrl")
+        Logger.debug("Starting node with new RGS server: '$newRgsUrl'")
 
         start(
             eventHandler = cachedEventHandler,

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -44,7 +44,6 @@ import to.bitkit.env.Env
 import to.bitkit.ext.DatePattern
 import to.bitkit.ext.totalNextOutboundHtlcLimitSats
 import to.bitkit.ext.uByteList
-import to.bitkit.models.ElectrumServer
 import to.bitkit.models.LnPeer
 import to.bitkit.models.LnPeer.Companion.toLnPeer
 import to.bitkit.utils.LdkError
@@ -78,7 +77,7 @@ class LightningService @Inject constructor(
 
     suspend fun setup(
         walletIndex: Int,
-        customServer: ElectrumServer? = null,
+        customServerUrl: String? = null,
         customRgsServerUrl: String? = null,
     ) {
         val mnemonic = keychain.loadString(Keychain.Key.BIP39_MNEMONIC.name) ?: throw ServiceError.MnemonicNotFound
@@ -102,7 +101,7 @@ class LightningService @Inject constructor(
         val builder = Builder.fromConfig(config).apply {
             setFilesystemLogger(generateLogFilePath(), Env.ldkLogLevel)
 
-            configureChainSource(customServer)
+            configureChainSource(customServerUrl)
             configureGossipSource(customRgsServerUrl)
 
             setEntropyBip39Mnemonic(mnemonic, passphrase)
@@ -151,10 +150,9 @@ class LightningService @Inject constructor(
         }
     }
 
-    private suspend fun Builder.configureChainSource(customServer: ElectrumServer? = null) {
-        val electrumServer = customServer ?: settingsStore.data.first().electrumServer
-        val serverUrl = electrumServer.toString()
-        Logger.info("Using onchain source Electrum url: $serverUrl")
+    private suspend fun Builder.configureChainSource(customServerUrl: String? = null) {
+        val serverUrl = customServerUrl ?: settingsStore.data.first().electrumServer
+        Logger.info("Using onchain source Electrum Sever url: $serverUrl")
         setChainSourceElectrum(
             serverUrl = serverUrl,
             config = ElectrumSyncConfig(

--- a/app/src/main/java/to/bitkit/ui/components/Button.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Button.kt
@@ -6,13 +6,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Home
@@ -476,7 +473,6 @@ private fun TertiaryButtonPreview() {
                     },
                 )
             }
-
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/components/Button.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Button.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -51,7 +52,7 @@ enum class ButtonSize {
 
 @Composable
 fun PrimaryButton(
-    text: String,
+    text: String?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     icon: (@Composable () -> Unit)? = null,
@@ -61,11 +62,114 @@ fun PrimaryButton(
     fullWidth: Boolean = true,
     color: Color = Colors.White16,
 ) {
+    val contentPadding = PaddingValues(horizontal = size.horizontalPadding.takeIf { text != null } ?: 0.dp)
     Button(
         onClick = onClick,
         enabled = enabled && !isLoading,
         colors = AppButtonDefaults.primaryColors.copy(containerColor = color),
-        contentPadding = PaddingValues(horizontal = size.horizontalPadding),
+        contentPadding = contentPadding,
+        modifier = Modifier
+            .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
+            .requiredHeight(size.height)
+            .then(modifier)
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator(
+                color = Colors.White32,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(size.height / 2)
+            )
+        } else {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (icon != null) {
+                    Box(modifier = if (enabled) Modifier else Modifier.alpha(0.5f)) {
+                        icon()
+                    }
+                }
+                text?.let {
+                    Text(
+                        text = text,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SecondaryButton(
+    text: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+    isLoading: Boolean = false,
+    size: ButtonSize = ButtonSize.Large,
+    enabled: Boolean = true,
+    fullWidth: Boolean = true,
+) {
+    val contentPadding = PaddingValues(horizontal = size.horizontalPadding.takeIf { text != null } ?: 0.dp)
+    val border = BorderStroke(2.dp, if (enabled) Colors.White16 else Color.Transparent)
+    OutlinedButton(
+        onClick = onClick,
+        enabled = enabled && !isLoading,
+        colors = AppButtonDefaults.secondaryColors,
+        contentPadding = contentPadding,
+        border = border,
+        modifier = Modifier
+            .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
+            .requiredHeight(size.height)
+            .then(modifier)
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator(
+                color = Colors.White32,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(size.height / 2)
+            )
+        } else {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (icon != null) {
+                    Box(modifier = if (enabled) Modifier else Modifier.alpha(0.5f)) {
+                        icon()
+                    }
+                }
+                text?.let {
+                    Text(
+                        text = text,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun TertiaryButton(
+    text: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+    isLoading: Boolean = false,
+    size: ButtonSize = ButtonSize.Large,
+    enabled: Boolean = true,
+    fullWidth: Boolean = true,
+) {
+    val contentPadding = PaddingValues(horizontal = size.horizontalPadding.takeIf { text != null } ?: 0.dp)
+    TextButton(
+        onClick = onClick,
+        enabled = enabled && !isLoading,
+        colors = AppButtonDefaults.tertiaryColors,
+        contentPadding = contentPadding,
         modifier = Modifier
             .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
             .requiredHeight(size.height)
@@ -82,102 +186,14 @@ fun PrimaryButton(
                 Box(modifier = if (enabled) Modifier else Modifier.alpha(0.5f)) {
                     icon()
                 }
-                Spacer(modifier = Modifier.width(8.dp))
             }
-            Text(
-                text = text,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
-}
-
-@Composable
-fun SecondaryButton(
-    text: String?,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    icon: (@Composable () -> Unit)? = null,
-    isLoading: Boolean = false,
-    size: ButtonSize = ButtonSize.Large,
-    enabled: Boolean = true,
-    fullWidth: Boolean = true,
-) {
-    OutlinedButton(
-        onClick = onClick,
-        enabled = enabled && !isLoading,
-        colors = AppButtonDefaults.secondaryColors,
-        contentPadding = PaddingValues(horizontal = size.horizontalPadding),
-        border = BorderStroke(2.dp, if (enabled) Colors.White16 else Color.Transparent),
-        modifier = Modifier
-            .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
-            .height(size.height)
-            .then(modifier)
-    ) {
-        if (isLoading) {
-            CircularProgressIndicator(
-                color = Colors.White32,
-                strokeWidth = 2.dp,
-                modifier = Modifier.size(size.height / 2)
-            )
-        } else {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                if (icon != null) {
-                    icon()
-                }
-                text?.let {
-                    Text(
-                        text = text,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
+            text?.let {
+                Text(
+                    text = text,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
-        }
-    }
-}
-
-@Composable
-fun TertiaryButton(
-    text: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    icon: (@Composable () -> Unit)? = null,
-    isLoading: Boolean = false,
-    size: ButtonSize = ButtonSize.Large,
-    enabled: Boolean = true,
-    fullWidth: Boolean = true,
-) {
-    TextButton(
-        onClick = onClick,
-        enabled = enabled && !isLoading,
-        colors = AppButtonDefaults.tertiaryColors,
-        contentPadding = PaddingValues(horizontal = size.horizontalPadding),
-        modifier = Modifier
-            .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
-            .height(size.height)
-            .then(modifier)
-    ) {
-        if (isLoading) {
-            CircularProgressIndicator(
-                color = Colors.White32,
-                strokeWidth = 2.dp,
-                modifier = Modifier.size(size.height / 2)
-            )
-        } else {
-            if (icon != null) {
-                icon()
-                Spacer(modifier = Modifier.width(8.dp))
-            }
-            Text(
-                text = text,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
         }
     }
 }
@@ -246,6 +262,39 @@ private fun PrimaryButtonPreview() {
                 onClick = {},
                 enabled = false,
             )
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                PrimaryButton(
+                    text = null,
+                    onClick = {},
+                    fullWidth = false,
+                    size = ButtonSize.Large,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Favorite,
+                            contentDescription = "",
+                            modifier = Modifier.size(16.dp)
+                        )
+                    },
+                )
+                PrimaryButton(
+                    text = null,
+                    onClick = {},
+                    fullWidth = false,
+                    size = ButtonSize.Small,
+                    enabled = false,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Home,
+                            contentDescription = "",
+                            modifier = Modifier.size(16.dp)
+                        )
+                    },
+                )
+            }
         }
     }
 }
@@ -261,18 +310,6 @@ private fun SecondaryButtonPreview() {
             SecondaryButton(
                 text = "Secondary",
                 onClick = {},
-            )
-            SecondaryButton(
-                text = null,
-                onClick = {},
-                fullWidth = false,
-                icon = {
-                    Icon(
-                        imageVector = Icons.Filled.Favorite,
-                        contentDescription = "",
-                        modifier = Modifier.size(16.dp)
-                    )
-                },
             )
             SecondaryButton(
                 text = "Secondary With Icon",
@@ -294,6 +331,13 @@ private fun SecondaryButtonPreview() {
                 text = "Secondary Disabled",
                 onClick = {},
                 enabled = false,
+                icon = {
+                    Icon(
+                        imageVector = Icons.Filled.Favorite,
+                        contentDescription = "",
+                        modifier = Modifier.size(16.dp)
+                    )
+                },
             )
             SecondaryButton(
                 text = "Secondary Small",
@@ -312,6 +356,39 @@ private fun SecondaryButtonPreview() {
                 onClick = {},
                 enabled = false,
             )
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                SecondaryButton(
+                    text = null,
+                    onClick = {},
+                    fullWidth = false,
+                    size = ButtonSize.Large,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Favorite,
+                            contentDescription = "",
+                            modifier = Modifier.size(16.dp)
+                        )
+                    },
+                )
+                SecondaryButton(
+                    text = null,
+                    onClick = {},
+                    fullWidth = false,
+                    size = ButtonSize.Small,
+                    enabled = false,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Home,
+                            contentDescription = "",
+                            modifier = Modifier.size(16.dp)
+                        )
+                    },
+                )
+            }
         }
     }
 }
@@ -366,6 +443,40 @@ private fun TertiaryButtonPreview() {
                 enabled = false,
                 onClick = {}
             )
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                TertiaryButton(
+                    text = null,
+                    onClick = {},
+                    fullWidth = false,
+                    size = ButtonSize.Large,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Favorite,
+                            contentDescription = "",
+                            modifier = Modifier.size(16.dp)
+                        )
+                    },
+                )
+                TertiaryButton(
+                    text = null,
+                    onClick = {},
+                    fullWidth = false,
+                    size = ButtonSize.Small,
+                    enabled = false,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Home,
+                            contentDescription = "",
+                            modifier = Modifier.size(16.dp)
+                        )
+                    },
+                )
+            }
+
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/components/TextInput.kt
+++ b/app/src/main/java/to/bitkit/ui/components/TextInput.kt
@@ -10,7 +10,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -48,8 +50,8 @@ fun TextInput(
         },
         isError = isError,
         textStyle = textStyle,
-        value = value,
-        onValueChange = onValueChange,
+        value = TextFieldValue(value, TextRange(value.length)),
+        onValueChange = { textFieldValue -> onValueChange(textFieldValue.text) },
         maxLines = maxLines,
         minLines = minLines,
         singleLine = singleLine,

--- a/app/src/main/java/to/bitkit/ui/onboarding/TermsOfUseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/TermsOfUseScreen.kt
@@ -111,7 +111,7 @@ fun TermsOfUseScreen(
                 CheckButton(
                     title = stringResource(R.string.onboarding__pp_checkbox),
                     htmlText = stringResource(R.string.onboarding__pp_checkbox_value)
-                        .withAccentLink("https://bitkit.to/privacy-policy"),
+                        .withAccentLink(Env.PRIVACY_POLICY_URL),
                     isChecked = privacyAccepted,
                     onCheckedChange = { privacyAccepted = it },
                     modifier = Modifier

--- a/app/src/main/java/to/bitkit/ui/settings/advanced/ElectrumConfigScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/advanced/ElectrumConfigScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -153,6 +155,11 @@ private fun Content(
                 value = uiState.host,
                 onValueChange = onChangeHost,
                 placeholder = "127.0.0.1",
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    capitalization = KeyboardCapitalization.None,
+                    imeAction = ImeAction.Next,
+                ),
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag("HostInput")
@@ -166,8 +173,11 @@ private fun Content(
             TextInput(
                 value = uiState.port,
                 onValueChange = onChangePort,
-                placeholder = "50001",
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                placeholder = "60001",
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done,
+                ),
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag("PortInput")

--- a/app/src/main/java/to/bitkit/ui/settings/advanced/ElectrumConfigViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/advanced/ElectrumConfigViewModel.kt
@@ -58,7 +58,8 @@ class ElectrumConfigViewModel @Inject constructor(
 
         viewModelScope.launch(bgDispatcher) {
             settingsStore.data.map { it.electrumServer }.distinctUntilChanged()
-                .collect { electrumServer ->
+                .collect { electrumServerUrl ->
+                    val electrumServer = ElectrumServer.parse(electrumServerUrl)
                     val connectedPeer = ElectrumServerPeer(
                         host = electrumServer.host,
                         port = electrumServer.getPort().toString(),
@@ -110,7 +111,7 @@ class ElectrumConfigViewModel @Inject constructor(
     }
 
     fun resetToDefault() {
-        val defaultServer = Env.defaultElectrumServer
+        val defaultServer = ElectrumServer.parse(Env.defaultElectrumServer)
         _uiState.update {
             it.copy(
                 host = defaultServer.host,
@@ -139,8 +140,9 @@ class ElectrumConfigViewModel @Inject constructor(
                     port = port,
                     protocol = protocol,
                 )
+                val serverUrl = electrumServer.toString()
 
-                lightningRepo.restartWithElectrumServer(electrumServer)
+                lightningRepo.restartWithElectrumServer(serverUrl)
                     .onSuccess {
                         _uiState.update {
                             it.copy(

--- a/app/src/main/java/to/bitkit/ui/settings/advanced/ElectrumConfigViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/advanced/ElectrumConfigViewModel.kt
@@ -113,12 +113,12 @@ class ElectrumConfigViewModel @Inject constructor(
     fun resetToDefault() {
         val defaultServer = ElectrumServer.parse(Env.defaultElectrumServer)
         _uiState.update {
-            it.copy(
+            val newState = it.copy(
                 host = defaultServer.host,
                 port = defaultServer.getPort().toString(),
                 protocol = defaultServer.protocol,
-                hasEdited = false,
             )
+            newState.copy(hasEdited = computeHasEdited(newState))
         }
     }
 

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -436,16 +436,16 @@ class LightningRepoTest : BaseUnitTest() {
     @Test
     fun `restartWithElectrumServer should setup with new server`() = test {
         startNodeForTesting()
-        val customServer = mock<ElectrumServer>()
+        val customServerUrl = "ssl://test.example.com:50002"
         whenever(lightningService.node).thenReturn(null)
         whenever(lightningService.stop()).thenReturn(Unit)
 
-        val result = sut.restartWithElectrumServer(customServer)
+        val result = sut.restartWithElectrumServer(customServerUrl)
 
         assertTrue(result.isSuccess)
         val inOrder = inOrder(lightningService)
         inOrder.verify(lightningService).stop()
-        inOrder.verify(lightningService).setup(any(), eq(customServer), anyOrNull())
+        inOrder.verify(lightningService).setup(any(), eq(customServerUrl), anyOrNull())
         inOrder.verify(lightningService).start(anyOrNull(), any())
         assertEquals(NodeLifecycleState.Running, sut.lightningState.value.nodeLifecycleState)
     }
@@ -453,10 +453,10 @@ class LightningRepoTest : BaseUnitTest() {
     @Test
     fun `restartWithElectrumServer should handle stop failure`() = test {
         startNodeForTesting()
-        val customServer = mock<ElectrumServer>()
+        val customServerUrl = "ssl://test.example.com:50002"
         whenever(lightningService.stop()).thenThrow(RuntimeException("Stop failed"))
 
-        val result = sut.restartWithElectrumServer(customServer)
+        val result = sut.restartWithElectrumServer(customServerUrl)
 
         assertTrue(result.isFailure)
     }

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -31,7 +31,6 @@ import to.bitkit.data.keychain.Keychain
 import to.bitkit.ext.createChannelDetails
 import to.bitkit.models.BalanceState
 import to.bitkit.models.CoinSelectionPreference
-import to.bitkit.models.ElectrumServer
 import to.bitkit.models.LnPeer
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.TransactionSpeed


### PR DESCRIPTION
This PR refactors the electrum server config to use a plain url string as starting point instead of a complex data model.

### Description
**Changes:**
- refactor: normalize button types params and logic
- refactor: use url string for electrum server config
- refactor: extract const for PRIVACY_POLICY_URL
- fix: check to enable connect button after reset to default
- fix: start cursor at end of text in filled input fields

### Preview
https://github.com/user-attachments/assets/5ff1cfc6-35e1-483e-b06b-55227318f600

### QA Notes
**Test:**
2. uninstall old app
3. restore existing wallet → expect success 
4. settings → advanced → electrum
5. enter details for local electrum server (use [bitkit-docker](https://github.com/ovitrif/bitkit-docker?tab=readme-ov-file#electrum-server))
    - once done on host input tap IME button → expect cursor to move to 'port' input at the end of the text
6. tap 'Connect to Host’ → expect success
7. tap 'Reset to Default' → expect "Connect to Host" to be enabled
8. tap 'Reset to Default' -> expect success
