### PR TITLE
chore: bump version 2.0.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,8 +55,8 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 175
-        versionName = "2.0.1"
+        versionCode = 176
+        versionName = "2.0.2"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         vectorDrawables {
             useSupportLibrary = true


### PR DESCRIPTION
Bump version to 2.0.2 (build 176) for release.

### Description

- `versionCode`: 175 → 176
- `versionName`: 2.0.1 → 2.0.2
- draft release: [`v2.0.2`](https://github.com/synonymdev/bitkit-android/releases/tag/untagged-7b4c052516e62473150f) including manually merged PRs:
  - #779
  - #785
  - #786

### Preview

N/A

### QA Notes

N/A
