### PR TITLE
Disable edit mode after editing widget

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -257,6 +257,7 @@ fun HomeScreen(
         },
         onClickEditWidgetList = homeViewModel::onClickEditWidgetList,
         onClickEditWidget = { widgetType ->
+            homeViewModel.disableEditMode()
             when (widgetType) {
                 WidgetType.BLOCK -> rootNavController.navigate(Routes.BlocksPreview)
                 WidgetType.CALCULATOR -> rootNavController.navigate(Routes.CalculatorPreview)

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -208,7 +208,7 @@ class HomeViewModel @Inject constructor(
         _uiState.update { it.copy(isEditingWidgets = true) }
     }
 
-    private fun disableEditMode() {
+    fun disableEditMode() {
         _uiState.update { it.copy(isEditingWidgets = false) }
     }
 


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Small adjustment/fix to have consistent behavior in bitkit-android and bitkit-ios. Also bitkit RN behaves currently the same.
After editing a widget the home screen now exits edit mode (previously stayed enabled on Android).

### Preview

Before:

[before.webm](https://github.com/user-attachments/assets/8262b22c-ab8f-4f1c-80f7-9cadb657a8e7)

After:

[after.webm](https://github.com/user-attachments/assets/ab35f2ef-26a0-4d23-96d2-3b94e79c50bf)


### QA Notes

https://github.com/synonymdev/bitkit-e2e-tests/pull/43