### PR TITLE
fix: lnurl navigating to the next step before ui update

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/widgets/DragDropColumn.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/DragDropColumn.kt
@@ -1,6 +1,6 @@
 package to.bitkit.ui.screens.widgets
 
-import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -24,10 +25,10 @@ fun DragDropColumn(
     items: List<WidgetWithPosition>,
     onMove: (Int, Int) -> Unit,
     modifier: Modifier = Modifier,
-    itemContent: @Composable (WidgetWithPosition, Boolean) -> Unit
+    itemContent: @Composable (WidgetWithPosition, Boolean) -> Unit,
 ) {
     var draggedItem by remember { mutableStateOf<Int?>(null) }
-    var draggedItemOffset by remember { mutableStateOf(0f) }
+    var draggedItemOffset by remember { mutableFloatStateOf(0f) }
 
     Column(
         modifier = modifier
@@ -50,7 +51,7 @@ fun DragDropColumn(
                         }
                     )
                     .pointerInput(Unit) {
-                        detectDragGesturesAfterLongPress(
+                        detectVerticalDragGestures(
                             onDragStart = {
                                 draggedItem = index
                             },
@@ -58,8 +59,8 @@ fun DragDropColumn(
                                 draggedItem = null
                                 draggedItemOffset = 0f
                             },
-                            onDrag = { _, dragAmount ->
-                                draggedItemOffset += dragAmount.y
+                            onVerticalDrag = { _, dragAmount ->
+                                draggedItemOffset += dragAmount
 
                                 val itemHeight = 96.dp.toPx() // Item height + spacing (80dp + 16dp)
                                 val draggedIndex = draggedItem ?: index

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -741,6 +741,21 @@ class AppViewModel @Inject constructor(
                 ?.let { it as? Scanner.Lightning }
                 ?.invoice
                 ?.takeIf { invoice ->
+                    if (invoice.isExpired) {
+                        toast(
+                            type = Toast.ToastType.ERROR,
+                            title = context.getString(R.string.other__scan_err_decoding),
+                            description = context.getString(R.string.other__scan__error__expired),
+                        )
+
+                        Logger.debug(
+                            "Lightning invoice expired in unified URI, defaulting to onchain-only",
+                            context = TAG
+                        )
+                        return@takeIf false
+                    }
+
+                    // Then check sending capacity
                     val canSend = lightningRepo.canSend(invoice.amountSatoshis.coerceAtLeast(1u))
                     if (!canSend) {
                         Logger.debug("Cannot pay unified invoice using LN, defaulting to onchain-only", context = TAG)


### PR DESCRIPTION
<!-- Closes | Fixes | Resolves #ISSUE_ID -->
Closes #418 
<!-- Brief summary of the PR changes, linking to the related resources (issue/design/bug/etc) if applicable. -->

### Description

  1. When pasting an LNURL-withdraw with equal min/max amounts, the code updates state and immediately navigates
  2. The navigation happens before the UI has recomposed with the new state values
  3. The WithdrawConfirmScreen expects uiState.amount to be set, but may see stale data
  4. This causes the app to appear frozen or unresponsive

  The fix:
  - Add a small delay before navigation (using existing TRANSITION_SCREEN_MS constant)
  - This gives the UI time to recompose with correct state
  
### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

- Connect to external node -> create a LNURL withdraw with minWithdrawable == maxWithdrawable -> paste in the app
