### PR TITLE
fix: prevent accidental sheet dismissal when tapping amount

### DIFF
--- a/app/src/main/java/to/bitkit/ui/sheets/NewTransactionSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/NewTransactionSheet.kt
@@ -156,7 +156,6 @@ fun NewTransactionSheetView(
 
             BalanceHeaderView(
                 sats = details.sats,
-                onClick = onDetailClick,
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag("ReceivedTransaction")


### PR DESCRIPTION
Fixes #648

This PR removes the tap action from the balance header on the received/sent confetti sheet to prevent unintended sheet dismissal.

### Description

When receiving or sending a payment, the confetti sheet displays a balance header showing the transaction amount. Previously, tapping this amount would close the sheet, which was confusing and unexpected. On iOS, this same interaction swaps between bitcoin and fiat display. This fix removes the `onClick` handler from the `BalanceHeaderView` in `NewTransactionSheet` to match expected behavior.

### Preview

[receive.webm](https://github.com/user-attachments/assets/dd23d325-2378-4c2c-9137-d1e8282a8f99)

[send.webm](https://github.com/user-attachments/assets/74b4fe3f-b552-4eba-ac38-5ede60320a9d)

### QA Notes

#### 1. Tap amount on received confetti sheet
1. Receive a payment (LN or on-chain)
2. Wait for the confetti sheet to appear
3. Tap on the bitcoin amount displayed
4. Verify the sheet remains open (does not dismiss)

#### 2. Tap amount on sent confetti sheet
1. Send a payment (LN or on-chain)
2. Wait for the confetti sheet to appear
3. Tap on the bitcoin amount displayed
4. Verify the sheet remains open (does not dismiss)

#### 3. Regression - Sheet dismissal
1. Receive or send a payment
2. Verify the sheet can still be dismissed by:
   - Tapping the close button
   - Swiping down
   - Tapping outside the sheet content