### PR TITLE
fix: hide monetary values in activity detail

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityDetailScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityDetailScreen.kt
@@ -1,5 +1,6 @@
 package to.bitkit.ui.screens.wallets.activity
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -75,6 +76,9 @@ import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.screens.wallets.activity.components.ActivityAddTagSheet
 import to.bitkit.ui.screens.wallets.activity.components.ActivityIcon
+import to.bitkit.ui.settingsViewModel
+import to.bitkit.ui.shared.UiConstants
+import to.bitkit.ui.shared.animations.BalanceAnimations
 import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.sheets.BoostTransactionSheet
@@ -314,6 +318,9 @@ private fun ActivityDetailContent(
     onCopy: (String) -> Unit,
     feeRates: FeeRates? = null,
 ) {
+    val settings = settingsViewModel ?: return
+    val hideBalance by settings.hideBalance.collectAsStateWithLifecycle()
+
     val isLightning = item is Activity.Lightning
     val isSent = item.isSent()
     val isTransfer = item.isTransfer()
@@ -376,7 +383,7 @@ private fun ActivityDetailContent(
                 sats = item.totalValue().toLong(),
                 prefix = amountPrefix,
                 showBitcoinSymbol = false,
-                useSwipeToHide = false,
+                useSwipeToHide = true,
                 modifier = Modifier.weight(1f)
             )
             ActivityIcon(
@@ -468,7 +475,17 @@ private fun ActivityDetailContent(
                             modifier = Modifier.size(16.dp)
                         )
                         Spacer(modifier = Modifier.width(4.dp))
-                        MoneySSB(sats = displayAmount.toLong())
+                        AnimatedContent(
+                            targetState = hideBalance,
+                            transitionSpec = { BalanceAnimations.activityAmountTransition },
+                            label = "amountAnimation"
+                        ) { isHidden ->
+                            if (isHidden) {
+                                BodySSB(text = UiConstants.HIDE_BALANCE_SHORT)
+                            } else {
+                                MoneySSB(sats = displayAmount.toLong())
+                            }
+                        }
                     }
                     Spacer(modifier = Modifier.height(16.dp))
                     HorizontalDivider()
@@ -495,7 +512,17 @@ private fun ActivityDetailContent(
                                 modifier = Modifier.size(16.dp)
                             )
                             Spacer(modifier = Modifier.width(4.dp))
-                            MoneySSB(sats = fee.toLong())
+                            AnimatedContent(
+                                targetState = hideBalance,
+                                transitionSpec = { BalanceAnimations.activityAmountTransition },
+                                label = "feeAnimation"
+                            ) { isHidden ->
+                                if (isHidden) {
+                                    BodySSB(text = UiConstants.HIDE_BALANCE_SHORT)
+                                } else {
+                                    MoneySSB(sats = fee.toLong())
+                                }
+                            }
                         }
                         Spacer(modifier = Modifier.height(16.dp))
                         HorizontalDivider()


### PR DESCRIPTION
Fixes #732

This PR fixes monetary values not being hidden on the activity detail page when the user has enabled balance hiding.

### Description

When users swipe to hide their balance, values are hidden throughout the app (home page, confetti sheet, activity list) but the individual activity detail page still displayed bitcoin and fiat amounts. This PR:

1. Enables the swipe-to-hide gesture on the balance header in activity detail
2. Hides the payment amount and fee values when balance hiding is active

### Preview

[Screen_recording_20260129_131012.webm](https://github.com/user-attachments/assets/0399719b-8137-4905-97ea-d1aa9bce2e9e)

[Screen_recording_20260129_131210.webm](https://github.com/user-attachments/assets/0ad2aade-b3f8-4e61-bcbb-f633c867b02e)


### QA Notes

#### 1. Activity detail with hidden balance
1. Open the wallet
2. Swipe on the balance to hide it
3. Tap on any activity in the list
4. Verify the header balance shows `• • • • • • • • •`
5. Verify the payment amount shows `• • • • •`
6. Verify the fee amount shows `• • • • •` (if applicable)

#### 2. Swipe to toggle on activity detail
1. With balance visible, tap on an activity
2. Swipe on the balance header to hide
3. Verify all monetary values are hidden
4. Swipe again to show
5. Verify all values are visible again

#### 3. Regression - Balance visible
1. Ensure balance is visible (not hidden)
2. Tap on any activity
3. Verify all amounts display correctly with proper currency formatting