### PR TITLE
fix: show tab bar on savings and spending screens

### DIFF
--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -477,6 +477,8 @@ fun ContentView(
                     val showTabBar = currentRoute in listOf(
                         Routes.Home::class.qualifiedName,
                         Routes.AllActivity::class.qualifiedName,
+                        Routes.Savings::class.qualifiedName,
+                        Routes.Spending::class.qualifiedName,
                     )
 
                     if (showTabBar) {


### PR DESCRIPTION
Fixes #696

This PR fixes the missing Send and Receive buttons on the Savings and Spending activity screens.

### Description

When navigating to the Savings or Spending balance screens, the tab bar (containing Send and Receive buttons) was not visible. This was because the tab bar visibility logic only included the Home and AllActivity routes. This PR adds the Savings and Spending routes to the list of screens where the tab bar should be displayed.

### Preview

[Screen_recording_20260129_124425.webm](https://github.com/user-attachments/assets/32379315-8e4a-4b62-9299-0b47c10d6110)


### QA Notes

#### 1. Savings screen tab bar
1. Open the wallet
2. Tap on Savings balance
3. Verify the tab bar with Send and Receive buttons is visible at the bottom

#### 2. Spending screen tab bar
1. Open the wallet
2. Tap on Spending balance
3. Verify the tab bar with Send and Receive buttons is visible at the bottom

#### 3. Regression - Home and Activity screens
1. Verify tab bar still appears on Home screen
2. Verify tab bar still appears on All Activity screen