### PR TITLE
Show Dev Settings by default in debug builds

### DIFF
--- a/app/src/main/java/to/bitkit/data/SettingsStore.kt
+++ b/app/src/main/java/to/bitkit/data/SettingsStore.kt
@@ -6,7 +6,6 @@ import androidx.datastore.dataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.Serializable
-import org.lightningdevkit.ldknode.Network
 import to.bitkit.data.serializers.SettingsSerializer
 import to.bitkit.env.Env
 import to.bitkit.models.BitcoinDisplayUnit
@@ -89,8 +88,7 @@ data class SettingsData(
     val isBiometricEnabled: Boolean = false,
     val isPinOnIdleEnabled: Boolean = false,
     val isPinForPaymentsEnabled: Boolean = false,
-    @Suppress("KotlinConstantConditions", "SimplifyBooleanWithConstants")
-    val isDevModeEnabled: Boolean = !Env.isE2eTest && Env.network != Network.BITCOIN,
+    val isDevModeEnabled: Boolean = Env.isDebug,
     val showWidgets: Boolean = true,
     val showWidgetTitles: Boolean = false,
     val lastUsedTags: List<String> = emptyList(),


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

In order to be consistent with iOS [[see](https://github.com/synonymdev/bitkit-ios/blob/master/Bitkit/Views/Settings/MainSettings.swift#L6)] and given the fact that both builds for e2e tests are done in debug configuration the PR sets Dev Settings as enabled in debug mode. E2E tests updated accordingly.

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

https://github.com/synonymdev/bitkit-e2e-tests/pull/51
