### PR TITLE
fix: remove empty message parameter from bip21 urls

### DIFF
--- a/app/src/main/java/to/bitkit/utils/Bip21Utils.kt
+++ b/app/src/main/java/to/bitkit/utils/Bip21Utils.kt
@@ -37,8 +37,8 @@ object Bip21Utils {
         }
 
         // Add optional parameters
-        label?.let { queryParams.add("label=${it.encodeToUrl()}") }
-        message?.let { queryParams.add("message=${it.encodeToUrl()}") }
+        if (!label.isNullOrBlank()) { queryParams.add("label=${label.encodeToUrl()}") }
+        if (!message.isNullOrBlank()) { queryParams.add("message=${message.encodeToUrl()}") }
 
         // Add query parameters if any exist
         if (queryParams.isNotEmpty()) {

--- a/app/src/test/java/to/bitkit/utils/Bip21UrlBuilderTest.kt
+++ b/app/src/test/java/to/bitkit/utils/Bip21UrlBuilderTest.kt
@@ -215,4 +215,63 @@ class Bip21UrlBuilderTest {
         val input = first + second
         Assert.assertTrue(isDuplicatedBip21(input))
     }
+
+    // Tests for empty/blank message and label handling - Issue #746
+
+    @Test
+    fun `address with null message produces no message parameter`() {
+        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        val expected = "bitcoin:$address"
+        Assert.assertEquals(expected, buildBip21Url(address, message = null))
+    }
+
+    @Test
+    fun `address with empty message produces no message parameter`() {
+        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        val expected = "bitcoin:$address"
+        Assert.assertEquals(expected, buildBip21Url(address, message = ""))
+    }
+
+    @Test
+    fun `address with blank message produces no message parameter`() {
+        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        val expected = "bitcoin:$address"
+        Assert.assertEquals(expected, buildBip21Url(address, message = "   "))
+    }
+
+    @Test
+    fun `address with null label produces no label parameter`() {
+        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        val expected = "bitcoin:$address?message=Bitkit"
+        Assert.assertEquals(expected, buildBip21Url(address, label = null))
+    }
+
+    @Test
+    fun `address with empty label produces no label parameter`() {
+        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        val expected = "bitcoin:$address?message=Bitkit"
+        Assert.assertEquals(expected, buildBip21Url(address, label = ""))
+    }
+
+    @Test
+    fun `address with blank label produces no label parameter`() {
+        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        val expected = "bitcoin:$address?message=Bitkit"
+        Assert.assertEquals(expected, buildBip21Url(address, label = "   "))
+    }
+
+    @Test
+    fun `address with empty message and label produces clean URL`() {
+        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        val expected = "bitcoin:$address"
+        Assert.assertEquals(expected, buildBip21Url(address, label = "", message = ""))
+    }
+
+    @Test
+    fun `address with lightning but empty message produces correct URL`() {
+        val address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        val invoice = "lnbc100n1p3k9v3pp5kzmj..."
+        val expected = "bitcoin:$address?lightning=${invoice.encodeToUrl()}"
+        Assert.assertEquals(expected, buildBip21Url(address, message = "", lightningInvoice = invoice))
+    }
 }


### PR DESCRIPTION
Fixes #746

This PR removes the unnecessary empty `message=` parameter from BIP21 Bitcoin addresses when copying them.

### Description

When copying on-chain or unified addresses, the app was appending an empty `?message=` parameter:
- `bitcoin:bcrt1q7ed23dp6qcq7z9nkqafw46qrulsp5rga40m820?message=`

This happened because `buildBip21Url()` used `?.let` to check for null values, but empty strings passed through and still added the parameter. The fix changes both `label` and `message` parameters to use `isNullOrBlank()` checks, consistent with how `lightningInvoice` is already handled in the same function.

### Preview

[Screen_recording_20260129_100429.webm](https://github.com/user-attachments/assets/e740a6f5-18d9-4b45-8f69-18680163fdb5)

[Screen_recording_20260129_100539.webm](https://github.com/user-attachments/assets/824d3e7b-f8b8-472b-be1c-f1bb9f284fd8)

### QA Notes

#### 1. Copy on-chain address without amount
1. Go to Receive > Savings
2. Copy the address
3. Paste and verify no `?message=` parameter appears
4. Expected: `bitcoin:bcrt1q...` (no query string)

#### 2. Copy unified address without amount
1. Go to Receive > Auto
2. Copy the address
3. Paste and verify no `?message=` in the Bitcoin portion
4. Expected: `bitcoin:bcrt1q...?lightning=lnbcrt...`

#### 3. Receive with custom description
1. Go to Receive > Savings
2. Tap "Add description" and enter a message
3. Copy the address
4. Verify `?message=YourMessage` appears correctly
5. Expected: `bitcoin:bcrt1q...?message=YourMessage`

#### 4. Receive with amount
1. Go to Receive > Savings
2. Set an amount (e.g., 1000 sats)
3. Copy the address
4. Verify address includes amount but no empty message
5. Expected: `bitcoin:bcrt1q...?amount=0.00001`