### PR TITLE
fix: share network callback via StateFlow

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/ConnectivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ConnectivityRepo.kt
@@ -12,10 +12,12 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import to.bitkit.di.BgDispatcher
 import to.bitkit.utils.Logger
@@ -35,7 +37,7 @@ class ConnectivityRepo @Inject constructor(
         private const val DELAY_MS = 250L
     }
 
-    val isOnline: Flow<ConnectivityState> = callbackFlow {
+    val isOnline: StateFlow<ConnectivityState> = callbackFlow {
         var currentNetwork: Network? = null
         var currentCapabilities: NetworkCapabilities? = null
 
@@ -127,7 +129,11 @@ class ConnectivityRepo @Inject constructor(
         }
     }.distinctUntilChanged().onEach { state ->
         Logger.debug("New network state: $state")
-    }
+    }.stateIn(
+        scope = repoScope,
+        started = SharingStarted.Eagerly,
+        initialValue = ConnectivityState.DISCONNECTED,
+    )
 
     private fun calculateConnectivityState(capabilities: NetworkCapabilities?): ConnectivityState {
         if (capabilities == null) return ConnectivityState.DISCONNECTED

--- a/app/src/test/java/to/bitkit/repositories/HealthRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/HealthRepoTest.kt
@@ -36,7 +36,7 @@ class HealthRepoTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        whenever(connectivityRepo.isOnline).thenReturn(flowOf(ConnectivityState.CONNECTED))
+        whenever(connectivityRepo.isOnline).thenReturn(MutableStateFlow(ConnectivityState.CONNECTED))
         whenever(lightningRepo.lightningState).thenReturn(MutableStateFlow(LightningState()))
         whenever(blocktankRepo.blocktankState).thenReturn(MutableStateFlow(BlocktankState()))
         whenever(cacheStore.backupStatuses).thenReturn(flowOf(emptyMap()))
@@ -245,7 +245,7 @@ class HealthRepoTest : BaseUnitTest() {
 
     @Test
     fun `all statuses except backup go to error when internet connectivity is off`() = test {
-        whenever(connectivityRepo.isOnline).thenReturn(flowOf(ConnectivityState.DISCONNECTED))
+        whenever(connectivityRepo.isOnline).thenReturn(MutableStateFlow(ConnectivityState.DISCONNECTED))
 
         // Set up conditions that would normally be READY/PENDING if online
         val mockChannel = mock<ChannelDetails> {
@@ -317,7 +317,7 @@ class HealthRepoTest : BaseUnitTest() {
 
     @Test
     fun `internet status maps to error when disconnected`() = test {
-        whenever(connectivityRepo.isOnline).thenReturn(flowOf(ConnectivityState.DISCONNECTED))
+        whenever(connectivityRepo.isOnline).thenReturn(MutableStateFlow(ConnectivityState.DISCONNECTED))
 
         sut = createSut()
 
@@ -378,7 +378,7 @@ class HealthRepoTest : BaseUnitTest() {
 
     @Test
     fun `isOnline returns false when internet is not ready`() = test {
-        whenever(connectivityRepo.isOnline).thenReturn(flowOf(ConnectivityState.DISCONNECTED))
+        whenever(connectivityRepo.isOnline).thenReturn(MutableStateFlow(ConnectivityState.DISCONNECTED))
 
         sut = createSut()
 

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.synonym.bitkitcore.FeeRates
 import com.synonym.bitkitcore.IBtInfo
 import com.synonym.bitkitcore.ILspNode
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -68,7 +69,7 @@ class LightningRepoTest : BaseUnitTest() {
     @Before
     fun setUp() = runBlocking {
         whenever(coreService.isGeoBlocked()).thenReturn(false)
-        whenever(connectivityRepo.isOnline).thenReturn(flowOf(ConnectivityState.CONNECTED))
+        whenever(connectivityRepo.isOnline).thenReturn(MutableStateFlow(ConnectivityState.CONNECTED))
         sut = LightningRepo(
             bgDispatcher = testDispatcher,
             lightningService = lightningService,
@@ -382,7 +383,7 @@ class LightningRepoTest : BaseUnitTest() {
     fun `sendOnChain should fail when sync is unhealthy`() = test {
         // Start node but make sync fail (isSyncHealthy = false)
         // Mock connectivity as disconnected to prevent retry loop from running indefinitely
-        whenever(connectivityRepo.isOnline).thenReturn(flowOf(ConnectivityState.DISCONNECTED))
+        whenever(connectivityRepo.isOnline).thenReturn(MutableStateFlow(ConnectivityState.DISCONNECTED))
         sut.setInitNodeLifecycleState()
         whenever(lightningService.node).thenReturn(mock())
         whenever(lightningService.setup(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(Unit)


### PR DESCRIPTION
This PR converts the `ConnectivityRepo.isOnline` flow to a shared `StateFlow` so all collectors share a single network callback registration.

### Description

Previously, each component collecting from `isOnline` created its own Android `NetworkCallback` registration. This caused multiple "Network callback registered" log entries and inefficient resource usage.

Changes:
- Converts `callbackFlow` to a shared `StateFlow` using `.stateIn()`
- Uses `SharingStarted.Eagerly` since connectivity state is needed immediately at app startup
- Updates test mocks to use `MutableStateFlow` instead of `flowOf()`

### Preview

[internet-connection.webm](https://github.com/user-attachments/assets/a50d4b85-a1a7-43fa-bc1f-3b7d615b1dbe)

### QA Notes

1. Build and run the app
2. Check logcat for connectivity messages
3. Verify only ONE "Network callback registered" message appears per app session
4. Navigate between screens to confirm no additional callback registrations occur
5. Toggle airplane mode on/off and verify connectivity state updates correctly