### PR TITLE
fix: remove unused READ_MEDIA_IMAGES permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <!-- Required for E2E tests connecting to local Electrum server (Android 16+) -->


### PR DESCRIPTION
This PR removes the unused `READ_MEDIA_IMAGES` permission to comply with Google Play Store policies.

### Description

The app was rejected because `READ_MEDIA_IMAGES` requires persistent access to media files, but Bitkit only uses gallery access for one-time QR code scanning. The existing implementation already uses permission-less APIs:

- **Android 13+**: `PickVisualMedia` (Photo Picker API)
- **Android 12 and below**: `GetContent()` intent

Both provide temporary, scoped access to selected files only, making the permission unnecessary.

### Preview

[Screen_recording_20260126_083520.webm](https://github.com/user-attachments/assets/14eda44f-abca-4d01-b4cd-e2a43ee01587)

(Also tested scan with success on android 13, didn't uploaded the video because it is my personal phone)

https://github.com/user-attachments/assets/e2da304f-16c8-4900-bdb8-25c38628805c


### QA Notes

1. Build the app: `./gradlew assembleDevDebug`
2. Open the QR scanner and tap the gallery icon
3. Select an image containing a QR code
4. Verify the QR code is successfully scanned
5. Repeat on both Android 13+ and Android 12 devices if available