### PR TITLE
Remove max fee warning from Boost initialization

### DIFF
--- a/app/src/main/java/to/bitkit/ui/sheets/BoostTransactionViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/BoostTransactionViewModel.kt
@@ -120,10 +120,6 @@ class BoostTransactionViewModel @Inject constructor(
                             totalFee = totalFeeSatsRecommended,
                             feeRate = feeRateRecommended
                         )
-
-                        if (_uiState.value.totalFeeSats >= maxTotalFee) {
-                            setBoostTransactionEffect(BoostTransactionEffects.OnMaxFee)
-                        }
                     }
 
                     else -> {


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->
Closes #403 
### Description

This PR removes the max amount check from Boost initialization, because it is confusing to UX

### Preview

[Screen_recording_20251009_142158.webm](https://github.com/user-attachments/assets/8fc1a3f6-bfdd-4018-91f5-559da2109f94)


### QA Notes

- [x] Send a small amount (like 1000) with a big fee -> try to RBF -> Should not display the max amount error at initialization

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
