### PR TITLE
chore: Make claude review update a single comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -36,6 +36,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          additional_permissions: "actions:read"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -49,9 +51,7 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,16 +19,16 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write      # Allow creating branches/commits
+      pull-requests: write # Allow pushing to PR branches
+      issues: write        # Allow updating issue comments
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read        # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0  # Full history for git operations
 
       - name: Run Claude Code
         id: claude

--- a/README.md
+++ b/README.md
@@ -134,7 +134,45 @@ Increment `versionCode` and `versionName` in `app/build.gradle.kts`, then run:
 APK is generated in `app/build/outputs/apk/_flavor_/release`. (`_flavor_` can be any of 'dev', 'mainnet', 'tnet').
 Example for dev: `app/build/outputs/apk/dev/release`
 
+## Contributing
+
+### AI Code Review with Claude
+
+This repository has Claude Code integrated for on-demand AI assistance on issues and pull requests.
+
+#### How to Use
+
+Mention `@claude` in any PR comment, issue, or review to trigger Claude:
+
+| Command | Description |
+|---------|-------------|
+| `@claude review` | Request a code review of the PR |
+| `@claude /review` | Same as above (slash command) |
+| `@claude review focus on security` | Review with specific focus |
+| `@claude explain this change` | Ask questions about the code |
+| `@claude fix the null pointer issue` | Request Claude to implement a fix |
+| `@claude /help` | Show available commands |
+
+#### Notes
+
+- Claude follows the project guidelines defined in `CLAUDE.md`
+- **Automatic reviews** run on every PR open and push (updates same comment)
+- **On-demand assistance** via `@claude` mentions in comments/issues
+- Claude can read CI results to provide context-aware feedback
+- For implementation requests, Claude will create commits on your branch
+
+#### Example
+
+```
+@claude review
+
+Please focus on:
+- Kotlin idioms and best practices
+- Potential memory leaks
+- Thread safety in coroutines
+```
+
 ## License
 
-This project is licensed under the MIT License.  
+This project is licensed under the MIT License.
 See the [LICENSE](./LICENSE) file for more details.


### PR DESCRIPTION
### Description

- Enable `use_sticky_comment` in Claude review workflow to update the same comment instead of creating new ones on each push
- Update permissions from `pull-requests: read` to `write` for comment editing
- Update permissions from `issues: read` to `write` for sticky comment feature
- Remove manual `gh pr comment` instruction and tool from workflow (handled automatically by sticky comment)
- Add `additional_permissions: "actions:read"` input to let Claude read CI results
- Update `claude.yml` to allow Claude to create commits on implementation requests:
  - Change `contents`, `pull-requests`, `issues` permissions to `write`
  - Change `fetch-depth` to `0` for full git history
- Add "AI Code Review with Claude" documentation section to `README.md` with usage examples

### Preview

N/A - workflow and docs changes.

### QA Notes

- Verify the workflow action succeeds by confirming Claude still reviews.
- On next PR with multiple pushes, confirm Claude updates the existing review comment instead of adding new ones.
- Test `@claude` mention to verify it can create commits when requested.
- Check README renders correctly on GitHub with the new Contributing section.