### PR TITLE
Determine e2e branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - name: Show selected E2E branch
         env:
-          E2E_BRANCH: ${{ needs.determine-e2e-branch.outputs.branch }}
+          E2E_BRANCH: ${{ needs.e2e-branch.outputs.branch }}
         run: echo $E2E_BRANCH
 
       - name: Clone E2E tests
@@ -95,7 +95,7 @@ jobs:
         with:
           repository: synonymdev/bitkit-e2e-tests
           path: bitkit-e2e-tests
-          ref: ${{ needs.determine-e2e-branch.outputs.branch }}
+          ref: ${{ needs.e2e-branch.outputs.branch }}
 
       - name: Enable KVM
         run: |


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Updates `e2e.yml` workflow to use reusable workflow [determine-e2e-branch.yml](https://github.com/synonymdev/bitkit-e2e-tests/blob/main/.github/workflows/determine-e2e-branch.yml) in order to:
 - Automatically use a matching branch in bitkit-e2e-tests if it exists. (e.g. `bitkit-android/feat/next-big-thingy` will try to use `bitkit-e2e-tests/feat/next-big-thingy`)
 - Fall back to `main` when no matching branch is found.
 - Allow manual override via `workflow_dispatch` input (`main`, `default-feature-branch`, or custom branch name).

This setup allows feature branches that require E2E test updates to run against their matching test branches, providing immediate feedback from the E2E suite directly in the PR.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

Tested via workflow_dispatch:
 - corresponding branch not exists -> fallback to main 🟢 
 - corresponding branch exists -> is used 🟢 
 - override using e2e main despite corresponding branch exists -> override successful 🟢 
 - override using e2e non-existing branch -> test fail as no e2e branch could be used 🟢 
