### PR TITLE
fix: configure routing params for single lsp

### DIFF
--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -34,6 +34,7 @@ import org.lightningdevkit.ldknode.NodeStatus
 import org.lightningdevkit.ldknode.PaymentDetails
 import org.lightningdevkit.ldknode.PaymentId
 import org.lightningdevkit.ldknode.PeerDetails
+import org.lightningdevkit.ldknode.RouteParametersConfig
 import org.lightningdevkit.ldknode.SpendableUtxo
 import org.lightningdevkit.ldknode.Txid
 import org.lightningdevkit.ldknode.defaultConfig
@@ -121,6 +122,12 @@ class LightningService @Inject constructor(
             anchorChannelsConfig = AnchorChannelsConfig(
                 trustedPeersNoReserve = trustedPeerNodeIds,
                 perChannelReserveSats = 1u,
+            ),
+            routeParameters = RouteParametersConfig(
+                maxTotalRoutingFeeMsat = null,
+                maxTotalCltvExpiryDelta = 1008u,
+                maxPathCount = 10u.toUByte(),
+                maxChannelSaturationPowerOfHalf = 1u.toUByte(),
             ),
             includeUntrustedPendingInSpendable = true,
         )


### PR DESCRIPTION
This PR configures explicit LDK routing parameters optimized for the single-LSP topology that most users operate in.

### Description

The default `RouteParametersConfig` from LDK may be too restrictive for our setup where most users route all payments through a single LSP. This adds explicit routing parameters to the node config:
1. Removes routing fee cap (`maxTotalRoutingFeeMsat = null`) to avoid rejecting valid routes
2. Sets CLTV expiry delta to 1008 blocks (~1 week)
3. Allows up to 10 multi-path payment splits for better payment success
4. Lowers channel saturation threshold for more aggressive channel utilization

### Preview

N/A - no UI changes

### QA Notes

#### 1. Outbound Lightning payment
1. Build and install a dev build
2. Send a Lightning payment of a small amount through the default LSP
3. Verify the payment completes successfully

#### 2. Varying amounts
1. Send payments of varying sizes (small, medium, larger)
2. Verify all payments route and complete successfully

#### 3. Receive payment
1. Generate a Lightning invoice
2. Pay it from an external wallet
3. Verify the payment is received successfully

#### 4. Regression check
1. Verify channel opens with the LSP still succeed
2. Verify on-chain transactions still work as expected