### PR TITLE
Skip e2e-branch on draft

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,6 +61,7 @@ jobs:
           path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
 
   e2e-branch:
+    if: github.event.pull_request.draft == false
     uses: synonymdev/bitkit-e2e-tests/.github/workflows/determine-e2e-branch.yml@main
     with:
       app_branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Small adjustment. The `e2e-branch` should also be skipped on draft PR as other e2e build jobs.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
