### PR TITLE
e2e-status for branch protection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -205,3 +205,17 @@ jobs:
       - name: Dump docker logs on failure (${{ matrix.shard.name }})
         if: failure()
         uses: jwalton/gh-docker-logs@v2
+
+  e2e-status:
+    name: e2e-status
+    runs-on: ubuntu-latest
+    needs: [e2e-tests]
+    if: always()
+    steps:
+      - name: Verify all E2E shards succeeded
+        run: |
+          if [ "${{ needs.e2e-tests.result }}" != "success" ]; then
+            echo "❌ Some E2E shards failed."
+            exit 1
+          fi
+          echo "✅ All E2E shards passed!"


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Adds an `e2e-status` job that aggregates the results of all E2E test shards.
This job provides a single unified status check (`e2e-status`) that can be used in branch protection rules to ensure all E2E shards pass before merging.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

<!-- Add testing instructions for the PR reviewer to validate the changes. -->
<!-- List the tests you ran, including regression tests if applicable. -->
