### PR TITLE
fix: unified invoice validation with zero on-chain balance

### DIFF
--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -758,7 +758,7 @@ class AppViewModel @Inject constructor(
         _sendUiState.update { it.copy(isAddressInputValid = true) }
     }
 
-    private fun validateOnChainAddress(invoice: OnChainInvoice) {
+    private suspend fun validateOnChainAddress(invoice: OnChainInvoice) {
         val validatedAddress = runCatching { validateBitcoinAddress(invoice.address) }
             .getOrElse {
                 showAddressValidationError(
@@ -775,6 +775,22 @@ class AppViewModel @Inject constructor(
                 descriptionRes = R.string.other__scan__error__generic,
                 testTag = "InvalidAddressToast",
             )
+            return
+        }
+
+        // Check if this is a unified invoice with Lightning available
+        val lnInvoice: LightningInvoice? = invoice.params?.get("lightning")?.let { bolt11 ->
+            runCatching { decode(bolt11) }.getOrNull()
+                ?.let { it as? Scanner.Lightning }
+                ?.invoice
+                ?.takeIf { lnInv ->
+                    !lnInv.isExpired && lightningRepo.canSend(lnInv.amountSatoshis.coerceAtLeast(1u))
+                }
+        }
+
+        // If Lightning path is available, accept the unified invoice
+        if (lnInvoice != null) {
+            _sendUiState.update { it.copy(isAddressInputValid = true) }
             return
         }
 


### PR DESCRIPTION
This PR fixes unified invoice validation to accept Lightning payment when on-chain balance is zero.

### Description

When typing or pasting a unified invoice (BIP21 with embedded Lightning), the validation incorrectly rejected it if on-chain balance was zero, even when the user had sufficient Lightning balance. The fix adds unified invoice detection to `validateOnChainAddress()`, mirroring the existing logic in `onScanOnchain()`.

### Preview

VIDEO_1
<!-- VIDEO_1: Record pasting a unified invoice with 0 on-chain balance but funded Lightning channel, showing it now validates successfully instead of showing "Insufficient Savings" error -->

### QA Notes

#### 1. Unified invoice with Lightning balance only
1. Create wallet with 0 on-chain balance but funded Lightning channel
2. Paste a unified invoice (BIP21 with `?lightning=` param)
3. Verify: Address should be accepted (green checkmark)
4. Before fix: Shows "Insufficient Savings" error

#### 2. Regression - Pure on-chain address
1. Paste a plain Bitcoin address
2. Verify on-chain balance validation still works as expected

#### 3. Regression - Scan flow
1. Scan a unified QR code
2. Verify it still routes correctly to Lightning payment