### PR TITLE
fix: ignore job cancellation on notification

### DIFF
--- a/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
+++ b/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
@@ -7,6 +7,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -109,6 +110,11 @@ class WakeNodeWorker @AssistedInject constructor(
             .fold(
                 onSuccess = { Result.success() },
                 onFailure = { e ->
+                    if (e is CancellationException) {
+                        Logger.debug("Work cancelled", context = TAG)
+                        return@fold Result.failure(workDataOf("Reason" to "Cancelled"))
+                    }
+
                     val reason = e.message ?: appContext.getString(R.string.common__error_body)
 
                     bestAttemptContent = NotificationDetails(


### PR DESCRIPTION
Related to #692

This PR prevents error notifications from being shown to users when the WakeNodeWorker job is cancelled.

### Description

- Adds early return for `CancellationException` in `WakeNodeWorker.doWork()` failure handler
- Skips setting error notification content when work is cancelled
- Logs cancellation as debug instead of error since it's expected behavior

### Preview

N/A - no UI changes

### QA Notes

1. Trigger a push notification that wakes the node
2. Kill the app while the node is starting up
3. Verify no "Lightning error" notification is shown to the user
4. Check logs show "Work cancelled" debug message instead of error