### PR TITLE
chore: bump version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,8 +45,8 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 15
-        versionName = "0.0.15"
+        versionCode = 16
+        versionName = "0.0.16"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         vectorDrawables {
             useSupportLibrary = true


### PR DESCRIPTION
Build for internal release `v0.0.16` needed for the 1st mainnet testing session.