### PR TITLE
fix: add peer detail full address handling

### DIFF
--- a/app/src/main/java/to/bitkit/ext/PeerDetails.kt
+++ b/app/src/main/java/to/bitkit/ext/PeerDetails.kt
@@ -38,7 +38,16 @@ fun PeerDetails.Companion.from(nodeId: String, host: String, port: String) = Pee
 )
 
 fun ILspNode.toPeerDetails(): PeerDetails? {
-    val address = connectionStrings.firstOrNull() ?: return null
+    val connectionString = connectionStrings.firstOrNull() ?: return null
+
+    // Connection string can be either "host:port" or "nodeId@host:port"
+    // Extract just the "host:port" part
+    val address = if (connectionString.contains("@")) {
+        connectionString.substringAfter("@")
+    } else {
+        connectionString
+    }
+
     return PeerDetails(
         nodeId = pubkey,
         address = address,

--- a/app/src/test/java/to/bitkit/ext/PeerDetailsTest.kt
+++ b/app/src/test/java/to/bitkit/ext/PeerDetailsTest.kt
@@ -1,0 +1,276 @@
+package to.bitkit.ext
+
+import com.synonym.bitkitcore.ILspNode
+import org.junit.Test
+import org.lightningdevkit.ldknode.PeerDetails
+import to.bitkit.test.BaseUnitTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PeerDetailsTest : BaseUnitTest() {
+
+    @Test
+    fun `host extension returns host part of address`() {
+        val peer = PeerDetails(
+            nodeId = "node123",
+            address = "example.com:9735",
+            isConnected = false,
+            isPersisted = false,
+        )
+
+        assertEquals("example.com", peer.host)
+    }
+
+    @Test
+    fun `port extension returns port part of address`() {
+        val peer = PeerDetails(
+            nodeId = "node123",
+            address = "example.com:9735",
+            isConnected = false,
+            isPersisted = false,
+        )
+
+        assertEquals("9735", peer.port)
+    }
+
+    @Test
+    fun `uri extension returns full connection string`() {
+        val peer = PeerDetails(
+            nodeId = "node123",
+            address = "example.com:9735",
+            isConnected = false,
+            isPersisted = false,
+        )
+
+        assertEquals("node123@example.com:9735", peer.uri)
+    }
+
+    @Test
+    fun `parse correctly parses full connection string`() {
+        val uri = "028a8910b0048630d4eb17af25668cdd7ea6f2d8ae20956e7a06e2ae46ebcb69fc@34.65.86.104:9400"
+
+        val peer = PeerDetails.parse(uri)
+
+        assertEquals("028a8910b0048630d4eb17af25668cdd7ea6f2d8ae20956e7a06e2ae46ebcb69fc", peer.nodeId)
+        assertEquals("34.65.86.104:9400", peer.address)
+        assertFalse(peer.isConnected)
+        assertFalse(peer.isPersisted)
+    }
+
+    @Test
+    fun `parse throws on invalid uri without at symbol`() {
+        val invalidUri = "node123example.com:9735"
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            PeerDetails.parse(invalidUri)
+        }
+
+        assertTrue(exception.message!!.contains("Invalid uri format"))
+    }
+
+    @Test
+    fun `parse throws on invalid uri without port`() {
+        val invalidUri = "node123@example.com"
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            PeerDetails.parse(invalidUri)
+        }
+
+        assertTrue(exception.message!!.contains("Invalid uri format"))
+    }
+
+    @Test
+    fun `from creates PeerDetails with correct values`() {
+        val peer = PeerDetails.from(
+            nodeId = "node123",
+            host = "example.com",
+            port = "9735",
+        )
+
+        assertEquals("node123", peer.nodeId)
+        assertEquals("example.com:9735", peer.address)
+        assertFalse(peer.isConnected)
+        assertFalse(peer.isPersisted)
+    }
+
+    @Test
+    fun `toPeerDetails handles connection string with host and port only`() {
+        val lspNode = ILspNode(
+            alias = "LSP1",
+            pubkey = "node1pubkey",
+            connectionStrings = listOf("node1.example.com:9735"),
+            readonly = null,
+        )
+
+        val peer = lspNode.toPeerDetails()
+
+        assertNotNull(peer)
+        assertEquals("node1pubkey", peer.nodeId)
+        assertEquals("node1.example.com:9735", peer.address)
+        assertFalse(peer.isConnected)
+        assertFalse(peer.isPersisted)
+    }
+
+    @Test
+    fun `toPeerDetails handles connection string with full uri format`() {
+        val lspNode = ILspNode(
+            alias = "LSP1",
+            pubkey = "028a8910b0048630d4eb17af25668cdd7ea6f2d8ae20956e7a06e2ae46ebcb69fc",
+            connectionStrings = listOf(
+                "028a8910b0048630d4eb17af25668cdd7ea6f2d8ae20956e7a06e2ae46ebcb69fc@34.65.86.104:9400",
+            ),
+            readonly = null,
+        )
+
+        val peer = lspNode.toPeerDetails()
+
+        assertNotNull(peer)
+        assertEquals("028a8910b0048630d4eb17af25668cdd7ea6f2d8ae20956e7a06e2ae46ebcb69fc", peer.nodeId)
+        assertEquals("34.65.86.104:9400", peer.address)
+        assertFalse(peer.isConnected)
+        assertFalse(peer.isPersisted)
+    }
+
+    @Test
+    fun `toPeerDetails returns null when connectionStrings is empty`() {
+        val lspNode = ILspNode(
+            alias = "LSP1",
+            pubkey = "node1pubkey",
+            connectionStrings = emptyList(),
+            readonly = null,
+        )
+
+        val peer = lspNode.toPeerDetails()
+
+        assertNull(peer)
+    }
+
+    @Test
+    fun `toPeerDetails handles IP address in connection string`() {
+        val lspNode = ILspNode(
+            alias = "LSP1",
+            pubkey = "node1pubkey",
+            connectionStrings = listOf("127.0.0.1:9735"),
+            readonly = null,
+        )
+
+        val peer = lspNode.toPeerDetails()
+
+        assertNotNull(peer)
+        assertEquals("node1pubkey", peer.nodeId)
+        assertEquals("127.0.0.1:9735", peer.address)
+    }
+
+    @Test
+    fun `toPeerDetails handles IPv6 address in connection string`() {
+        val lspNode = ILspNode(
+            alias = "LSP1",
+            pubkey = "node1pubkey",
+            connectionStrings = listOf("[2001:db8::1]:9735"),
+            readonly = null,
+        )
+
+        val peer = lspNode.toPeerDetails()
+
+        assertNotNull(peer)
+        assertEquals("node1pubkey", peer.nodeId)
+        assertEquals("[2001:db8::1]:9735", peer.address)
+    }
+
+    @Test
+    fun `toPeerDetails takes first connection string when multiple provided`() {
+        val lspNode = ILspNode(
+            alias = "LSP1",
+            pubkey = "node1pubkey",
+            connectionStrings = listOf("primary.example.com:9735", "backup.example.com:9735"),
+            readonly = null,
+        )
+
+        val peer = lspNode.toPeerDetails()
+
+        assertNotNull(peer)
+        assertEquals("primary.example.com:9735", peer.address)
+    }
+
+    @Test
+    fun `toPeerDetailsList converts all valid nodes`() {
+        val lspNodes = listOf(
+            ILspNode(
+                alias = "LSP1",
+                pubkey = "node1pubkey",
+                connectionStrings = listOf("node1.example.com:9735"),
+                readonly = null,
+            ),
+            ILspNode(
+                alias = "LSP2",
+                pubkey = "node2pubkey",
+                connectionStrings = listOf("node2pubkey@node2.example.com:9735"),
+                readonly = null,
+            ),
+        )
+
+        val peers = lspNodes.toPeerDetailsList()
+
+        assertEquals(2, peers.size)
+        assertEquals("node1pubkey", peers[0].nodeId)
+        assertEquals("node1.example.com:9735", peers[0].address)
+        assertEquals("node2pubkey", peers[1].nodeId)
+        assertEquals("node2.example.com:9735", peers[1].address)
+    }
+
+    @Test
+    fun `toPeerDetailsList filters out nodes with empty connectionStrings`() {
+        val lspNodes = listOf(
+            ILspNode(
+                alias = "LSP1",
+                pubkey = "node1pubkey",
+                connectionStrings = listOf("node1.example.com:9735"),
+                readonly = null,
+            ),
+            ILspNode(
+                alias = "LSP2",
+                pubkey = "node2pubkey",
+                connectionStrings = emptyList(),
+                readonly = null,
+            ),
+            ILspNode(
+                alias = "LSP3",
+                pubkey = "node3pubkey",
+                connectionStrings = listOf("node3.example.com:9735"),
+                readonly = null,
+            ),
+        )
+
+        val peers = lspNodes.toPeerDetailsList()
+
+        assertEquals(2, peers.size)
+        assertEquals("node1pubkey", peers[0].nodeId)
+        assertEquals("node3pubkey", peers[1].nodeId)
+    }
+
+    @Test
+    fun `toPeerDetailsList returns empty list when all nodes have empty connectionStrings`() {
+        val lspNodes = listOf(
+            ILspNode(
+                alias = "LSP1",
+                pubkey = "node1pubkey",
+                connectionStrings = emptyList(),
+                readonly = null,
+            ),
+            ILspNode(
+                alias = "LSP2",
+                pubkey = "node2pubkey",
+                connectionStrings = emptyList(),
+                readonly = null,
+            ),
+        )
+
+        val peers = lspNodes.toPeerDetailsList()
+
+        assertTrue(peers.isEmpty())
+    }
+}


