### PR TITLE
fix: crash in backup confirm mnemonic screen

### DIFF
--- a/app/src/main/java/to/bitkit/ui/settings/backups/ConfirmMnemonicScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/ConfirmMnemonicScreen.kt
@@ -73,8 +73,10 @@ fun ConfirmMnemonicScreen(
         pressedStates = pressedStates,
         isComplete = isComplete,
         onWordPress = { word, shuffledIndex ->
-            // Find index of the last filled word
-            val lastIndex = selectedWords.indexOfFirst { it == null } - 1
+            val firstNullIndex = selectedWords.indexOfFirst { it == null }
+            if (firstNullIndex == -1) return@ConfirmMnemonicContent
+
+            val lastIndex = firstNullIndex - 1
             val nextIndex = if (lastIndex == -1) 0 else lastIndex + 1
 
             // If the word is correct and pressed, do nothing


### PR DESCRIPTION
Fixes #778

This PR fixes a crash in the backup mnemonic confirmation screen that occurs when tapping a word button after all words have already been selected.

### Description

When all seed words are correctly placed, tapping any remaining word button causes an `ArrayIndexOutOfBoundsException` (index -1). The root cause is that `indexOfFirst { it == null }` returns -1 when no slots are empty, leading to an invalid array index of -1 in the word placement logic. The fix adds an early return when all slots are filled, preventing any further word selection attempts.

### Preview

[Screen_recording_20260213_135453.webm](https://github.com/user-attachments/assets/3b61357f-79d5-483a-8ea8-4ff52dfb1f53)


### QA Notes

#### 1. Complete seed and tap extra word
1. Go to Settings > Backup > Confirm Mnemonic
2. Select all 12 (or 24) words in the correct order
3. Tap any word button again
4. Verify the app does not crash and the tap is ignored

#### 2. Normal flow still works
1. Start the confirm mnemonic flow
2. Select words in the correct order
3. Verify incorrect words show in red and can be unchecked
4. Verify the Continue button enables only when all words match