### PR TITLE
fix: set swipe color according payment method

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendConfirmScreen.kt
@@ -289,6 +289,10 @@ fun ContentRunning(
 
         SwipeToConfirm(
             text = stringResource(R.string.wallet__send_swipe),
+            color = when (uiState.payMethod) {
+                SendMethod.ONCHAIN -> Colors.Brand
+                SendMethod.LIGHTNING -> Colors.Purple
+            },
             loading = isLoading,
             confirmed = isLoading,
             onConfirm = onSwipeToConfirm,


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

Phis PR sets the swipe component color according the payment method
### Preview

[onchain.webm](https://github.com/user-attachments/assets/d73b469c-d0bd-4880-b365-a0cebf7c337a)

[lightning.webm](https://github.com/user-attachments/assets/dac48885-fffd-48b4-af86-563f220b8507)

[uniffied.webm](https://github.com/user-attachments/assets/86345c1a-d705-4bae-9dcf-1d427986edb1)

### QA Notes

- [x] onchain
- [x] lightning
- [x] unified

