### PR TITLE
ci: Initial E2E Migration CI workflow

### DIFF
--- a/.github/workflows/e2e_migration.yml
+++ b/.github/workflows/e2e_migration.yml
@@ -1,0 +1,193 @@
+name: E2E Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      e2e_branch:
+        description: "Branch of synonymdev/bitkit-e2e-tests to use (main | default-feature-branch | custom branch name)"
+        required: false
+        default: "default-feature-branch"
+
+env:
+  TERM: xterm-256color
+  FORCE_COLOR: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "adopt"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode google-services.json
+        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > app/google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+
+      - name: Build debug app (regtest)
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHATWOOT_API: ${{ secrets.CHATWOOT_API }}
+          E2E: true
+          E2E_BACKEND: network
+          GEO: false
+        run: ./gradlew assembleDevDebug
+
+      - name: Rename APK
+        run: |
+          apk=$(find app/build/outputs/apk/dev/debug -name 'bitkit-android-*-devDebug.apk')
+          mv "$apk" app/build/outputs/apk/dev/debug/bitkit_e2e.apk
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: bitkit-e2e-apk_${{ github.run_number }}
+          path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
+
+  e2e-branch:
+    if: github.event.pull_request.draft == false
+    uses: synonymdev/bitkit-e2e-tests/.github/workflows/determine-e2e-branch.yml@main
+    with:
+      app_branch: ${{ github.head_ref || github.ref_name }}
+      e2e_branch_input: ${{ github.event.inputs.e2e_branch || 'default-feature-branch' }}
+
+  e2e-tests:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    needs: [build, e2e-branch]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - { name: migration_1, grep: "@migration_1" }
+          - { name: migration_2, grep: "@migration_2" }
+          - { name: migration_3, grep: "@migration_3" }
+          - { name: migration_4, grep: "@migration_4" }
+
+    name: e2e-tests - ${{ matrix.scenario.name }}
+
+    steps:
+      - name: Show selected E2E branch
+        env:
+          E2E_BRANCH: ${{ needs.e2e-branch.outputs.branch }}
+        run: echo $E2E_BRANCH
+
+      - name: Clone E2E tests
+        uses: actions/checkout@v4
+        with:
+          repository: synonymdev/bitkit-e2e-tests
+          path: bitkit-e2e-tests
+          ref: ${{ needs.e2e-branch.outputs.branch }}
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Download APK
+        uses: actions/download-artifact@v4
+        with:
+          name: bitkit-e2e-apk_${{ github.run_number }}
+          path: bitkit-e2e-tests/aut
+
+      - name: Download RN app for migration
+        run: |
+          curl -L -o bitkit-e2e-tests/aut/bitkit_rn_regtest.apk \
+            https://github.com/synonymdev/bitkit-e2e-tests/releases/download/migration-rn-regtest/bitkit_rn_regtest.apk
+
+      - name: List APK directory contents
+        run: ls -l bitkit-e2e-tests/aut
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Cache npm cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        working-directory: bitkit-e2e-tests
+        run: npm ci
+
+      - name: Run E2E Tests 1 (${{ matrix.scenario.name }})
+        continue-on-error: true
+        id: test1
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          profile: pixel_6
+          api-level: 33
+          arch: x86_64
+          avd-name: Pixel_6
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-front none
+          script: cd bitkit-e2e-tests && ./ci_run_android.sh --mochaOpts.grep "${{ matrix.scenario.grep }}"
+        env:
+          BACKEND: regtest
+          RECORD_VIDEO: true
+          ATTEMPT: 1
+
+      - name: Run E2E Tests 2 (${{ matrix.scenario.name }})
+        continue-on-error: true
+        id: test2
+        if: steps.test1.outcome != 'success'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          profile: pixel_6
+          api-level: 33
+          arch: x86_64
+          avd-name: Pixel_6
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-front none
+          script: cd bitkit-e2e-tests && ./ci_run_android.sh --mochaOpts.grep "${{ matrix.scenario.grep }}"
+        env:
+          BACKEND: regtest
+          RECORD_VIDEO: true
+          ATTEMPT: 2
+
+      - name: Run E2E Tests 3 (${{ matrix.scenario.name }})
+        id: test3
+        if: steps.test1.outcome != 'success' && steps.test2.outcome != 'success'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          profile: pixel_6
+          api-level: 33
+          arch: x86_64
+          avd-name: Pixel_6
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-front none
+          script: cd bitkit-e2e-tests && ./ci_run_android.sh --mochaOpts.grep "${{ matrix.scenario.grep }}"
+        env:
+          BACKEND: regtest
+          RECORD_VIDEO: true
+          ATTEMPT: 3
+
+      - name: Upload E2E Artifacts (${{ matrix.scenario.name }})
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts_${{ matrix.scenario.name }}_${{ github.run_number }}
+          path: bitkit-e2e-tests/artifacts/


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for running E2E migration tests that validate the upgrade path from the legacy React Native app to the native Android app.

### Description

The workflow:
1. Builds the native app with regtest backend configuration
2. Downloads the legacy RN app from https://github.com/synonymdev/bitkit-e2e-tests/releases/tag/migration-rn-regtest
3. Runs 4 parallelized migration test scenarios (migration_1 through migration_4)

Key differences from the standard E2E workflow:
- Uses `BACKEND=regtest` for network regtest instead of local docker
- No local regtest infrastructure setup required
- Manual trigger only (workflow_dispatch) for now

### Preview

<!-- Insert relevant screenshot / recording -->

### QA Notes

The migration scenarios are developed in https://github.com/synonymdev/bitkit-e2e-tests/pull/95
For now, they are very basic (only onchain funds in the RN app), but will be expanded.
```
@migration - Migration from legacy RN app to native app
    ✓ @migration_1 - Uninstall RN, install Native, restore mnemonic
    ✓ @migration_2 - Install native on top of RN (upgrade)
    ✓ @migration_3 - Uninstall RN, install Native, restore with passphrase
    ✓ @migration_4 - Install native on top of RN with passphrase (upgrade)
```