### PR DESCRIPTION
 Fixes the "Invalid socket address" error that occurs when connecting to trusted Lightning peers loaded from Blocktank info.                                                                            
                                                                                                                                                                                                         
  ### Description                                                                                                                                                                                        
                                                                                                                                                                                                         
  The `ILspNode.toPeerDetails()` extension function was assuming that the `connectionStrings` field contained only `host:port` format (e.g., `"34.65.86.104:9400"`), but the actual Blocktank API returns the full connection URI in the format `nodeId@host:port` (e.g., `"028a8910...@34.65.86.104:9400"`).
                                                                                                                                                                                                         
  When this full connection string was passed directly to LDK's `node.connect()` function as the address parameter, it was rejected with "Invalid socket address" because LDK expects only the socket address portion (`host:port`).
                                                                                                                                                                                                         
  **Changes:**                                                                                                                                                                                           
  - Modified `toPeerDetails()` to parse connection strings and extract just the `host:port` portion when the full URI format is present                                                                  
  - The function now handles both formats correctly:                                                                                                                                                     
    - `"host:port"` → used as-is                                                                                                                                                                         
    - `"nodeId@host:port"` → extracts `"host:port"` portion                                                                                                                                              
  - Added comprehensive unit tests (`PeerDetailsTest.kt`) with 16 test cases covering all extension functions and edge cases                                                                             
                                                                                                                                                                                                         
  **Root Cause:**                                                                                                                                                                                        
  This issue appeared after PR #536 which introduced loading trusted peers from Blocktank info. Previously, peers were loaded from `Env.trustedLnPeers` which had the correct format. The new code path exposed the format mismatch.
                                                                                                                                                                                                         
  ### Preview                                                                                                                                                                                            
                                                                                                                                                                                                         
