### PR TITLE
ci: add path filter to e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: "default-feature-branch"
   pull_request:
+    paths:
+      - 'app/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'gradle.properties'
 
 env:
   TERM: xterm-256color


### PR DESCRIPTION
This PR adds path filters to the E2E workflow so it only runs when app-related files change.

### Description

Adds path filters to skip E2E tests for non-code changes:

**Included paths (E2E runs):**
- `app/**` - source code, resources, manifests
- `gradle/**` - version catalogs
- `*.gradle.kts` - build scripts
- `gradle.properties` - build properties

**Excluded (E2E skipped):**
- `.github/**` - workflow changes
- `*.md` - documentation
- `.ai/**`, `docs/**` - docs

### Preview

N/A - workflow change

### QA Notes

1. Create a PR with only `.md` changes → E2E should NOT run
2. Create a PR with `app/` changes → E2E should run
3. Manual dispatch still works regardless of paths