### PR TITLE
fix: update balance on channel close from connections

### DIFF
--- a/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsViewModel.kt
@@ -461,6 +461,7 @@ class LightningConnectionsViewModel @Inject constructor(
                         channelId = channel.channelId,
                         fundingTxId = channel.fundingTxo?.txid,
                     )
+                    walletRepo.syncNodeAndWallet()
 
                     ToastEventBus.send(
                         type = Toast.ToastType.SUCCESS,


### PR DESCRIPTION
Fixes #721

### Description

This PR creates a transfer activity record when closing a channel from the Connections screen, matching the existing behavior in the Transfer to Savings flow.

When closing via Connections > Detail > Close Connection, no `TransferEntity` was created, so `DeriveBalanceStateUseCase` had no record to subtract the closing channel's balance from the displayed spending total. The Transfer to Savings flow already handled this correctly by calling `transferRepo.createTransfer()` with type `COOP_CLOSE` after a successful close.

### Preview

[Screen_recording_20260210_141203.webm](https://github.com/user-attachments/assets/b9a5a905-2150-4899-b050-02fd90b54ff0)

### QA Notes

1. Setup a wallet with 2 open channels
2. Navigate to Settings > Connections
3. Select a channel and tap "Close Connection"
4. Verify the spending balance on the home screen decreases after the close
5. Force stop and reopen the app -- verify the balance remains correct