### PR TITLE
fix: High Balance warning time out calculation for fresh wallets

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -155,7 +155,11 @@ class HomeViewModel @Inject constructor(
             val totalOnChainSats = walletRepo.balanceState.value.totalSats
             val balanceUsd = satsToUsd(totalOnChainSats) ?: return@launch
             val thresholdReached = balanceUsd > BigDecimal(BALANCE_THRESHOLD_USD)
-            val isTimeOutOver = settings.lastTimeAskedBalanceWarningMillis - ASK_INTERVAL_MILLIS > ASK_INTERVAL_MILLIS
+            val isTimeOutOver = if (settings.lastTimeAskedBalanceWarningMillis == 0L) {
+                true
+            } else {
+                settings.lastTimeAskedBalanceWarningMillis - ASK_INTERVAL_MILLIS > ASK_INTERVAL_MILLIS
+            }
             val belowMaxWarnings = settings.balanceWarningTimes < MAX_WARNINGS
 
             if (thresholdReached && isTimeOutOver && belowMaxWarnings && !_uiState.value.highBalanceSheetVisible) {

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -49,7 +49,6 @@ class HomeViewModel @Inject constructor(
         setupStateObservation()
         setupArticleRotation()
         setupFactRotation()
-        checkHighBalance()
     }
 
     private fun setupStateObservation() {
@@ -91,6 +90,7 @@ class HomeViewModel @Inject constructor(
                     showEmptyState = settings.showEmptyBalanceView && balanceState.totalSats == 0uL
                 )
             }.collect { newState ->
+                checkHighBalance()
                 _uiState.update { newState }
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -147,6 +147,8 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun checkHighBalance() {
+        if (_uiState.value.highBalanceSheetVisible) return
+
         viewModelScope.launch {
             delay(CHECK_DELAY_MILLISECONDS)
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description
 isTimeOutOver didn't pass on fresh wallet because the value is initialized as zero
<!-- Extended summary of the changes, can be a list. -->

### Preview

https://github.com/user-attachments/assets/1cfb2604-5448-436d-acc4-711d127c99e7

<!-- Insert relevant screenshot / recording -->

### QA Notes
- New wallet -> receive $500 USD > should display warning
<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
