### PR TITLE
fix: increase chatwoot timeout to 1 minute

### DIFF
--- a/app/src/main/java/to/bitkit/di/HttpModule.kt
+++ b/app/src/main/java/to/bitkit/di/HttpModule.kt
@@ -46,8 +46,8 @@ object HttpModule {
     @Suppress("MagicNumber")
     private fun HttpTimeoutConfig.defaultTimeoutConfig() {
         requestTimeoutMillis = 60_000
-        connectTimeoutMillis = 30_000
-        socketTimeoutMillis = 30_000
+        connectTimeoutMillis = 60_000
+        socketTimeoutMillis = 60_000
     }
 
     private fun LoggingConfig.defaultLoggingConfig() {


### PR DESCRIPTION
Fixes #618

This PR increases the HTTP connect and socket timeouts from 30 seconds to 60 seconds to resolve Chatwoot API timeout errors when submitting support requests.

### Description

Users were experiencing frequent failures when using Settings > Support > Report Issue. The error logs showed:
```
Connect timeout has expired [url=https://synonym.to/api/chatwoot, connect_timeout=30000 ms]
```

The Chatwoot API can be slow to respond, causing connections to timeout before completing. This change increases both `connectTimeoutMillis` and `socketTimeoutMillis` to 60 seconds (matching the existing `requestTimeoutMillis`) to give the API more time to respond.

### Preview

N/A - No UI changes

### QA Notes

#### 1. Submit support request
1. Go to Settings > Support > Report Issue
2. Enter an email address and message
3. Tap Send
4. Verify the request completes successfully without timeout errors

#### 2. Regression - Other HTTP calls
1. Verify Lightning channel operations work normally
2. Verify Blocktank API calls work as expected