### PR TITLE
fix: use navigateToHome() in ExternalSuccessScreen

### DIFF
--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -749,7 +749,7 @@ private fun RootNavHost(
                 }
                 composableWithDefaultTransitions<Routes.ExternalSuccess> {
                     ExternalSuccessScreen(
-                        onContinue = { navController.popBackStack<Routes.TransferRoot>(inclusive = true) },
+                        onContinue = { navController.navigateToHome() },
                     )
                 }
                 composableWithDefaultTransitions<Routes.ExternalFeeCustom> {


### PR DESCRIPTION
Match iOS (and RN) behavior by navigating directly to home after external channel connection success, instead of popping back to TransferRoot.

### Description

Previously, tapping the continue button on the External Success screen used `popBackStack<Routes.TransferRoot>(inclusive = true)`, which didn't explicitly navigate to the Home screen. This caused inconsistent behavior compared to iOS, where the app returns directly to Home after the success screen.

The fix changes the navigation to use `navigateToHome()`, which properly restores the Home screen without re-composing it. This ensures consistent behavior across platforms and fixes a timing issue with timed sheets in E2E tests. Hopefully fixes `@transfer_2` flakiness 🤞 

### Preview


### QA Notes

1. **Connect to external node**
   - Go to Transfer → Spending balance → Advanced → Connect to node
   - Scan or paste a valid Lightning node URI
   - Complete the connection flow
   - On success screen, tap the continue button
   - Verify you return directly to the Home screen

2. **Verify Home screen state**
   - After returning to Home, verify the activity list shows the new channel
   - Verify the balance reflects the channel opening transaction
   - Verify no unexpected sheets appear immediately after navigation

 - https://github.com/synonymdev/bitkit-e2e-tests/pull/109
