### PR TITLE
fix: prevent force close channels of trusted peers

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -881,6 +881,10 @@ class LightningRepo @Inject constructor(
         return isRunning && lightningService.canReceive()
     }
 
+    fun separateTrustedChannels(
+        channels: List<ChannelDetails>,
+    ): Pair<List<ChannelDetails>, List<ChannelDetails>> = lightningService.separateTrustedChannels(channels)
+
     suspend fun registerForNotifications(token: String? = null) = executeWhenNodeRunning("registerForNotifications") {
         return@executeWhenNodeRunning try {
             val token = token ?: firebaseMessaging.token.await()

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -375,6 +375,19 @@ class LightningService @Inject constructor(
         return ourPeers.any { p -> p !in lspPeers }
     }
 
+    fun getLspPeerNodeIds(): Set<String> = trustedPeers.map { it.nodeId }.toSet()
+
+    fun separateTrustedChannels(
+        channels: List<ChannelDetails>,
+    ): Pair<List<ChannelDetails>, List<ChannelDetails>> {
+        val trustedPeerIds = getLspPeerNodeIds()
+        val trusted = channels.filter { it.counterpartyNodeId in trustedPeerIds }
+        val nonTrusted = channels.filter { it.counterpartyNodeId !in trustedPeerIds }
+        return trusted to nonTrusted
+    }
+
+    fun isTrustedPeer(nodeId: String): Boolean = nodeId in getLspPeerNodeIds()
+
     // endregion
 
     // region channels
@@ -418,6 +431,7 @@ class LightningService @Inject constructor(
         }
     }
 
+    @Suppress("ThrowsCount")
     suspend fun closeChannel(
         channel: ChannelDetails,
         force: Boolean = false,
@@ -427,6 +441,12 @@ class LightningService @Inject constructor(
         val channelId = channel.channelId
         val userChannelId = channel.userChannelId
         val counterpartyNodeId = channel.counterpartyNodeId
+
+        // Prevent force closing channels with trusted peers (LSP nodes)
+        if (force && isTrustedPeer(counterpartyNodeId)) {
+            throw TrustedPeerForceCloseException()
+        }
+
         try {
             ServiceQueue.LDK.background {
                 Logger.debug("Initiating channel close (force=$force): '$channelId'", context = TAG)
@@ -950,6 +970,10 @@ data class NetworkGraphInfo(
     val nodeCount: Int,
     val channelCount: Int,
     val latestRgsSyncTimestamp: ULong?,
+)
+
+class TrustedPeerForceCloseException : Exception(
+    "Cannot force close channel with trusted peer. Force close is disabled for Blocktank LSP channels."
 )
 
 // region helpers

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -592,6 +592,7 @@ private fun RootNavHost(
                     wallet = walletViewModel,
                     transfer = transferViewModel,
                     onContinueClick = { navController.popBackStack<Routes.TransferRoot>(inclusive = true) },
+                    onTransferUnavailable = { navController.popBackStack<Routes.TransferRoot>(inclusive = true) },
                 )
             }
             composableWithDefaultTransitions<Routes.SpendingIntro> {

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsProgressScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsProgressScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -27,6 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import to.bitkit.R
+import to.bitkit.models.Toast
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
@@ -52,8 +54,10 @@ fun SavingsProgressScreen(
     transfer: TransferViewModel,
     wallet: WalletViewModel,
     onContinueClick: () -> Unit = {},
+    onTransferUnavailable: () -> Unit = {},
 ) {
     val window = LocalActivity.current?.window
+    val context = LocalContext.current
     var progressState by remember { mutableStateOf(SavingsProgressState.PROGRESS) }
 
     // Effect to close channels & update UI
@@ -68,11 +72,35 @@ fun SavingsProgressScreen(
             delay(5000)
             progressState = SavingsProgressState.SUCCESS
         } else {
-            transfer.startCoopCloseRetries(channelsFailedToCoopClose) {
-                app.showSheet(Sheet.ForceTransfer)
+            // Check if any channels can be retried (filter out trusted peers)
+            val (_, nonTrustedChannels) = transfer.separateTrustedChannels(channelsFailedToCoopClose)
+
+            if (nonTrustedChannels.isEmpty()) {
+                // All channels are trusted peers - show error and navigate back immediately
+                window?.clearFlags(FLAG_KEEP_SCREEN_ON)
+                app.toast(
+                    type = Toast.ToastType.ERROR,
+                    title = context.getString(R.string.lightning__close_error),
+                    description = context.getString(R.string.lightning__close_error_msg),
+                )
+                onTransferUnavailable()
+            } else {
+                transfer.startCoopCloseRetries(
+                    channels = nonTrustedChannels,
+                    onGiveUp = { app.showSheet(Sheet.ForceTransfer) },
+                    onTransferUnavailable = {
+                        window?.clearFlags(FLAG_KEEP_SCREEN_ON)
+                        app.toast(
+                            type = Toast.ToastType.ERROR,
+                            title = context.getString(R.string.lightning__close_error),
+                            description = context.getString(R.string.lightning__close_error_msg),
+                        )
+                        onTransferUnavailable()
+                    },
+                )
+                delay(2500)
+                progressState = SavingsProgressState.INTERRUPTED
             }
-            delay(2500)
-            progressState = SavingsProgressState.INTERRUPTED
         }
     }
 

--- a/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
@@ -374,6 +374,10 @@ class TransferViewModel @Inject constructor(
     /** Closes the channels selected earlier, pending closure */
     suspend fun closeSelectedChannels() = closeChannels(channelsToClose)
 
+    fun separateTrustedChannels(
+        channels: List<ChannelDetails>,
+    ): Pair<List<ChannelDetails>, List<ChannelDetails>> = lightningRepo.separateTrustedChannels(channels)
+
     private suspend fun closeChannels(channels: List<ChannelDetails>): List<ChannelDetails> {
         val channelsFailedToClose = coroutineScope {
             channels.map { channel ->
@@ -404,6 +408,7 @@ class TransferViewModel @Inject constructor(
     fun startCoopCloseRetries(
         channels: List<ChannelDetails>,
         onGiveUp: () -> Unit,
+        onTransferUnavailable: () -> Unit,
     ) {
         val startTimeMs = clock.now().toEpochMilliseconds()
         channelsToClose = channels
@@ -427,21 +432,63 @@ class TransferViewModel @Inject constructor(
                 delay(RETRY_INTERVAL_MS)
             }
 
-            Logger.info("Giving up on coop close.")
-            onGiveUp()
+            Logger.info("Giving up on coop close. Checking if force close is possible.", context = TAG)
+
+            // Check if any channels can be force closed (filter out trusted peers)
+            val (_, nonTrustedChannels) = lightningRepo.separateTrustedChannels(channelsToClose)
+
+            if (nonTrustedChannels.isNotEmpty()) {
+                onGiveUp()
+            } else {
+                Logger.warn("All channels are with trusted peers. Cannot force close.", context = TAG)
+                channelsToClose = emptyList()
+                onTransferUnavailable()
+            }
         }
     }
 
     fun forceTransfer(onComplete: () -> Unit) = viewModelScope.launch {
         _isForceTransferLoading.value = true
         runCatching {
-            val failedChannels = forceCloseChannels(channelsToClose)
+            // Filter out trusted peer channels (cannot force close LSP channels)
+            val (trustedChannels, nonTrustedChannels) = lightningRepo.separateTrustedChannels(channelsToClose)
+
+            if (trustedChannels.isNotEmpty()) {
+                Logger.warn("Skipping ${trustedChannels.size} trusted peer channel(s)", context = TAG)
+            }
+
+            if (nonTrustedChannels.isEmpty()) {
+                channelsToClose = emptyList()
+                Logger.error("Cannot force close channels with trusted peer", context = TAG)
+                ToastEventBus.send(
+                    type = Toast.ToastType.ERROR,
+                    title = context.getString(R.string.lightning__force_failed_title),
+                    description = context.getString(R.string.lightning__force_failed_msg)
+                )
+                return@runCatching
+            }
+
+            val failedChannels = forceCloseChannels(nonTrustedChannels)
+
+            // Remove successfully closed channels and trusted peer channels from the list
+            val successfulChannelIds = nonTrustedChannels
+                .filterNot { channel -> failedChannels.any { it.channelId == channel.channelId } }
+                .map { it.channelId }
+                .toSet()
+            val trustedChannelIds = trustedChannels.map { it.channelId }.toSet()
+            channelsToClose = channelsToClose.filterNot {
+                it.channelId in successfulChannelIds || it.channelId in trustedChannelIds
+            }
+
             if (failedChannels.isEmpty()) {
                 Logger.info("Force close initiated successfully for all channels", context = TAG)
+                val initMsg = context.getString(R.string.lightning__force_init_msg)
+                val skippedMsg = context.getString(R.string.lightning__force_channels_skipped)
+                val description = if (trustedChannels.isNotEmpty()) "$initMsg $skippedMsg" else initMsg
                 ToastEventBus.send(
                     type = Toast.ToastType.LIGHTNING,
                     title = context.getString(R.string.lightning__force_init_title),
-                    description = context.getString(R.string.lightning__force_init_msg)
+                    description = description,
                 )
             } else {
                 Logger.error("Force close failed for ${failedChannels.size} channels", context = TAG)
@@ -451,8 +498,8 @@ class TransferViewModel @Inject constructor(
                     description = context.getString(R.string.lightning__force_failed_msg)
                 )
             }
-        }.onFailure { e ->
-            Logger.error("Force close failed", e = e, context = TAG)
+        }.onFailure {
+            Logger.error("Force close failed", e = it, context = TAG)
             ToastEventBus.send(
                 type = Toast.ToastType.ERROR,
                 title = context.getString(R.string.lightning__force_failed_title),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,6 +254,7 @@
     <string name="lightning__force_button">Force Transfer</string>
     <string name="lightning__force_init_title">Force Transfer Initiated</string>
     <string name="lightning__force_init_msg">Your funds will be accessible in ±14 days.</string>
+    <string name="lightning__force_channels_skipped">Some connections could not be closed.</string>
     <string name="lightning__force_failed_title">Force Transfer Failed</string>
     <string name="lightning__force_failed_msg">Unable to transfer your funds back to savings. Please try again.</string>
     <string name="lightning__channel_opened_title">Spending Balance Ready</string>


### PR DESCRIPTION
This PR is to skip force close of channels with trusted peers (Blocktank). If only trusted peers channels are being closed the app will not show the force close option and will just return with an error. If both trusted and not trusted channels are forced closed, the trusted peers channels will be skipped.

Fix #528