### PR TITLE
fix: don't request notification permission on recovery mode

### DIFF
--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -756,9 +756,11 @@ private fun NavGraphBuilder.home(
 ) {
     composable<Routes.Home> {
         val uiState by walletViewModel.uiState.collectAsStateWithLifecycle()
+        val isRecoveryMode by walletViewModel.isRecoveryMode.collectAsStateWithLifecycle()
         val hazeState = rememberHazeState()
 
         RequestNotificationPermissions(
+            showPermissionDialog = !isRecoveryMode,
             onPermissionChange = { granted ->
                 settingsViewModel.setNotificationPreference(granted)
             }


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->
Closes #420 
### Description

This PR check if the app is on recovery mode before asking for notification permission

### Preview

[recovery-notifications.webm](https://github.com/user-attachments/assets/2c518fca-5ea9-430a-9e9f-802019ae76cf)

### QA Notes

- [x] Fresh install -> recovery mode -> don't ask for notification permission
- [x] Fresh install -> create / recover wallet -> ash for notification permission (android > 10)
