### PR TITLE
E2E retry mechanism

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -150,6 +150,7 @@ jobs:
           script: cd bitkit-e2e-tests && ./ci_run_android.sh --mochaOpts.grep "${{ matrix.shard.grep }}"
         env:
           RECORD_VIDEO: true
+          ATTEMPT: 1
 
       - name: Run E2E Tests 2 (${{ matrix.shard.name }})
         continue-on-error: true
@@ -166,6 +167,7 @@ jobs:
           script: cd bitkit-e2e-tests && ./ci_run_android.sh --mochaOpts.grep "${{ matrix.shard.grep }}"
         env:
           RECORD_VIDEO: true
+          ATTEMPT: 2
 
       - name: Run E2E Tests 3 (${{ matrix.shard.name }})
         id: test3
@@ -181,6 +183,7 @@ jobs:
           script: cd bitkit-e2e-tests && ./ci_run_android.sh --mochaOpts.grep "${{ matrix.shard.grep }}"
         env:
           RECORD_VIDEO: true
+          ATTEMPT: 3
 
       - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

 - Employs E2E logic from https://github.com/synonymdev/bitkit-e2e-tests/pull/25.
 - Each shard in `e2e.yml` will run up to 3 attempts.
 - Only tests that failed in the previous attempt are re-executed.
 - In case of failures the artifacts zip will include recordings, screenshots and logcats for each attempt separately and organized per attempt under subfolders `attempt-N` (e.g. `attempt-1`, `attempt-2`,…) so multiple runs of the same failing test can be compared.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