[Uploading Screen_recording_20251219_132825.webm…]()

                                                                                                                                                                                                         
  ### QA Notes                                                                                                                                                                                           
                                                                                                                                                                                                         
  **Tests Added:**                                                                                                                                                                                       
  - ✅ 16 unit tests in `PeerDetailsTest.kt` all passing                                                                                                                                                 
  - ✅ Tests cover both connection string formats, edge cases, and all extension functions                                                                                                               
  - ✅ Detekt linter passes                                                                                                                                                                              
                                                                                                                                                                                                         
  **Manual Testing:**                                                                                                                                                                                    
  1. Start the app and verify it connects to trusted peers without "Invalid socket address" errors                                                                                                       
  2. Check logs for successful peer connections (should show `✓ Connected to trusted peer: <nodeId>`)                                                                                                    
  3. Verify no "Peer connect error" logs with LDK "Invalid socket address" errors                                                                                                                        
  4. Run unit tests: `./gradlew testDevDebugUnitTest --tests PeerDetailsTest`                                                                                                                            
                                                                                                                                                                                                         
  **Regression Testing:**                                                                                                                                                                                
  - Existing peer connection functionality remains unchanged                                                                                                                                             
  - All other `PeerDetails` extension functions (parse, from, host, port, uri) continue to work correctly                                                                                                
           