### PR TITLE
fix: remove next item trigger from timed sheet dismiss

### DIFF
--- a/app/src/main/java/to/bitkit/ui/nav/entries/SheetEntries.kt
+++ b/app/src/main/java/to/bitkit/ui/nav/entries/SheetEntries.kt
@@ -745,7 +745,7 @@ private fun EntryProviderScope<NavKey>.sheetFlowEntries(
         }
         BackgroundPaymentsIntroSheet(
             onContinue = {
-                appViewModel.dismissTimedSheet(skipQueue = true)
+                appViewModel.dismissTimedSheet()
                 navigator.navigate(Routes.BackgroundPayments.Settings)
             },
         )
@@ -759,7 +759,7 @@ private fun EntryProviderScope<NavKey>.sheetFlowEntries(
         }
         QuickPayIntroSheet(
             onContinue = {
-                appViewModel.dismissTimedSheet(skipQueue = true)
+                appViewModel.dismissTimedSheet()
                 navigator.navigate(Routes.QuickPay.Settings)
             },
         )
@@ -777,7 +777,7 @@ private fun EntryProviderScope<NavKey>.sheetFlowEntries(
             learnMoreClick = {
                 val intent = Intent(Intent.ACTION_VIEW, Env.STORING_BITCOINS_URL.toUri())
                 context.startActivity(intent)
-                appViewModel.dismissTimedSheet(skipQueue = true)
+                appViewModel.dismissTimedSheet()
                 navigator.goBack()
             },
         )

--- a/app/src/main/java/to/bitkit/utils/timedsheets/TimedSheetManager.kt
+++ b/app/src/main/java/to/bitkit/utils/timedsheets/TimedSheetManager.kt
@@ -42,7 +42,7 @@ class TimedSheetManager(private val scope: CoroutineScope) {
         checkJob = null
     }
 
-    fun dismissCurrentSheet(skipQueue: Boolean = false) {
+    fun dismissCurrentSheet() {
         if (currentTimedSheet == null) return
 
         scope.launch {
@@ -50,12 +50,7 @@ class TimedSheetManager(private val scope: CoroutineScope) {
             _currentSheet.value = null
             currentTimedSheet = null
 
-            if (skipQueue) {
-                Logger.debug("Clearing timed sheet queue", context = TAG)
-            } else {
-                delay(CHECK_DELAY_MILLIS)
-                checkAndShowNextSheet()
-            }
+            Logger.debug("Clearing timed sheet queue", context = TAG)
         }
     }
 

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -1736,8 +1736,7 @@ class AppViewModel @Inject constructor(
 
     fun onLeftHome() = timedSheetManager.onHomeScreenExited()
 
-    fun dismissTimedSheet(skipQueue: Boolean = false) =
-        timedSheetManager.dismissCurrentSheet(skipQueue)
+    fun dismissTimedSheet() = timedSheetManager.dismissCurrentSheet()
 
     private suspend fun checkCriticalAppUpdate() = withContext(bgDispatcher) {
         delay(SCREEN_TRANSITION_DELAY_MS)

--- a/app/src/test/java/to/bitkit/utils/timedsheets/TimedSheetManagerTest.kt
+++ b/app/src/test/java/to/bitkit/utils/timedsheets/TimedSheetManagerTest.kt
@@ -103,7 +103,7 @@ class TimedSheetManagerTest : BaseUnitTest() {
 
         assertEquals(TimedSheetType.APP_UPDATE, sut.currentSheet.value)
 
-        sut.dismissCurrentSheet(skipQueue = true)
+        sut.dismissCurrentSheet()
         testScope.advanceTimeBy(100)
 
         assertNull(sut.currentSheet.value)
@@ -139,7 +139,7 @@ class TimedSheetManagerTest : BaseUnitTest() {
 
         assertEquals(TimedSheetType.BACKUP, sut.currentSheet.value)
 
-        sut.dismissCurrentSheet(skipQueue = false)
+        sut.dismissCurrentSheet()
         testScope.advanceTimeBy(100)
 
         assertNull(sut.currentSheet.value)


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->
Related to https://github.com/synonymdev/bitkit-ios/issues/294 and https://github.com/synonymdev/bitkit-android/pull/556#issuecomment-3698648454

### Description

This PR removes the next item trigger from the Timed sheet manager on sheet dismiss, to align with iOS behavior (similar to RN).

OBS: The iOS had the same trigger but wasn't working and it was removed in https://github.com/synonymdev/bitkit-ios/pull/295

### Preview

[Screen_recording_20251230_091510.webm](https://github.com/user-attachments/assets/b8291bbc-bfdb-4bf8-a5b3-1abd4f5a6b23)

### QA Notes

Test steps:

1. Go to dev settings
2. Receive 100 000 000
3. Mine a block
4. Go to home
5. Display the backup sheet
6. Dismiss it
7. Stay in home
8. Should NOT display high balance sheet
9. Leave home
10. Return to home
11. Should display high balance sheet
