### PR TITLE
refactor: replace Spacer with custom spacers

### DIFF
--- a/app/src/main/java/to/bitkit/ui/components/AuthCheckView.kt
+++ b/app/src/main/java/to/bitkit/ui/components/AuthCheckView.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -179,7 +178,7 @@ private fun PinPad(
                         .testTag("AttemptsRemaining")
                 )
             }
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
 
         if (allowBiometrics) {
@@ -199,7 +198,7 @@ private fun PinPad(
                     )
                 },
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
 
         PinDots(

--- a/app/src/main/java/to/bitkit/ui/components/BalanceHeaderView.kt
+++ b/app/src/main/java/to/bitkit/ui/components/BalanceHeaderView.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -162,7 +161,7 @@ fun BalanceHeader(
             )
 
             if (showEyeIcon) {
-                Spacer(modifier = Modifier.weight(1f))
+                FillWidth()
                 AnimatedContent(
                     targetState = hideBalance,
                     transitionSpec = { BalanceAnimations.eyeIconTransition },

--- a/app/src/main/java/to/bitkit/ui/components/BiometricsView.kt
+++ b/app/src/main/java/to/bitkit/ui/components/BiometricsView.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -61,7 +59,7 @@ fun BiometricsView(
             contentDescription = null,
             modifier = Modifier.size(64.dp),
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
         Subtitle(
             text = run {
                 val biometricsName = stringResource(R.string.security__bio)

--- a/app/src/main/java/to/bitkit/ui/components/EmptyWalletView.kt
+++ b/app/src/main/java/to/bitkit/ui/components/EmptyWalletView.kt
@@ -4,9 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -42,7 +40,7 @@ fun EmptyStateView(
             modifier = Modifier
                 .padding(bottom = 130.dp)
         ) {
-            Spacer(modifier = Modifier.height(6.dp))
+            VerticalSpacer(6.dp)
             Row(
                 verticalAlignment = Alignment.Bottom,
                 modifier = Modifier
@@ -61,7 +59,7 @@ fun EmptyStateView(
                         .heightIn(max = 144.dp)
                         .offset(x = (-10).dp)
                 )
-                Spacer(modifier = Modifier.weight(1f))
+                FillWidth()
             }
         }
         if (onClose != null) {

--- a/app/src/main/java/to/bitkit/ui/components/FeeInfo.kt
+++ b/app/src/main/java/to/bitkit/ui/components/FeeInfo.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
@@ -28,9 +26,9 @@ fun RowScope.FeeInfo(
             text = label,
             color = Colors.White64,
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        VerticalSpacer(8.dp)
         MoneySSB(sats = amount)
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
         HorizontalDivider(modifier = Modifier.padding(top = 16.dp))
     }
 }

--- a/app/src/main/java/to/bitkit/ui/components/InfoScreenContent.kt
+++ b/app/src/main/java/to/bitkit/ui/components/InfoScreenContent.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -55,12 +53,12 @@ fun InfoScreenContent(
                 .padding(horizontal = 16.dp)
                 .testTag(testTag)
         ) {
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             Display(text = title)
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(text = description, color = Colors.White64)
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Box(
                 contentAlignment = Alignment.Center,
@@ -77,13 +75,13 @@ fun InfoScreenContent(
                 )
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
             PrimaryButton(
                 text = buttonText,
                 onClick = onButtonClick,
                 modifier = Modifier.testTag("$testTag-button")
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/components/LightningChannel.kt
+++ b/app/src/main/java/to/bitkit/ui/components/LightningChannel.kt
@@ -7,13 +7,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
@@ -62,7 +60,7 @@ fun LightningChannel(
                 Caption13Up(text = stringResource(R.string.lightning__spending_label), color = Colors.White64)
                 Caption13Up(text = stringResource(R.string.lightning__receiving_label), color = Colors.White64)
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
         }
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -93,7 +91,7 @@ fun LightningChannel(
                 )
             }
         }
-        Spacer(modifier = Modifier.height(8.dp))
+        VerticalSpacer(8.dp)
         Row(
             verticalAlignment = CenterVertically,
             modifier = Modifier
@@ -114,7 +112,7 @@ fun LightningChannel(
                         .background(spendingAvailableColor, RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp))
                 )
             }
-            Spacer(modifier = Modifier.width(4.dp))
+            HorizontalSpacer(4.dp)
             Box(
                 modifier = Modifier
                     .weight(1f)

--- a/app/src/main/java/to/bitkit/ui/components/MnemonicWordsGrid.kt
+++ b/app/src/main/java/to/bitkit/ui/components/MnemonicWordsGrid.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -92,7 +90,7 @@ private fun WordItem(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         BodyMSB(text = "$number.", color = Colors.White64)
-        Spacer(modifier = Modifier.width(8.dp))
+        HorizontalSpacer(8.dp)
         BodyMSB(text = word, color = Colors.White)
     }
 }

--- a/app/src/main/java/to/bitkit/ui/components/SearchInput.kt
+++ b/app/src/main/java/to/bitkit/ui/components/SearchInput.kt
@@ -4,12 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -145,7 +143,7 @@ private fun PreviewWithTrailingIcons() {
                         isActive = true,
                         onClick = {}
                     )
-                    Spacer(modifier = Modifier.width(12.dp))
+                    HorizontalSpacer(12.dp)
                     SearchInputIconButton(
                         iconRes = R.drawable.ic_calendar,
                         isActive = false,

--- a/app/src/main/java/to/bitkit/ui/components/Spacers.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Spacers.kt
@@ -15,44 +15,56 @@ import to.bitkit.ui.theme.Insets
 import to.bitkit.ui.theme.TopBarHeight
 
 @Composable
-fun VerticalSpacer(height: Dp) {
-    Spacer(modifier = Modifier.height(height))
+fun VerticalSpacer(
+    height: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Spacer(modifier = modifier then Modifier.height(height))
 }
 
 @Composable
-fun ColumnScope.VerticalSpacer(minHeight: Dp, maxHeight: Dp) {
+fun ColumnScope.VerticalSpacer(
+    minHeight: Dp,
+    maxHeight: Dp,
+    modifier: Modifier = Modifier,
+) {
     Spacer(
-        modifier = Modifier
+        modifier = modifier then Modifier
             .weight(1f)
             .sizeIn(minHeight = minHeight, maxHeight = maxHeight)
     )
 }
 
 @Composable
-fun HorizontalSpacer(width: Dp) {
-    Spacer(modifier = Modifier.width(width))
+fun HorizontalSpacer(
+    width: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Spacer(modifier = modifier then Modifier.width(width))
 }
 
 @Suppress("ComposeMultipleContentEmitters")
 @Composable
 fun ColumnScope.FillHeight(
+    modifier: Modifier = Modifier,
     @FloatRange weight: Float = 1f,
     fill: Boolean = true,
     min: Dp = 0.dp,
 ) {
-    if (min > 0.dp) Spacer(modifier = Modifier.height(min))
-    Spacer(modifier = Modifier.weight(weight, fill = fill))
+    if (min > 0.dp) Spacer(modifier = modifier then Modifier.height(min))
+    Spacer(modifier = modifier then Modifier.weight(weight, fill = fill))
 }
 
 @Suppress("ComposeMultipleContentEmitters")
 @Composable
 fun RowScope.FillWidth(
+    modifier: Modifier = Modifier,
     @FloatRange weight: Float = 1f,
     fill: Boolean = true,
     min: Dp = 0.dp,
 ) {
-    if (min > 0.dp) Spacer(modifier = Modifier.width(min))
-    Spacer(modifier = Modifier.weight(weight, fill = fill))
+    if (min > 0.dp) Spacer(modifier = modifier then Modifier.width(min))
+    Spacer(modifier = modifier then Modifier.weight(weight, fill = fill))
 }
 
 @Composable

--- a/app/src/main/java/to/bitkit/ui/components/SyncNodeView.kt
+++ b/app/src/main/java/to/bitkit/ui/components/SyncNodeView.kt
@@ -1,9 +1,7 @@
 package to.bitkit.ui.components
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,7 +21,7 @@ fun SyncNodeView(modifier: Modifier) {
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Spacer(Modifier.height(32.dp))
+        VerticalSpacer(32.dp)
 
         BodyM(
             text = stringResource(R.string.lightning__wait_text_top),
@@ -31,7 +29,7 @@ fun SyncNodeView(modifier: Modifier) {
             modifier = Modifier.padding(horizontal = 16.dp)
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         TransferAnimationView(
             largeCircleRes = R.drawable.ln_sync_large,
@@ -40,11 +38,11 @@ fun SyncNodeView(modifier: Modifier) {
             rotateContent = false
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         BodySSB(text = stringResource(R.string.lightning__wait_text_bottom), color = Colors.White32)
 
-        Spacer(modifier = Modifier.height(32.dp))
+        VerticalSpacer(32.dp)
     }
 }
 

--- a/app/src/main/java/to/bitkit/ui/components/TabBar.kt
+++ b/app/src/main/java/to/bitkit/ui/components/TabBar.kt
@@ -6,14 +6,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -92,7 +90,7 @@ fun BoxScope.TabBar(
                         contentDescription = stringResource(R.string.wallet__send),
                         modifier = Modifier.size(iconSize)
                     )
-                    Spacer(Modifier.width(iconToTextGap))
+                    HorizontalSpacer(iconToTextGap)
                     BodySSB(text = stringResource(R.string.wallet__send))
                 }
             }
@@ -113,7 +111,7 @@ fun BoxScope.TabBar(
                         contentDescription = stringResource(R.string.wallet__receive),
                         modifier = Modifier.size(iconSize)
                     )
-                    Spacer(Modifier.width(iconToTextGap))
+                    HorizontalSpacer(iconToTextGap)
                     BodySSB(text = stringResource(R.string.wallet__receive))
                 }
             }

--- a/app/src/main/java/to/bitkit/ui/components/WalletBalanceView.kt
+++ b/app/src/main/java/to/bitkit/ui/components/WalletBalanceView.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -106,7 +105,7 @@ private fun RowScope.Content(
             text = title,
             color = Colors.White64,
         )
-        Spacer(modifier = Modifier.height(8.dp))
+        VerticalSpacer(8.dp)
 
         converted?.let { converted ->
             Row(

--- a/app/src/main/java/to/bitkit/ui/components/settings/SettingsButtonRow.kt
+++ b/app/src/main/java/to/bitkit/ui/components/settings/SettingsButtonRow.kt
@@ -4,13 +4,10 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -30,6 +27,8 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.BodyS
 import to.bitkit.ui.components.BodySSB
+import to.bitkit.ui.components.HorizontalSpacer
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
@@ -74,7 +73,7 @@ fun SettingsButtonRow(
                         tint = iconTint,
                         modifier = Modifier.size(iconSize),
                     )
-                    Spacer(modifier = Modifier.width(10.dp))
+                    HorizontalSpacer(10.dp)
                 }
                 Column(
                     verticalArrangement = Arrangement.Center,
@@ -84,7 +83,7 @@ fun SettingsButtonRow(
                 ) {
                     if (subtitle != null) {
                         BodyMSB(text = title)
-                        Spacer(modifier = Modifier.height(4.dp))
+                        VerticalSpacer(4.dp)
                         BodySSB(
                             text = subtitle,
                             maxLines = maxLinesSubtitle,
@@ -120,7 +119,7 @@ fun SettingsButtonRow(
 
                     is SettingsButtonValue.StringValue -> {
                         BodyM(text = value.value, modifier = Modifier.testTag("Value"))
-                        Spacer(modifier = Modifier.width(8.dp))
+                        HorizontalSpacer(8.dp)
                         Icon(
                             painter = painterResource(R.drawable.ic_chevron_right),
                             contentDescription = null,

--- a/app/src/main/java/to/bitkit/ui/components/settings/SettingsTextButtonRow.kt
+++ b/app/src/main/java/to/bitkit/ui/components/settings/SettingsTextButtonRow.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.components.settings
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -25,6 +23,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Caption
 import to.bitkit.ui.components.HorizontalSpacer
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.shared.util.screen
 import to.bitkit.ui.theme.AppThemeSurface
@@ -73,7 +72,7 @@ fun SettingsTextButtonRow(
                 ) {
                     BodyM(text = title)
                     if (description != null) {
-                        Spacer(modifier = Modifier.height(2.dp))
+                        VerticalSpacer(2.dp)
                         Caption(text = description, color = Colors.White64)
                     }
                 }

--- a/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletScreen.kt
@@ -5,9 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -88,7 +86,7 @@ fun CreateWalletScreen(
                         .testTag("RestoreWallet")
                 )
             }
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletWithPassphraseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/CreateWalletWithPassphraseScreen.kt
@@ -4,9 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -90,14 +88,14 @@ fun CreateWalletWithPassphraseScreen(
                 contentScale = ContentScale.Fit,
                 modifier = Modifier.fillMaxWidth()
             )
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             Display(text = stringResource(R.string.onboarding__passphrase_header).withAccent())
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(
                 text = stringResource(R.string.onboarding__passphrase_text),
                 color = Colors.White64,
             )
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             OutlinedTextField(
                 value = bip39Passphrase,
                 onValueChange = { bip39Passphrase = it },
@@ -115,7 +113,7 @@ fun CreateWalletWithPassphraseScreen(
                     .padding(top = 4.dp)
                     .testTag("PassphraseInput")
             )
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.onboarding__create_new_wallet),
                 onClick = { onCreateClick(bip39Passphrase) },

--- a/app/src/main/java/to/bitkit/ui/onboarding/IntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/IntroScreen.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -24,6 +22,7 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.shared.util.screen
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
@@ -67,12 +66,12 @@ fun IntroScreen(
                     .align(Alignment.BottomCenter)
             ) {
                 Display(text = stringResource(R.string.onboarding__welcome_title).withAccent())
-                Spacer(modifier = Modifier.height(8.dp))
+                VerticalSpacer(8.dp)
                 BodyM(
                     text = stringResource(R.string.onboarding__welcome_text),
                     color = Colors.White64,
                 )
-                Spacer(modifier = Modifier.height(32.dp))
+                VerticalSpacer(32.dp)
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/to/bitkit/ui/onboarding/OnboardingSlidesScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/OnboardingSlidesScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -204,7 +203,7 @@ fun OnboardingTab(
                 .align(Alignment.BottomCenter),
         ) {
             Display(text = title.withAccent(accentColor = titleAccentColor))
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(
                 text = text,
                 color = Colors.White64,

--- a/app/src/main/java/to/bitkit/ui/onboarding/RestoreWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/RestoreWalletScreen.kt
@@ -11,10 +11,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -60,6 +58,7 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyS
 import to.bitkit.ui.components.ButtonSize
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.TextInput
@@ -248,11 +247,7 @@ private fun Content(
                     )
                 }
 
-                Spacer(
-                    modifier = Modifier
-                        .height(16.dp)
-                        .weight(1f)
-                )
+                FillHeight(min = 16.dp)
 
                 AnimatedVisibility(visible = uiState.invalidWordIndices.any { it != uiState.focusedIndex }) {
                     BodyS(

--- a/app/src/main/java/to/bitkit/ui/onboarding/TermsOfUseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/TermsOfUseScreen.kt
@@ -3,7 +3,6 @@ package to.bitkit.ui.onboarding
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -60,11 +59,11 @@ fun TermsOfUseScreen(
                         .verticalScroll(rememberScrollState())
                         .testTag("TOS")
                 ) {
-                    Spacer(modifier = Modifier.height(16.dp))
+                    VerticalSpacer(16.dp)
                     Display(text = stringResource(R.string.onboarding__tos_header).withAccent())
-                    Spacer(modifier = Modifier.height(12.dp))
+                    VerticalSpacer(12.dp)
                     TosContent()
-                    Spacer(modifier = Modifier.height(20.dp))
+                    VerticalSpacer(20.dp)
                 }
                 Box(
                     modifier = Modifier
@@ -100,7 +99,7 @@ fun TermsOfUseScreen(
                         .testTag("Check2")
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                VerticalSpacer(24.dp)
 
                 PrimaryButton(
                     text = stringResource(R.string.common__continue),

--- a/app/src/main/java/to/bitkit/ui/onboarding/WarningMultipleDevicesScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/WarningMultipleDevicesScreen.kt
@@ -2,10 +2,8 @@ package to.bitkit.ui.onboarding
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -19,6 +17,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.ScreenColumn
 import to.bitkit.ui.theme.AppThemeSurface
@@ -55,14 +54,14 @@ fun WarningMultipleDevicesScreen(
                 text = stringResource(R.string.onboarding__multiple_header).withAccent(accentColor = Colors.Yellow),
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
 
             BodyM(
                 text = stringResource(R.string.onboarding__multiple_text),
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             PrimaryButton(
                 text = stringResource(R.string.common__understood),
@@ -70,7 +69,7 @@ fun WarningMultipleDevicesScreen(
                 modifier = Modifier.testTag("MultipleDevices-button")
             )
 
-            Spacer(modifier = Modifier.height(24.dp))
+            VerticalSpacer(24.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/profile/CreateProfileScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/profile/CreateProfileScreen.kt
@@ -1,7 +1,6 @@
 package to.bitkit.ui.screens.profile
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -10,6 +9,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -30,13 +30,13 @@ fun CreateProfileScreen(
         Column(
             modifier = Modifier.padding(horizontal = 32.dp)
         ) {
-            Spacer(Modifier.weight(1f))
+            FillHeight()
 
             Display(
                 text = stringResource(R.string.other__coming_soon),
                 color = Colors.White
             )
-            Spacer(Modifier.weight(1f))
+            FillHeight()
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/profile/ProfileIntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/profile/ProfileIntroScreen.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.screens.profile
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,6 +14,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -52,14 +51,14 @@ fun ProfileIntroScreen(
                 ).withAccent(accentColor = Colors.Brand),
                 color = Colors.White
             )
-            Spacer(Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(text = stringResource(R.string.slashtags__onboarding_profile1_text), color = Colors.White64)
-            Spacer(Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.common__continue),
                 onClick = onContinue
             )
-            Spacer(Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/settings/LdkDebugScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/settings/LdkDebugScreen.kt
@@ -4,9 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -29,6 +27,7 @@ import to.bitkit.ui.components.ButtonSize
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.TextInput
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SectionFooter
 import to.bitkit.ui.components.settings.SectionHeader
 import to.bitkit.ui.components.settings.SettingsTextButtonRow
@@ -150,7 +149,7 @@ private fun LdkDebugContent(
                 onClick = onRestartNode,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/settings/VssDebugScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/settings/VssDebugScreen.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -44,6 +42,7 @@ import to.bitkit.ui.components.ButtonSize
 import to.bitkit.ui.components.Caption
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.TertiaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppAlertDialog
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -231,7 +230,7 @@ private fun VssDebugContent(
                 }
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
         }
     }
 

--- a/app/src/main/java/to/bitkit/ui/screens/shop/ShopIntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/shop/ShopIntroScreen.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.screens.shop
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,6 +14,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -50,14 +49,14 @@ fun ShopIntroScreen(
                 text = stringResource(R.string.other__shop__intro__title).withAccent(accentColor = Colors.Brand),
                 color = Colors.Yellow
             )
-            Spacer(Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(text = stringResource(R.string.other__shop__intro__description), color = Colors.White64)
-            Spacer(Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.common__continue),
                 onClick = onContinue
             )
-            Spacer(Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/FundingAdvancedScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/FundingAdvancedScreen.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.screens.transfer
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,6 +14,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.RectangleButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -40,15 +39,15 @@ fun FundingAdvancedScreen(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             Display(
                 text = stringResource(
                     R.string.lightning__funding_advanced__title
                 ).withAccent(accentColor = Colors.Purple)
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(text = stringResource(R.string.lightning__funding_advanced__text), color = Colors.White64)
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/FundingScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/FundingScreen.kt
@@ -4,9 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
@@ -28,6 +26,7 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMB
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.RectangleButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -60,9 +59,9 @@ fun FundingScreen(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             Display(text = stringResource(R.string.lightning__funding__title).withAccent(accentColor = Colors.Purple))
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
 
             val text = if (isGeoBlocked) {
                 stringResource(R.string.lightning__funding__text_blocked)
@@ -71,7 +70,7 @@ fun FundingScreen(
             }
             BodyM(text = text, color = Colors.White64)
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/LiquidityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/LiquidityScreen.kt
@@ -1,9 +1,7 @@
 package to.bitkit.ui.screens.transfer
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,8 +16,10 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMB
 import to.bitkit.ui.components.ChannelStatusUi
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.LightningChannel
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -69,15 +69,15 @@ private fun LiquidityScreen(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             Display(text = stringResource(R.string.lightning__liquidity__title).withAccent(accentColor = Colors.Purple))
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(text = stringResource(R.string.lightning__liquidity__text), color = Colors.White64)
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             BodyMB(text = stringResource(R.string.lightning__liquidity__label))
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             LightningChannel(
                 capacity = channelSize,
@@ -87,13 +87,13 @@ private fun LiquidityScreen(
                 showLabels = true,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.common__understood),
                 onClick = onContinueClick,
                 modifier = Modifier.testTag("LiquidityContinue")
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsAdvancedScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsAdvancedScreen.kt
@@ -4,9 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -33,6 +31,7 @@ import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.MoneyDisplay
 import to.bitkit.ui.components.MoneySSB
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.currencyViewModel
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -116,14 +115,14 @@ private fun SavingsAdvancedContent(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             Display(text = stringResource(R.string.lightning__savings_advanced__title).withAccent())
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(
                 text = stringResource(R.string.lightning__savings_advanced__text),
                 color = Colors.White64,
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             LazyColumn(
                 modifier = Modifier.weight(1f)
@@ -142,9 +141,9 @@ private fun SavingsAdvancedContent(
             }
 
             Caption13Up(text = stringResource(R.string.lightning__savings_advanced__total), color = Colors.White64)
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             MoneyDisplay(sats = totalAmount.toLong(), onClick = onAmountClick)
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             PrimaryButton(
                 text = stringResource(R.string.common__continue),
@@ -152,7 +151,7 @@ private fun SavingsAdvancedContent(
                 enabled = channelItems.any { it.isSelected },
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsAvailabilityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsAvailabilityScreen.kt
@@ -5,9 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -22,8 +20,10 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.ScreenColumn
 import to.bitkit.ui.theme.AppThemeSurface
@@ -47,15 +47,15 @@ fun SavingsAvailabilityScreen(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             Display(text = stringResource(R.string.lightning__availability__title).withAccent())
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(
                 text = stringResource(R.string.lightning__availability__text).withAccentBoldBright(),
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
             Box(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
@@ -69,7 +69,7 @@ fun SavingsAvailabilityScreen(
                     modifier = Modifier.size(256.dp)
                 )
             }
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -88,7 +88,7 @@ fun SavingsAvailabilityScreen(
                         .testTag("AvailabilityContinue")
                 )
             }
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsConfirmScreen.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.screens.transfer
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -31,9 +29,11 @@ import to.bitkit.ext.filterOpen
 import to.bitkit.ui.components.ButtonSize
 import to.bitkit.ui.components.Caption13Up
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.MoneyDisplay
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SwipeToConfirm
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.currencyViewModel
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -110,16 +110,16 @@ private fun SavingsConfirmContent(
                 .fillMaxSize()
 
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             Display(text = stringResource(R.string.lightning__transfer__confirm).withAccent())
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Caption13Up(text = stringResource(R.string.lightning__savings_confirm__label), color = Colors.White64)
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             MoneyDisplay(sats = amount.toLong(), onClick = onAmountClick)
 
             if (hasMultiple) {
-                Spacer(modifier = Modifier.height(24.dp))
+                VerticalSpacer(24.dp)
                 if (hasSelected) {
                     PrimaryButton(
                         text = stringResource(R.string.lightning__savings_confirm__transfer_all),
@@ -137,7 +137,7 @@ private fun SavingsConfirmContent(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
             Image(
                 painter = painterResource(R.drawable.piggybank),
                 contentDescription = null,
@@ -148,7 +148,7 @@ private fun SavingsConfirmContent(
                     .align(alignment = CenterHorizontally)
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             var isLoading by remember { mutableStateOf(false) }
             SwipeToConfirm(
@@ -163,7 +163,7 @@ private fun SavingsConfirmContent(
                     }
                 }
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsIntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsIntroScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.transfer
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -21,6 +19,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.shared.util.screen
@@ -58,16 +57,16 @@ fun SavingsIntroScreen(
                 .align(Alignment.BottomCenter)
         ) {
             Display(stringResource(R.string.lightning__savings_intro__title).withAccent())
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(stringResource(R.string.lightning__savings_intro__text), color = Colors.White64)
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.lightning__savings_intro__button),
                 onClick = onContinueClick,
                 modifier = Modifier.testTag("SavingsIntro-button")
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsProgressScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SavingsProgressScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.transfer
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -29,8 +27,10 @@ import to.bitkit.R
 import to.bitkit.models.Toast
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.Sheet
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -129,13 +129,13 @@ private fun Content(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(12.dp))
+            VerticalSpacer(12.dp)
             when (progressState) {
                 SavingsProgressState.PROGRESS -> {
                     Display(
                         text = stringResource(R.string.lightning__savings_progress__title).withAccent(),
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    VerticalSpacer(8.dp)
                     BodyM(
                         text = stringResource(R.string.lightning__savings_progress__text).withAccentBoldBright(),
                         color = Colors.White64,
@@ -144,7 +144,7 @@ private fun Content(
 
                 SavingsProgressState.SUCCESS -> {
                     Display(text = stringResource(R.string.lightning__transfer_success__title_savings).withAccent())
-                    Spacer(modifier = Modifier.height(8.dp))
+                    VerticalSpacer(8.dp)
                     BodyM(
                         text = stringResource(R.string.lightning__transfer_success__text_savings),
                         color = Colors.White64,
@@ -153,14 +153,14 @@ private fun Content(
 
                 SavingsProgressState.INTERRUPTED -> {
                     Display(text = stringResource(R.string.lightning__savings_interrupted__title).withAccent())
-                    Spacer(modifier = Modifier.height(8.dp))
+                    VerticalSpacer(8.dp)
                     BodyM(
                         text = stringResource(R.string.lightning__savings_interrupted__text).withAccentBoldBright(),
                         color = Colors.White64,
                     )
                 }
             }
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
             if (progressState == SavingsProgressState.PROGRESS) {
                 TransferAnimationView(
                     largeCircleRes = R.drawable.onchain_sync_large,
@@ -189,7 +189,7 @@ private fun Content(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             if (!inProgress) {
                 PrimaryButton(
@@ -198,7 +198,7 @@ private fun Content(
                     modifier = Modifier.testTag("TransferSuccess-button")
                 )
             }
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SettingUpScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SettingUpScreen.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.screens.transfer
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -29,6 +27,7 @@ import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -109,14 +108,14 @@ private fun SettingUpScreen(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(12.dp))
+            VerticalSpacer(12.dp)
             if (inProgress) {
                 Display(
                     text = stringResource(R.string.lightning__savings_progress__title)
                         .withAccent(accentColor = Colors.Purple),
                     modifier = Modifier.fillMaxWidth(),
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                VerticalSpacer(8.dp)
                 BodyM(
                     text = stringResource(R.string.lightning__setting_up_text).withAccentBoldBright(),
                     color = Colors.White64,
@@ -127,20 +126,20 @@ private fun SettingUpScreen(
                         .withAccent(accentColor = Colors.Purple),
                     modifier = Modifier.fillMaxWidth(),
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                VerticalSpacer(8.dp)
                 BodyM(
                     text = stringResource(R.string.lightning__transfer_success__text_spending),
                     color = Colors.White64,
                 )
             }
-            Spacer(modifier = Modifier.height(28.dp))
+            VerticalSpacer(28.dp)
             if (inProgress) {
                 TransferAnimationView(
                     largeCircleRes = R.drawable.ln_sync_large,
                     smallCircleRes = R.drawable.ln_sync_small,
                     modifier = Modifier.weight(1f)
                 )
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
                 val steps = listOf(
                     stringResource(R.string.lightning__setting_up_step1),
                     stringResource(R.string.lightning__setting_up_step2),
@@ -175,7 +174,7 @@ private fun SettingUpScreen(
                 onClick = onContinueClick,
                 modifier = Modifier.testTag("TransferSuccess-button")
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingIntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingIntroScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.transfer
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -20,6 +18,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.shared.util.screen
@@ -57,16 +56,16 @@ fun SpendingIntroScreen(
                 .align(Alignment.BottomCenter)
         ) {
             Display(stringResource(R.string.lightning__spending_intro__title).withAccent(accentColor = Colors.Purple))
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(stringResource(R.string.lightning__spending_intro__text), color = Colors.White64)
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.lightning__spending_intro__button),
                 onClick = onContinueClick,
                 modifier = Modifier.testTag("SpendingIntro-button")
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/TransferIntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/TransferIntroScreen.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.MaterialTheme
@@ -24,6 +22,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.theme.AppThemeSurface
@@ -62,16 +61,16 @@ fun TransferIntroScreen(
                 .align(Alignment.BottomCenter)
         ) {
             Display(stringResource(R.string.lightning__transfer_intro__title).withAccent(accentColor = Colors.Purple))
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(stringResource(R.string.lightning__transfer_intro__text), color = Colors.White64)
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.lightning__transfer_intro__button),
                 onClick = onContinueClick,
                 modifier = Modifier.testTag("TransferIntro-button")
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/components/ProgressSteps.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/components/ProgressSteps.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -27,6 +26,7 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import to.bitkit.ui.components.BodySSB
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 
@@ -104,7 +104,7 @@ fun ProgressSteps(
                 }
             }
         }
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
         BodySSB(text = steps[activeStepIndex], color = Colors.White32)
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalAmountScreen.kt
@@ -3,10 +3,8 @@ package to.bitkit.ui.screens.transfer.external
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
@@ -125,7 +123,7 @@ private fun Content(
                         text = stringResource(R.string.wallet__send_available),
                         color = Colors.White64,
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    VerticalSpacer(8.dp)
                     MoneySSB(sats = amountState.max, showSymbol = true)
                 }
                 FillWidth()

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalConfirmScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -26,7 +25,9 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.FeeInfo
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.SwipeToConfirm
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -81,9 +82,9 @@ private fun Content(
             val serviceFee = 0L
             val totalFee = uiState.amount.sats + networkFee
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             Display(stringResource(R.string.lightning__transfer__confirm).withAccent(accentColor = Colors.Purple))
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -112,7 +113,7 @@ private fun Content(
                 )
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Image(
                 painter = painterResource(id = R.drawable.coin_stack_x),
@@ -131,7 +132,7 @@ private fun Content(
                 onConfirm = onConfirm,
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalConnectionScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalConnectionScreen.kt
@@ -3,10 +3,8 @@ package to.bitkit.ui.screens.transfer.external
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -44,9 +42,11 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.ButtonSize
 import to.bitkit.ui.components.Caption13Up
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.TextInput
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -130,15 +130,15 @@ private fun ExternalConnectionContent(
                 .imePadding()
                 .verticalScroll(rememberScrollState())
         ) {
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             Display(stringResource(R.string.lightning__external_manual__title).withAccent(accentColor = Colors.Purple))
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(stringResource(R.string.lightning__external_manual__text), color = Colors.White64)
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             Caption13Up(text = stringResource(R.string.lightning__external_manual__node_id), color = Colors.White64)
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             TextInput(
                 placeholder = "00000000000000000000000000000000000000000000000000000000000000",
                 value = nodeId,
@@ -154,9 +154,9 @@ private fun ExternalConnectionContent(
                     .testTag("NodeIdInput")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             Caption13Up(text = stringResource(R.string.lightning__external_manual__host), color = Colors.White64)
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             TextInput(
                 placeholder = "00.00.00.00",
                 value = host,
@@ -172,9 +172,9 @@ private fun ExternalConnectionContent(
                     .testTag("HostInput")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             Caption13Up(text = stringResource(R.string.lightning__external_manual__port), color = Colors.White64)
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             TextInput(
                 placeholder = "9735",
                 value = port,
@@ -191,7 +191,7 @@ private fun ExternalConnectionContent(
                     .testTag("PortInput")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             PrimaryButton(
                 text = stringResource(R.string.lightning__external_manual__paste),
                 size = ButtonSize.Small,
@@ -206,8 +206,8 @@ private fun ExternalConnectionContent(
                 fullWidth = false,
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
-            Spacer(modifier = Modifier.weight(1f))
+            VerticalSpacer(16.dp)
+            FillHeight()
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -228,7 +228,7 @@ private fun ExternalConnectionContent(
                         .testTag("ExternalContinue")
                 )
             }
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -332,7 +331,7 @@ private fun Content(
                         .testTag("TotalBalance")
                 )
                 if (!homeUiState.showEmptyState) {
-                    Spacer(modifier = Modifier.height(32.dp))
+                    VerticalSpacer(32.dp)
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -368,9 +367,9 @@ private fun Content(
                         )
 
                         Column {
-                            Spacer(modifier = Modifier.height(32.dp))
+                            VerticalSpacer(32.dp)
                             Text13Up(stringResource(R.string.cards__suggestions), color = Colors.White64)
-                            Spacer(modifier = Modifier.height(16.dp))
+                            VerticalSpacer(16.dp)
                             LazyRow(
                                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                                 state = state,
@@ -395,7 +394,7 @@ private fun Content(
                     }
 
                     if (homeUiState.showWidgets) {
-                        Spacer(modifier = Modifier.height(32.dp))
+                        VerticalSpacer(32.dp)
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween,
@@ -420,7 +419,7 @@ private fun Content(
                             }
                         }
 
-                        Spacer(modifier = Modifier.height(16.dp))
+                        VerticalSpacer(16.dp)
 
                         if (homeUiState.isEditingWidgets) {
                             DragDropColumn(
@@ -444,7 +443,7 @@ private fun Content(
                             Widgets(homeUiState)
                         }
 
-                        Spacer(modifier = Modifier.height(32.dp))
+                        VerticalSpacer(32.dp)
                         TertiaryButton(
                             text = stringResource(R.string.widgets__add),
                             icon = {
@@ -458,7 +457,7 @@ private fun Content(
                             modifier = Modifier.testTag("WidgetsAdd")
                         )
                     }
-                    Spacer(modifier = Modifier.height(32.dp))
+                    VerticalSpacer(32.dp)
 
                     AnimatedVisibility(homeUiState.banners.isNotEmpty()) {
                         Column(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -34,6 +32,7 @@ import to.bitkit.ui.components.EmptyStateView
 import to.bitkit.ui.components.IncomingTransfer
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.TabBar
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -107,7 +106,7 @@ fun SavingsWalletScreen(
                 }
 
                 if (!showEmptyState) {
-                    Spacer(modifier = Modifier.height(32.dp))
+                    VerticalSpacer(32.dp)
 
                     if (canTransfer) {
                         SecondaryButton(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -36,6 +34,7 @@ import to.bitkit.ui.components.EmptyStateView
 import to.bitkit.ui.components.IncomingTransfer
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.TabBar
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -109,7 +108,7 @@ fun SpendingWalletScreen(
                 }
 
                 if (!showEmptyState) {
-                    Spacer(modifier = Modifier.height(32.dp))
+                    VerticalSpacer(32.dp)
 
                     if (canTransfer) {
                         SecondaryButton(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityDetailScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityDetailScreen.kt
@@ -8,13 +8,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
@@ -68,10 +66,12 @@ import to.bitkit.ui.components.BodySSB
 import to.bitkit.ui.components.BottomSheetPreview
 import to.bitkit.ui.components.ButtonSize
 import to.bitkit.ui.components.Caption13Up
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.components.MoneySSB
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.TagButton
 import to.bitkit.ui.components.Title
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.screens.wallets.activity.components.ActivityAddTagSheet
@@ -394,7 +394,7 @@ private fun ActivityDetailContent(
             ) // TODO Display the user avatar when selfSend
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
         StatusSection(item, accentColor, feeRates)
         HorizontalDivider(modifier = Modifier.padding(top = 16.dp))
 
@@ -417,10 +417,10 @@ private fun ActivityDetailContent(
                         tint = accentColor,
                         modifier = Modifier.size(16.dp)
                     )
-                    Spacer(modifier = Modifier.width(4.dp))
+                    HorizontalSpacer(4.dp)
                     BodySSB(text = timestamp.toActivityItemDate())
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
                 HorizontalDivider()
             }
 
@@ -438,10 +438,10 @@ private fun ActivityDetailContent(
                         tint = accentColor,
                         modifier = Modifier.size(16.dp)
                     )
-                    Spacer(modifier = Modifier.width(4.dp))
+                    HorizontalSpacer(4.dp)
                     BodySSB(text = timestamp.toActivityItemTime())
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
                 HorizontalDivider()
             }
         }
@@ -475,7 +475,7 @@ private fun ActivityDetailContent(
                             tint = accentColor,
                             modifier = Modifier.size(16.dp)
                         )
-                        Spacer(modifier = Modifier.width(4.dp))
+                        HorizontalSpacer(4.dp)
                         AnimatedContent(
                             targetState = hideBalance,
                             transitionSpec = { BalanceAnimations.activityAmountTransition },
@@ -488,7 +488,7 @@ private fun ActivityDetailContent(
                             }
                         }
                     }
-                    Spacer(modifier = Modifier.height(16.dp))
+                    VerticalSpacer(16.dp)
                     HorizontalDivider()
                 }
                 if (fee != null) {
@@ -512,7 +512,7 @@ private fun ActivityDetailContent(
                                 tint = accentColor,
                                 modifier = Modifier.size(16.dp)
                             )
-                            Spacer(modifier = Modifier.width(4.dp))
+                            HorizontalSpacer(4.dp)
                             AnimatedContent(
                                 targetState = hideBalance,
                                 transitionSpec = { BalanceAnimations.activityAmountTransition },
@@ -525,7 +525,7 @@ private fun ActivityDetailContent(
                                 }
                             }
                         }
-                        Spacer(modifier = Modifier.height(16.dp))
+                        VerticalSpacer(16.dp)
                         HorizontalDivider()
                     }
                 }
@@ -553,7 +553,7 @@ private fun ActivityDetailContent(
                         )
                     }
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
                 HorizontalDivider()
             }
         }
@@ -596,7 +596,7 @@ private fun ActivityDetailContent(
             }
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         // Action buttons
         Column(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityExploreScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityExploreScreen.kt
@@ -6,10 +6,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -51,7 +49,9 @@ import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.BalanceHeaderView
 import to.bitkit.ui.components.BodySSB
 import to.bitkit.ui.components.Caption13Up
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -212,7 +212,7 @@ private fun ActivityExploreContent(
             ActivityIcon(activity = item, size = 48.dp)
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         when (item) {
             is Activity.Onchain -> {
@@ -222,7 +222,7 @@ private fun ActivityExploreContent(
                     txDetails = txDetails,
                     boostTxDoesExist = boostTxDoesExist,
                 )
-                Spacer(modifier = Modifier.weight(1f))
+                FillHeight()
                 PrimaryButton(
                     text = stringResource(R.string.wallet__activity_explorer),
                     onClick = { onClickExplore(item.v1.txId) },
@@ -231,7 +231,7 @@ private fun ActivityExploreContent(
 
             is Activity.Lightning -> {
                 LightningDetails(lightning = item, onCopy = onCopy)
-                Spacer(modifier = Modifier.weight(1f))
+                FillHeight()
             }
         }
     }
@@ -375,7 +375,7 @@ private fun Section(
         } else if (value != null) {
             BodySSB(text = value)
         }
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
         HorizontalDivider()
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -4,9 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
@@ -22,6 +20,7 @@ import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import to.bitkit.R
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.Sheet
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.screens.wallets.activity.components.ActivityListFilter
@@ -117,7 +116,7 @@ private fun AllActivityScreenContent(
             modifier = Modifier.padding(horizontal = 16.dp)
 
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         // List
         Box(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/DateRangeSelectorSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/DateRangeSelectorSheet.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -69,6 +68,7 @@ import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.BottomSheetPreview
 import to.bitkit.ui.components.Caption13Up
 import to.bitkit.ui.components.FillHeight
+import to.bitkit.ui.components.FillWidth
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.SheetSize
@@ -511,9 +511,7 @@ private fun CalendarGrid(
                         )
                     } else {
                         // Empty space for days outside the month
-                        Spacer(
-                            modifier = Modifier.weight(1f)
-                        )
+                        FillWidth()
                     }
                 }
             }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/TagSelectorSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/TagSelectorSheet.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.wallets.activity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -23,8 +21,10 @@ import to.bitkit.ui.activityListViewModel
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.BottomSheetPreview
 import to.bitkit.ui.components.Caption13Up
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.SheetSize
 import to.bitkit.ui.components.TagButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.shared.util.gradientBackground
@@ -68,14 +68,14 @@ private fun Content(
     ) {
         SheetTopBar(stringResource(R.string.wallet__tags_filter_title))
 
-        Spacer(modifier = Modifier.height(42.dp))
+        VerticalSpacer(42.dp)
 
         Caption13Up(
             text = stringResource(R.string.wallet__tags_filter),
             color = Colors.White64,
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         FlowRow(
             modifier = Modifier
@@ -93,7 +93,7 @@ private fun Content(
             }
         }
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
     }
 }
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListFilter.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListFilter.kt
@@ -4,12 +4,9 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -20,9 +17,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import to.bitkit.R
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.components.SearchInput
 import to.bitkit.ui.components.SearchInputIconButton
 import to.bitkit.ui.components.TagButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.theme.AppThemeSurface
 
 @Composable
@@ -65,7 +64,7 @@ fun ActivityListFilter(
                             )
                         }
                     }
-                    Spacer(modifier = Modifier.width(12.dp))
+                    HorizontalSpacer(12.dp)
                 }
 
                 SearchInputIconButton(
@@ -77,7 +76,7 @@ fun ActivityListFilter(
                     },
                     modifier = Modifier.testTag("TagsPrompt")
                 )
-                Spacer(modifier = Modifier.width(12.dp))
+                HorizontalSpacer(12.dp)
                 SearchInputIconButton(
                     iconRes = R.drawable.ic_calendar,
                     isActive = hasDateRangeFilter,
@@ -90,7 +89,7 @@ fun ActivityListFilter(
             }
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         CustomTabRowWithSpacing(
             tabs = tabs,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -3,10 +3,8 @@ package to.bitkit.ui.screens.wallets.activity.components
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -112,7 +110,7 @@ fun ActivityListGrouped(
                     }
                 }
                 item {
-                    Spacer(modifier = Modifier.height(120.dp))
+                    VerticalSpacer(120.dp)
                 }
             }
         } else {

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityRow.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityRow.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -48,6 +46,7 @@ import to.bitkit.ui.blocktankViewModel
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.CaptionB
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.currencyViewModel
 import to.bitkit.ui.screens.wallets.activity.utils.previewActivityItems
 import to.bitkit.ui.settingsViewModel
@@ -109,7 +108,7 @@ fun ActivityRow(
             .testTag(testTag)
     ) {
         ActivityIcon(activity = item, size = 40.dp, isCpfpChild = isCpfpChild)
-        Spacer(modifier = Modifier.width(16.dp))
+        HorizontalSpacer(16.dp)
         Column(
             verticalArrangement = Arrangement.spacedBy(4.dp),
             modifier = Modifier.weight(1f)
@@ -162,7 +161,7 @@ fun ActivityRow(
                 maxLines = 1,
             )
         }
-        Spacer(modifier = Modifier.width(16.dp))
+        HorizontalSpacer(16.dp)
         AmountView(
             item = item,
             prefix = amountPrefix,
@@ -286,7 +285,7 @@ private fun AmountViewContent(
             if (titleSymbol != null && !isSymbolSuffix) {
                 BodyMSB(text = titleSymbol, color = Colors.White64)
             }
-            Spacer(modifier = Modifier.width(2.dp))
+            HorizontalSpacer(2.dp)
             AnimatedContent(
                 targetState = hideBalance,
                 transitionSpec = { BalanceAnimations.activityAmountTransition },

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/CustomTabRowWithSpacing.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/CustomTabRowWithSpacing.kt
@@ -9,11 +9,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -23,6 +21,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import to.bitkit.ui.components.CaptionB
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.theme.Colors
 
@@ -89,7 +88,7 @@ fun <T : TabItem> CustomTabRowWithSpacing(
                 }
 
                 if (index < tabs.size - 1) {
-                    Spacer(modifier = Modifier.width(8.dp))
+                    HorizontalSpacer(8.dp)
                 }
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/EmptyActivityRow.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/EmptyActivityRow.kt
@@ -3,10 +3,8 @@ package to.bitkit.ui.screens.wallets.activity.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.CaptionB
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
@@ -39,7 +38,7 @@ fun EmptyActivityRow(
             backgroundColor = Colors.Yellow16,
             size = 32.dp,
         )
-        Spacer(modifier = Modifier.width(16.dp))
+        HorizontalSpacer(16.dp)
         Column(
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/LocationBlockScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/LocationBlockScreen.kt
@@ -2,10 +2,8 @@ package to.bitkit.ui.screens.wallets.receive
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -18,7 +16,9 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BottomSheetPreview
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.shared.util.gradientBackground
@@ -39,7 +39,7 @@ fun LocationBlockScreen(
     ) {
         SheetTopBar(stringResource(R.string.wallet__receive_bitcoin), onBack = onBackPressed)
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -48,7 +48,7 @@ fun LocationBlockScreen(
         ) {
             BodyM(text = stringResource(R.string.lightning__funding__text_blocked_cjit), color = Colors.White64)
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Image(
                 painter = painterResource(R.drawable.globe),
@@ -59,10 +59,10 @@ fun LocationBlockScreen(
                     .padding(horizontal = 60.dp)
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             PrimaryButton(text = stringResource(R.string.onboarding__advanced_setup), onClick = navigateAdvancedSetup)
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveLiquidityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveLiquidityScreen.kt
@@ -1,9 +1,7 @@
 package to.bitkit.ui.screens.wallets.receive
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -98,7 +96,7 @@ private fun Content(
             ),
             onBack = onBack
         )
-        Spacer(Modifier.height(24.dp))
+        VerticalSpacer(24.dp)
 
         Column(
             modifier = Modifier
@@ -128,7 +126,7 @@ private fun Content(
                     }
                 )
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             LightningChannel(
                 capacity = channelSize,
@@ -138,7 +136,7 @@ private fun Content(
                 showLabels = true,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             FillHeight()
 
@@ -164,7 +162,7 @@ private fun Content(
                 onClick = onContinue,
                 modifier = Modifier.testTag("LiquidityContinue")
             )
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveQrScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveQrScreen.kt
@@ -10,11 +10,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -191,7 +189,7 @@ fun ReceiveQrScreen(
     ) {
         SheetTopBar(stringResource(R.string.wallet__receive_bitcoin))
         Column {
-            Spacer(Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             // Tab row
             CustomTabRowWithSpacing(
@@ -213,7 +211,7 @@ fun ReceiveQrScreen(
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
-            Spacer(Modifier.height(24.dp))
+            VerticalSpacer(24.dp)
 
             // Content area (QR or Details) with LazyRow
             LazyRow(
@@ -273,7 +271,7 @@ fun ReceiveQrScreen(
                 }
             }
 
-            Spacer(Modifier.height(24.dp))
+            VerticalSpacer(24.dp)
 
             AnimatedVisibility(visible = lightningState.nodeLifecycleState.isRunning()) {
                 val showCjitButton = showingCjitOnboarding && selectedTab == ReceiveTab.SPENDING
@@ -316,7 +314,7 @@ fun ReceiveQrScreen(
                 )
             }
 
-            Spacer(Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }
@@ -348,7 +346,7 @@ private fun ReceiveQrView(
             modifier = Modifier.weight(1f, fill = false)
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.Top,
@@ -419,7 +417,7 @@ private fun ReceiveQrView(
                 modifier = Modifier.weight(1f)
             )
         }
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
     }
 }
 
@@ -562,12 +560,12 @@ private fun CopyAddressCard(
             .padding(24.dp)
     ) {
         Caption13Up(text = title, color = Colors.White64)
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
         BodyS(
             text = (body ?: address).truncate(32).uppercase(),
             modifier = testTag?.let { Modifier.testTag(it) } ?: Modifier
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/AddTagScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/AddTagScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.wallets.send
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
@@ -28,6 +26,7 @@ import kotlinx.coroutines.delay
 import to.bitkit.R
 import to.bitkit.ui.components.BottomSheetPreview
 import to.bitkit.ui.components.Caption13Up
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.TagButton
 import to.bitkit.ui.components.TextInput
@@ -96,9 +95,9 @@ fun AddTagContent(
         ) {
             VerticalSpacer(16.dp)
             if (uiState.tagsSuggestions.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
                 Caption13Up(text = stringResource(R.string.wallet__tags_previously), color = Colors.White64)
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
                 FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -114,9 +113,9 @@ fun AddTagContent(
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             Caption13Up(text = stringResource(R.string.wallet__tags_new), color = Colors.White64)
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             TextInput(
                 placeholder = stringResource(R.string.wallet__tags_new_enter),
                 value = uiState.tagInput,
@@ -135,8 +134,8 @@ fun AddTagContent(
                     .then(tagInputTestTag?.let { Modifier.testTag(it) } ?: Modifier)
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
-            Spacer(modifier = Modifier.weight(1f))
+            VerticalSpacer(16.dp)
+            FillHeight()
             PrimaryButton(
                 text = stringResource(R.string.wallet__tags_add_button),
                 onClick = { onTagConfirmed(uiState.tagInput) },
@@ -144,7 +143,7 @@ fun AddTagContent(
                 modifier = Modifier
                     .then(addButtonTestTag?.let { Modifier.testTag(it) } ?: Modifier)
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAddressScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAddressScreen.kt
@@ -1,10 +1,8 @@
 package to.bitkit.ui.screens.wallets.send
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
@@ -92,7 +90,7 @@ fun SendAddressScreen(
                 onClick = { onEvent(SendEvent.AddressContinue(uiState.addressInput)) },
                 modifier = Modifier.testTag("AddressContinue")
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendConfirmScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -197,7 +196,7 @@ private fun Content(
                 onBack = onBack.takeIf { canGoBack },
             )
 
-            Spacer(Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             if (isNodeRunning) {
                 ContentRunning(
@@ -270,7 +269,7 @@ fun ContentRunning(
                 .testTag("ReviewAmount")
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         when (uiState.payMethod) {
             SendMethod.ONCHAIN -> OnChainDescription(uiState = uiState, onEvent = onEvent)
@@ -307,9 +306,9 @@ private fun LnurlCommentSection(
     uiState: SendUiState,
     onEvent: (SendEvent) -> Unit,
 ) {
-    Spacer(modifier = Modifier.height(16.dp))
+    VerticalSpacer(16.dp)
     Caption13Up(stringResource(R.string.wallet__lnurl_pay_confirm__comment), color = Colors.White64)
-    Spacer(modifier = Modifier.height(8.dp))
+    VerticalSpacer(8.dp)
 
     TextInput(
         value = uiState.comment,
@@ -329,9 +328,9 @@ private fun TagsSection(
     onClickTag: (String) -> Unit,
     onClickAddTag: () -> Unit,
 ) {
-    Spacer(modifier = Modifier.height(16.dp))
+    VerticalSpacer(16.dp)
     Caption13Up(text = stringResource(R.string.wallet__tags), color = Colors.White64)
-    Spacer(modifier = Modifier.height(8.dp))
+    VerticalSpacer(8.dp)
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -372,7 +371,7 @@ private fun OnChainDescription(
     val fee by remember(uiState.speed) { mutableStateOf(FeeRate.fromSpeed(uiState.speed)) }
     Column(modifier = Modifier.fillMaxWidth()) {
         Caption13Up(text = stringResource(R.string.wallet__send_to), color = Colors.White64)
-        Spacer(modifier = Modifier.height(8.dp))
+        VerticalSpacer(8.dp)
         BodySSB(
             text = uiState.address,
             maxLines = 1,
@@ -448,7 +447,7 @@ private fun OnChainDescription(
                 ) {
                     VerticalSpacer(16.dp)
                     Caption13Up(text = stringResource(R.string.wallet__send_confirming_in), color = Colors.White64)
-                    Spacer(modifier = Modifier.height(8.dp))
+                    VerticalSpacer(8.dp)
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -489,7 +488,7 @@ private fun LightningDescription(
             else -> uiState.decodedInvoice?.bolt11.orEmpty()
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        VerticalSpacer(8.dp)
         BodySSB(
             text = destination,
             maxLines = 1,
@@ -511,7 +510,7 @@ private fun LightningDescription(
             ) {
                 VerticalSpacer(16.dp)
                 Caption13Up(text = stringResource(R.string.wallet__send_fee_and_speed), color = Colors.White64)
-                Spacer(modifier = Modifier.height(8.dp))
+                VerticalSpacer(8.dp)
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -537,7 +536,7 @@ private fun LightningDescription(
                             )
                         } ?: BodySSB(text = stringResource(R.string.fee__instant__title))
                 }
-                Spacer(modifier = Modifier.weight(1f))
+                FillHeight()
                 HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
             }
             if (!isLnurlPay && expirySeconds != null) {
@@ -551,7 +550,7 @@ private fun LightningDescription(
                         text = stringResource(R.string.wallet__send_invoice_expiration),
                         color = Colors.White64,
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    VerticalSpacer(8.dp)
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -567,7 +566,7 @@ private fun LightningDescription(
 
                         BodySSB(text = invoiceExpiryTimestamp)
                     }
-                    Spacer(modifier = Modifier.weight(1f))
+                    FillHeight()
                     HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
                 }
             }
@@ -576,7 +575,7 @@ private fun LightningDescription(
         if (!isLnurlPay && description != null) {
             Column {
                 Caption13Up(text = stringResource(R.string.wallet__note), color = Colors.White64)
-                Spacer(modifier = Modifier.height(8.dp))
+                VerticalSpacer(8.dp)
                 BodySSB(text = description)
                 HorizontalDivider(modifier = Modifier.padding(top = 16.dp))
             }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendErrorScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendErrorScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -20,8 +19,10 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BottomSheetPreview
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.shared.util.gradientBackground
@@ -62,11 +63,11 @@ private fun Content(
                 .fillMaxSize()
                 .padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             BodyM(text = errorText, color = Colors.White64)
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
             Image(
                 painter = painterResource(R.drawable.cross),
                 contentDescription = null,
@@ -74,7 +75,7 @@ private fun Content(
                     .fillMaxWidth()
                     .height(256.dp)
             )
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -94,7 +95,7 @@ private fun Content(
                 )
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendPinCheckScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendPinCheckScreen.kt
@@ -3,7 +3,6 @@ package to.bitkit.ui.screens.wallets.send
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -27,10 +26,12 @@ import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyS
 import to.bitkit.ui.components.BottomSheetPreview
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.KEY_DELETE
 import to.bitkit.ui.components.NumberPad
 import to.bitkit.ui.components.NumberPadType
 import to.bitkit.ui.components.PinDots
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.shared.modifiers.sheetHeight
@@ -95,7 +96,7 @@ private fun PinCheckContent(
             titleText = stringResource(R.string.security__pin_send_title),
             onBack = onBack,
         )
-        Spacer(Modifier.height(32.dp))
+        VerticalSpacer(32.dp)
 
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -106,7 +107,7 @@ private fun PinCheckContent(
                 modifier = Modifier.padding(horizontal = 32.dp)
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             AnimatedVisibility(visible = attemptsRemaining < Env.PIN_ATTEMPTS) {
                 if (isLastAttempt) {
@@ -130,7 +131,7 @@ private fun PinCheckContent(
                             .testTag("AttemptsRemaining")
                     )
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
             }
 
             PinDots(
@@ -138,7 +139,7 @@ private fun PinCheckContent(
                 modifier = Modifier.padding(vertical = 16.dp),
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             NumberPad(
                 onPress = onKeyPress,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendQuickPayScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendQuickPayScreen.kt
@@ -1,10 +1,8 @@
 package to.bitkit.ui.screens.wallets.send
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -23,7 +21,9 @@ import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.BalanceHeaderView
 import to.bitkit.ui.components.BottomSheetPreview
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.SyncNodeView
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.transfer.components.TransferAnimationView
 import to.bitkit.ui.shared.modifiers.sheetHeight
@@ -93,23 +93,23 @@ private fun Content(
                         .fillMaxSize()
                         .padding(horizontal = 16.dp)
                 ) {
-                    Spacer(modifier = Modifier.height(16.dp))
+                    VerticalSpacer(16.dp)
                     BalanceHeaderView(sats = amount.toLong(), modifier = Modifier.fillMaxWidth())
 
-                    Spacer(modifier = Modifier.weight(1f))
+                    FillHeight()
                     TransferAnimationView(
                         largeCircleRes = R.drawable.ln_sync_large,
                         smallCircleRes = R.drawable.ln_sync_small,
                         contentRes = R.drawable.coin_stack_4,
                     )
-                    Spacer(modifier = Modifier.weight(1f))
+                    FillHeight()
 
                     Display(
                         text = stringResource(R.string.wallet__send_quickpay__title)
                             .withAccent(accentColor = Colors.Purple)
                     )
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                    VerticalSpacer(16.dp)
                 }
             }
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/suggestion/BuyIntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/suggestion/BuyIntroScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.wallets.suggestion
 import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -22,6 +20,7 @@ import to.bitkit.models.Suggestion
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.ScreenColumn
 import to.bitkit.ui.screens.wallets.HomeViewModel
@@ -70,9 +69,9 @@ fun BuyIntroContent(
                 text = stringResource(R.string.other__buy_header).withAccent(accentColor = Colors.Brand),
                 color = Colors.White
             )
-            Spacer(Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(text = stringResource(R.string.other__buy_text), color = Colors.White64)
-            Spacer(Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.other__buy_button),
                 onClick = {
@@ -81,7 +80,7 @@ fun BuyIntroContent(
                     context.startActivity(intent)
                 }
             )
-            Spacer(Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/DragDropColumn.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/DragDropColumn.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -19,6 +17,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import to.bitkit.models.WidgetWithPosition
+import to.bitkit.ui.components.VerticalSpacer
 
 @Composable
 fun DragDropColumn(
@@ -84,7 +83,7 @@ fun DragDropColumn(
 
             // Add spacing between items (except after the last item)
             if (index < items.size - 1) {
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
             }
         }
     }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/WidgetsIntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/WidgetsIntroScreen.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.screens.widgets
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -17,6 +15,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -51,15 +50,15 @@ fun WidgetsIntroScreen(
                 text = stringResource(R.string.widgets__onboarding__title).withAccent(accentColor = Colors.Brand),
                 color = Colors.White
             )
-            Spacer(Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
             BodyM(text = stringResource(R.string.widgets__onboarding__description), color = Colors.White64)
-            Spacer(Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             PrimaryButton(
                 text = stringResource(R.string.common__continue),
                 onClick = onContinue,
                 modifier = Modifier.testTag("WidgetsOnboarding-button")
             )
-            Spacer(Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlockCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlockCard.kt
@@ -5,12 +5,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -27,6 +25,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.BodySB
 import to.bitkit.ui.components.CaptionB
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 
@@ -73,7 +72,7 @@ fun BlockCard(
                             .testTag("block_card_widget_title_icon"),
                         tint = Color.Unspecified
                     )
-                    Spacer(modifier = Modifier.width(16.dp))
+                    HorizontalSpacer(16.dp)
                     BodyMSB(
                         text = stringResource(R.string.widgets__blocks__name),
                         modifier = Modifier.testTag("block_card_widget_title_text")

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksEditScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.blocks
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -30,6 +28,7 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodySSB
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -99,7 +98,7 @@ fun BlocksEditContent(
                 .verticalScroll(rememberScrollState())
                 .testTag("WidgetEditScrollView")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             BodyM(
                 text = stringResource(R.string.widgets__widget__edit_description).replace(
@@ -110,7 +109,7 @@ fun BlocksEditContent(
                 modifier = Modifier.testTag("edit_description")
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             // Block number toggle
             BlockEditOptionRow(

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksPreviewScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.blocks
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -28,10 +26,12 @@ import to.bitkit.R
 import to.bitkit.models.widget.BlockModel
 import to.bitkit.models.widget.BlocksPreferences
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.Headline
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Text13Up
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
 import to.bitkit.ui.scaffold.AppTopBar
@@ -99,7 +99,7 @@ fun BlocksPreviewContent(
                 .padding(horizontal = 16.dp)
                 .testTag("main_content")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             Row(
                 modifier = Modifier
@@ -149,7 +149,7 @@ fun BlocksPreviewContent(
                 modifier = Modifier.testTag("WidgetEdit")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Text13Up(
                 stringResource(R.string.common__preview),

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/calculator/components/CalculatorCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/calculator/components/CalculatorCard.kt
@@ -5,13 +5,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -35,6 +32,7 @@ import to.bitkit.R
 import to.bitkit.models.BITCOIN_SYMBOL
 import to.bitkit.models.BitcoinDisplayUnit
 import to.bitkit.ui.components.BodyMSB
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.screens.widgets.calculator.CalculatorViewModel
 import to.bitkit.ui.theme.AppThemeSurface
@@ -110,7 +108,7 @@ fun CalculatorCardContent(
         ) {
             if (showWidgetTitle) {
                 WidgetTitleRow()
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
             }
 
             // Bitcoin input with visual transformation
@@ -156,7 +154,7 @@ private fun WidgetTitleRow() {
                 .testTag("widget_title_icon"),
             tint = Color.Unspecified
         )
-        Spacer(modifier = Modifier.width(16.dp))
+        HorizontalSpacer(16.dp)
         BodyMSB(
             text = stringResource(R.string.widgets__calculator__name),
             modifier = Modifier.testTag("widget_title_text")

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsCard.kt
@@ -5,13 +5,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -29,6 +26,8 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyMB
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.BodyS
+import to.bitkit.ui.components.HorizontalSpacer
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 
@@ -62,13 +61,13 @@ fun FactsCard(
                             .testTag("widget_title_icon"),
                         tint = Color.Unspecified
                     )
-                    Spacer(modifier = Modifier.width(16.dp))
+                    HorizontalSpacer(16.dp)
                     BodyMSB(
                         text = stringResource(R.string.widgets__facts__name),
                         modifier = Modifier.testTag("widget_title_text")
                     )
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
             }
 
             BodyMB(
@@ -79,7 +78,7 @@ fun FactsCard(
             )
 
             if (showSource) {
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
 
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsEditScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.facts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
@@ -25,9 +23,11 @@ import to.bitkit.R
 import to.bitkit.models.widget.FactsPreferences
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.CaptionB
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Title
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -80,7 +80,7 @@ fun FactsEditContent(
                 .padding(horizontal = 16.dp)
                 .testTag("WidgetEditScrollView")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             BodyM(
                 text = stringResource(R.string.widgets__widget__edit_description).replace(
@@ -91,7 +91,7 @@ fun FactsEditContent(
                 modifier = Modifier.testTag("edit_description")
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -169,7 +169,7 @@ fun FactsEditContent(
                 modifier = Modifier.testTag("source_divider")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Row(
                 modifier = Modifier
@@ -211,7 +211,7 @@ private fun Preview() {
             onClickReset = {},
             onClickPreview = {},
             factsPreferences = FactsPreferences(),
-            fact = "Bitcoin doesn’t need your personal information",
+            fact = "Bitcoin doesn't need your personal information",
         )
     }
 }
@@ -226,7 +226,7 @@ private fun Preview2() {
             onClickReset = {},
             onClickPreview = {},
             factsPreferences = FactsPreferences(showSource = true),
-            fact = "Bitcoin doesn’t need your personal information",
+            fact = "Bitcoin doesn't need your personal information",
         )
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsPreviewScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.facts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -27,10 +25,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import to.bitkit.R
 import to.bitkit.models.widget.FactsPreferences
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.Headline
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Text13Up
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
 import to.bitkit.ui.scaffold.AppTopBar
@@ -98,7 +98,7 @@ fun FactsPreviewContent(
                 .padding(horizontal = 16.dp)
                 .testTag("main_content")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             Row(
                 modifier = Modifier
@@ -148,7 +148,7 @@ fun FactsPreviewContent(
                 modifier = Modifier.testTag("WidgetEdit")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Text13Up(
                 stringResource(R.string.common__preview),
@@ -209,7 +209,7 @@ private fun Preview() {
             onClickDelete = {},
             onClickSave = {},
             factsPreferences = FactsPreferences(),
-            fact = "Bitcoin doesn’t need your personal information",
+            fact = "Bitcoin doesn't need your personal information",
             isFactsWidgetEnabled = false
         )
     }
@@ -226,7 +226,7 @@ private fun Preview2() {
             onClickDelete = {},
             onClickSave = {},
             factsPreferences = FactsPreferences(showSource = true),
-            fact = "Bitcoin doesn’t need your personal information",
+            fact = "Bitcoin doesn't need your personal information",
             isFactsWidgetEnabled = true
         )
     }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlineCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlineCard.kt
@@ -7,13 +7,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -34,6 +31,8 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMB
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.BodyS
+import to.bitkit.ui.components.HorizontalSpacer
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 
@@ -77,13 +76,13 @@ fun HeadlineCard(
                             .testTag("widget_title_icon"),
                         tint = Color.Unspecified
                     )
-                    Spacer(modifier = Modifier.width(16.dp))
+                    HorizontalSpacer(16.dp)
                     BodyMSB(
                         text = stringResource(R.string.widgets__news__name),
                         modifier = Modifier.testTag("widget_title_text")
                     )
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
             }
 
             if (showTime && time.isNotEmpty()) {
@@ -91,7 +90,7 @@ fun HeadlineCard(
                     text = time,
                     modifier = Modifier.testTag("time_text")
                 )
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
             }
 
             BodyMB(
@@ -102,7 +101,7 @@ fun HeadlineCard(
             )
 
             if (showSource) {
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
 
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesEditScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.headlines
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
@@ -26,9 +24,11 @@ import to.bitkit.models.widget.ArticleModel
 import to.bitkit.models.widget.HeadlinePreferences
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.CaptionB
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Title
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -87,7 +87,7 @@ fun HeadlinesEditContent(
                 .padding(horizontal = 16.dp)
                 .testTag("WidgetEditScrollView")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             BodyM(
                 text = stringResource(R.string.widgets__widget__edit_description).replace(
@@ -98,7 +98,7 @@ fun HeadlinesEditContent(
                 modifier = Modifier.testTag("edit_description")
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -208,7 +208,7 @@ fun HeadlinesEditContent(
                 modifier = Modifier.testTag("source_divider")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Row(
                 modifier = Modifier

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesPreviewScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.headlines
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -28,10 +26,12 @@ import to.bitkit.R
 import to.bitkit.models.widget.ArticleModel
 import to.bitkit.models.widget.HeadlinePreferences
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.Headline
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Text13Up
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
 import to.bitkit.ui.scaffold.AppTopBar
@@ -99,7 +99,7 @@ fun HeadlinesPreviewContent(
                 .padding(horizontal = 16.dp)
                 .testTag("main_content")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             Row(
                 modifier = Modifier
@@ -149,7 +149,7 @@ fun HeadlinesPreviewContent(
                 modifier = Modifier.testTag("WidgetEdit")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Text13Up(
                 stringResource(R.string.common__preview),

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceCard.kt
@@ -7,13 +7,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ShapeDefaults
@@ -47,6 +45,8 @@ import to.bitkit.models.widget.PricePreferences
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.BodySB
 import to.bitkit.ui.components.CaptionB
+import to.bitkit.ui.components.HorizontalSpacer
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 
@@ -83,7 +83,7 @@ fun PriceCard(
                             .testTag("price_card_widget_title_icon"),
                         tint = Color.Unspecified
                     )
-                    Spacer(modifier = Modifier.width(16.dp))
+                    HorizontalSpacer(16.dp)
                     BodyMSB(
                         text = stringResource(R.string.widgets__price__name),
                         modifier = Modifier.testTag("price_card_widget_title_text")
@@ -116,7 +116,7 @@ fun PriceCard(
                         modifier = Modifier.testTag("price_card_pair_change_${widgetData.pair}")
                     )
 
-                    Spacer(modifier = Modifier.width(16.dp))
+                    HorizontalSpacer(16.dp)
 
                     BodySB(
                         text = widgetData.price,
@@ -141,7 +141,7 @@ fun PriceCard(
             }
 
             if (pricePreferences.showSource) {
-                Spacer(modifier = Modifier.height(8.dp))
+                VerticalSpacer(8.dp)
 
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PricePreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PricePreviewScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.price
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -34,10 +32,12 @@ import to.bitkit.data.dto.price.PriceWidgetData
 import to.bitkit.data.dto.price.TradingPair
 import to.bitkit.models.widget.PricePreferences
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.Headline
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Text13Up
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
 import to.bitkit.ui.scaffold.AppTopBar
@@ -118,7 +118,7 @@ fun PricePreviewContent(
                 .verticalScroll(rememberScrollState())
                 .testTag("WidgetEditScrollView")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             Row(
                 modifier = Modifier
@@ -168,7 +168,7 @@ fun PricePreviewContent(
                 modifier = Modifier.testTag("WidgetEdit")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Text13Up(
                 stringResource(R.string.common__preview),

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherCard.kt
@@ -5,11 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -32,6 +30,7 @@ import to.bitkit.data.dto.FeeCondition
 import to.bitkit.models.widget.WeatherPreferences
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.BodySB
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.components.Subtitle
 import to.bitkit.ui.screens.widgets.blocks.WeatherModel
 import to.bitkit.ui.theme.AppThemeSurface
@@ -71,7 +70,7 @@ fun WeatherCard(
                             .testTag("weather_card_condition_icon"),
                         tint = Color.Unspecified
                     )
-                    Spacer(modifier = Modifier.width(16.dp))
+                    HorizontalSpacer(16.dp)
                     BodyMSB(
                         text = stringResource(R.string.widgets__weather__name),
                         modifier = Modifier.testTag("weather_card_widget_title_text")

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherEditScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.weather
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -35,6 +33,7 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodySSB
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -93,7 +92,7 @@ fun WeatherEditContent(
                 .verticalScroll(rememberScrollState())
                 .testTag("WidgetEditScrollView")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             BodyM(
                 text = stringResource(R.string.widgets__widget__edit_description).replace(
@@ -104,7 +103,7 @@ fun WeatherEditContent(
                 modifier = Modifier.testTag("edit_description")
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherPreviewScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.screens.widgets.weather
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -29,10 +27,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import to.bitkit.R
 import to.bitkit.models.widget.WeatherPreferences
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.Headline
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Text13Up
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
 import to.bitkit.ui.scaffold.AppTopBar
@@ -103,7 +103,7 @@ fun WeatherPreviewContent(
                 .verticalScroll(rememberScrollState())
                 .testTag("main_content")
         ) {
-            Spacer(modifier = Modifier.height(26.dp))
+            VerticalSpacer(26.dp)
 
             Row(
                 modifier = Modifier
@@ -153,7 +153,7 @@ fun WeatherPreviewContent(
                 modifier = Modifier.testTag("WidgetEdit")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Text13Up(
                 stringResource(R.string.common__preview),

--- a/app/src/main/java/to/bitkit/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/SettingsScreen.kt
@@ -2,7 +2,6 @@ package to.bitkit.ui.settings
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -29,6 +28,7 @@ import to.bitkit.R
 import to.bitkit.models.Toast
 import to.bitkit.ui.Routes
 import to.bitkit.ui.appViewModel
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.navigateToAboutSettings
 import to.bitkit.ui.navigateToAdvancedSettings
@@ -167,7 +167,7 @@ fun SettingsScreenContent(
                     modifier = Modifier.testTag("DevSettings")
                 )
             }
-            Spacer(Modifier.weight(1f))
+            FillHeight()
             Image(
                 painter = painterResource(R.drawable.cog),
                 contentDescription = null,
@@ -177,7 +177,7 @@ fun SettingsScreenContent(
                     .clickableAlpha(1f) { onCogTap() }
                     .testTag("DevOptions")
             )
-            Spacer(Modifier.weight(1f))
+            FillHeight()
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/advanced/sweep/SweepSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/advanced/sweep/SweepSettingsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -32,6 +31,7 @@ import to.bitkit.ui.Routes
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodySSB
 import to.bitkit.ui.components.Caption
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.MoneySSB
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.Title
@@ -122,7 +122,7 @@ private fun LoadingView() {
             color = Colors.White64,
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         Box(
             contentAlignment = Alignment.Center,
@@ -138,7 +138,7 @@ private fun LoadingView() {
             )
         }
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -220,7 +220,7 @@ private fun FoundFundsView(
             }
         }
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         PrimaryButton(
             text = stringResource(R.string.sweep__to_wallet),
@@ -270,7 +270,7 @@ private fun NoFundsView(onBack: () -> Unit) {
             color = Colors.White64,
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         Box(
             contentAlignment = Alignment.Center,
@@ -286,7 +286,7 @@ private fun NoFundsView(onBack: () -> Unit) {
             )
         }
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         PrimaryButton(
             text = stringResource(R.string.common__ok),
@@ -307,7 +307,7 @@ private fun ErrorView(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.fillMaxSize()
     ) {
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         Icon(
             painter = painterResource(id = R.drawable.ic_warning),
@@ -327,7 +327,7 @@ private fun ErrorView(
             color = Colors.White64,
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         PrimaryButton(
             text = stringResource(R.string.common__retry),

--- a/app/src/main/java/to/bitkit/ui/settings/advanced/sweep/SweepSuccessScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/advanced/sweep/SweepSuccessScreen.kt
@@ -3,7 +3,6 @@ package to.bitkit.ui.settings.advanced.sweep
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -26,6 +25,7 @@ import to.bitkit.R
 import to.bitkit.ui.Routes
 import to.bitkit.ui.components.BalanceHeaderView
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
@@ -90,7 +90,7 @@ private fun Content(
 
                 BalanceHeaderView(sats = amountSats)
 
-                Spacer(modifier = Modifier.weight(1f))
+                FillHeight()
 
                 Box(
                     contentAlignment = Alignment.Center,
@@ -104,7 +104,7 @@ private fun Content(
                     )
                 }
 
-                Spacer(modifier = Modifier.weight(1f))
+                FillHeight()
 
                 PrimaryButton(
                     text = stringResource(R.string.sweep__success_wallet_overview),

--- a/app/src/main/java/to/bitkit/ui/settings/backups/ConfirmMnemonicScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/ConfirmMnemonicScreen.kt
@@ -4,13 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -32,7 +29,10 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.ButtonSize
+import to.bitkit.ui.components.FillHeight
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.effects.BlockScreenshots
 import to.bitkit.ui.shared.util.gradientBackground
@@ -137,7 +137,7 @@ private fun ConfirmMnemonicContent(
             .testTag("backup_confirm_mnemonic_screen")
     ) {
         SheetTopBar(stringResource(R.string.security__mnemonic_confirm), onBack = onBack)
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -150,7 +150,7 @@ private fun ConfirmMnemonicContent(
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             // Shuffled word buttons
             FlowRow(
@@ -174,7 +174,7 @@ private fun ConfirmMnemonicContent(
                 }
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             // Selected words display (2 columns)
             Row(
@@ -208,8 +208,8 @@ private fun ConfirmMnemonicContent(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
-            Spacer(modifier = Modifier.height(24.dp))
+            FillHeight()
+            VerticalSpacer(24.dp)
 
             PrimaryButton(
                 text = stringResource(R.string.common__continue),
@@ -218,7 +218,7 @@ private fun ConfirmMnemonicContent(
                 modifier = Modifier.testTag("ContinueConfirmMnemonic")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }
@@ -231,7 +231,7 @@ private fun SelectedWordItem(
 ) {
     Row {
         BodyMSB(text = "$number.", color = Colors.White64)
-        Spacer(modifier = Modifier.width(4.dp))
+        HorizontalSpacer(4.dp)
         BodyMSB(
             text = word.ifEmpty { "" },
             color = if (word.isEmpty()) Colors.White64 else if (isCorrect) Colors.Green else Colors.Red

--- a/app/src/main/java/to/bitkit/ui/settings/backups/ConfirmPassphraseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/ConfirmPassphraseScreen.kt
@@ -1,10 +1,8 @@
 package to.bitkit.ui.settings.backups
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -22,8 +20,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.TextInput
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.effects.BlockScreenshots
 import to.bitkit.ui.shared.util.gradientBackground
@@ -70,7 +70,7 @@ private fun ConfirmPassphraseContent(
             .testTag("backup_confirm_passphrase_screen")
     ) {
         SheetTopBar(stringResource(R.string.security__pass_confirm), onBack = onBack)
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -83,7 +83,7 @@ private fun ConfirmPassphraseContent(
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             TextInput(
                 placeholder = stringResource(R.string.security__pass).replaceFirstChar { it.uppercase() },
@@ -100,7 +100,7 @@ private fun ConfirmPassphraseContent(
                     .testTag("backup_passphrase_input")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             PrimaryButton(
                 text = stringResource(R.string.common__continue),
@@ -109,7 +109,7 @@ private fun ConfirmPassphraseContent(
                 modifier = Modifier.testTag("backup_confirm_passphrase_continue_button")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/backups/MetadataScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/MetadataScreen.kt
@@ -2,10 +2,8 @@ package to.bitkit.ui.settings.backups
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -23,6 +21,7 @@ import to.bitkit.ext.toLocalizedTimestamp
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyS
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppThemeSurface
@@ -66,7 +65,7 @@ private fun MetadataContent(
             .testTag("backup_metadata_screen")
     ) {
         SheetTopBar(stringResource(R.string.security__mnemonic_data_header), onBack = onBack)
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -92,7 +91,7 @@ private fun MetadataContent(
                 modifier = Modifier.testTag("backup_time_text")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             PrimaryButton(
                 text = stringResource(R.string.common__ok),
@@ -100,7 +99,7 @@ private fun MetadataContent(
                 modifier = Modifier.testTag("OK")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/backups/MultipleDevicesScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/MultipleDevicesScreen.kt
@@ -2,10 +2,8 @@ package to.bitkit.ui.settings.backups
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -20,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppThemeSurface
@@ -49,7 +48,7 @@ private fun MultipleDevicesContent(
             .testTag("multiple_devices_screen")
     ) {
         SheetTopBar(stringResource(R.string.security__mnemonic_multiple_header), onBack = onBack)
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -76,7 +75,7 @@ private fun MultipleDevicesContent(
                 modifier = Modifier.testTag("OK")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/backups/ResetAndRestoreScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/ResetAndRestoreScreen.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -30,6 +28,7 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Sheet
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppAlertDialog
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -71,7 +70,7 @@ private fun Content(
             onBackClick = onBack,
             actions = { DrawerNavIcon() },
         )
-        Spacer(Modifier.height(32.dp))
+        VerticalSpacer(32.dp)
 
         Column(
             modifier = Modifier
@@ -114,7 +113,7 @@ private fun Content(
                 )
             }
 
-            Spacer(Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
 
         if (showConfirmDialog) {

--- a/app/src/main/java/to/bitkit/ui/settings/backups/ShowMnemonicScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/ShowMnemonicScreen.kt
@@ -10,10 +10,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -45,9 +43,11 @@ import to.bitkit.models.Toast
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyS
 import to.bitkit.ui.components.BottomSheetPreview
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.MnemonicWordsGrid
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SheetSize
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.effects.BlockScreenshots
 import to.bitkit.ui.shared.modifiers.sheetHeight
@@ -125,7 +125,7 @@ private fun ShowMnemonicContent(
             .testTag("backup_show_mnemonic_screen")
     ) {
         SheetTopBar(stringResource(R.string.security__mnemonic_your))
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -147,7 +147,7 @@ private fun ShowMnemonicContent(
                 )
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Box(
                 modifier = Modifier.fillMaxWidth()
@@ -189,15 +189,15 @@ private fun ShowMnemonicContent(
                 }
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             BodyS(
                 text = stringResource(R.string.security__mnemonic_never_share).withAccent(accentColor = Colors.Brand),
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.weight(1f))
-            Spacer(modifier = Modifier.height(24.dp))
+            FillHeight()
+            VerticalSpacer(24.dp)
 
             PrimaryButton(
                 text = stringResource(R.string.common__continue),
@@ -206,7 +206,7 @@ private fun ShowMnemonicContent(
                 modifier = Modifier.testTag("ContinueShowMnemonic")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/backups/ShowPassphraseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/ShowPassphraseScreen.kt
@@ -2,10 +2,8 @@ package to.bitkit.ui.settings.backups
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -21,7 +19,9 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMSB
 import to.bitkit.ui.components.BodyS
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.effects.BlockScreenshots
 import to.bitkit.ui.shared.util.gradientBackground
@@ -58,7 +58,7 @@ private fun ShowPassphraseContent(
             .testTag("backup_show_passphrase_screen")
     ) {
         SheetTopBar(stringResource(R.string.security__pass_your), onBack = onBack)
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -70,7 +70,7 @@ private fun ShowPassphraseContent(
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Column(
                 modifier = Modifier
@@ -85,7 +85,7 @@ private fun ShowPassphraseContent(
                     color = Colors.White64,
                 )
 
-                Spacer(modifier = Modifier.height(8.dp))
+                VerticalSpacer(8.dp)
 
                 BodyMSB(
                     text = bip39Passphrase,
@@ -94,14 +94,14 @@ private fun ShowPassphraseContent(
                 )
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
             BodyS(
                 text = stringResource(R.string.security__pass_never_share).withAccent(accentColor = Colors.Brand),
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.weight(1f))
-            Spacer(modifier = Modifier.height(24.dp))
+            FillHeight()
+            VerticalSpacer(24.dp)
 
             PrimaryButton(
                 text = stringResource(R.string.common__continue),
@@ -109,7 +109,7 @@ private fun ShowPassphraseContent(
                 modifier = Modifier.testTag("backup_show_passphrase_continue_button")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/backups/SuccessScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/SuccessScreen.kt
@@ -2,10 +2,8 @@ package to.bitkit.ui.settings.backups
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -20,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppThemeSurface
@@ -50,7 +49,7 @@ private fun SuccessContent(
             .testTag("backup_success_screen")
     ) {
         SheetTopBar(stringResource(R.string.security__mnemonic_result_header), onBack = onBack)
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -77,7 +76,7 @@ private fun SuccessContent(
                 modifier = Modifier.testTag("OK")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/backups/WarningScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backups/WarningScreen.kt
@@ -2,10 +2,8 @@ package to.bitkit.ui.settings.backups
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -20,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppThemeSurface
@@ -50,7 +49,7 @@ private fun WarningContent(
             .testTag("backup_warning_screen")
     ) {
         SheetTopBar(stringResource(R.string.security__mnemonic_keep_header), onBack = onBack)
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             modifier = Modifier
@@ -78,7 +77,7 @@ private fun WarningContent(
                 modifier = Modifier.testTag("OK")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/general/DefaultUnitSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/general/DefaultUnitSettingsScreen.kt
@@ -1,8 +1,6 @@
 package to.bitkit.ui.settings.general
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -18,6 +16,7 @@ import to.bitkit.models.BitcoinDisplayUnit
 import to.bitkit.models.PrimaryDisplay
 import to.bitkit.repositories.CurrencyState
 import to.bitkit.ui.LocalCurrencies
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SectionFooter
 import to.bitkit.ui.components.settings.SectionHeader
 import to.bitkit.ui.components.settings.SettingsButtonRow
@@ -106,7 +105,7 @@ fun DefaultUnitSettingsScreenContent(
                 )
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/pin/ChangePinConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/ChangePinConfirmScreen.kt
@@ -2,7 +2,6 @@ package to.bitkit.ui.settings.pin
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -26,10 +25,12 @@ import to.bitkit.env.Env
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyS
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.KEY_DELETE
 import to.bitkit.ui.components.NumberPad
 import to.bitkit.ui.components.NumberPadType
 import to.bitkit.ui.components.PinDots
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.navigateToChangePinResult
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -100,7 +101,7 @@ private fun ChangePinConfirmContent(
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             AnimatedVisibility(visible = showError) {
                 BodyS(
@@ -118,7 +119,7 @@ private fun ChangePinConfirmContent(
                 modifier = Modifier.padding(vertical = 16.dp),
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             NumberPad(
                 onPress = onKeyPress,

--- a/app/src/main/java/to/bitkit/ui/settings/pin/ChangePinNewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/ChangePinNewScreen.kt
@@ -1,7 +1,6 @@
 package to.bitkit.ui.settings.pin
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -20,10 +19,12 @@ import androidx.navigation.NavController
 import to.bitkit.R
 import to.bitkit.env.Env
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.KEY_DELETE
 import to.bitkit.ui.components.NumberPad
 import to.bitkit.ui.components.NumberPadType
 import to.bitkit.ui.components.PinDots
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.navigateToChangePinConfirm
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -82,14 +83,14 @@ private fun ChangePinNewContent(
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             PinDots(
                 pin = pin,
                 modifier = Modifier.padding(vertical = 16.dp),
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             NumberPad(
                 onPress = onKeyPress,

--- a/app/src/main/java/to/bitkit/ui/settings/pin/ChangePinResultScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/ChangePinResultScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.settings.pin
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -21,6 +19,7 @@ import to.bitkit.R
 import to.bitkit.ui.Routes
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.ScreenColumn
 import to.bitkit.ui.theme.AppThemeSurface
@@ -74,7 +73,7 @@ private fun ChangePinResultContent(
                 modifier = Modifier.testTag("OK")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/pin/ChangePinScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/ChangePinScreen.kt
@@ -2,7 +2,6 @@ package to.bitkit.ui.settings.pin
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -25,10 +24,12 @@ import to.bitkit.env.Env
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyS
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.KEY_DELETE
 import to.bitkit.ui.components.NumberPad
 import to.bitkit.ui.components.NumberPadType
 import to.bitkit.ui.components.PinDots
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.navigateToChangePinNew
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -100,7 +101,7 @@ private fun ChangePinContent(
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             AnimatedVisibility(visible = attemptsRemaining < Env.PIN_ATTEMPTS) {
                 if (isLastAttempt) {
@@ -121,7 +122,7 @@ private fun ChangePinContent(
                             .testTag("AttemptsRemaining")
                     )
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                VerticalSpacer(16.dp)
             }
 
             PinDots(
@@ -129,7 +130,7 @@ private fun ChangePinContent(
                 modifier = Modifier.padding(vertical = 16.dp),
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             NumberPad(
                 onPress = onKeyPress,

--- a/app/src/main/java/to/bitkit/ui/settings/pin/DisablePinScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/DisablePinScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.settings.pin
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -23,6 +21,7 @@ import to.bitkit.ui.Routes
 import to.bitkit.ui.components.AuthCheckAction
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.navigateToAuthCheck
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -84,7 +83,7 @@ private fun DisablePinContent(
                 modifier = Modifier.testTag("DisablePin")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/pin/PinBiometricsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/PinBiometricsScreen.kt
@@ -8,11 +8,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -34,8 +32,10 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMSB
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.settingsViewModel
 import to.bitkit.ui.shared.modifiers.clickableAlpha
@@ -99,7 +99,7 @@ private fun AskForBiometricsContent(
     ) {
         SheetTopBar(stringResource(R.string.security__bio))
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         if (!isBiometrySupported) {
             BioNotAvailableView(onSkip = onSkip)
@@ -120,7 +120,7 @@ private fun AskForBiometricsContent(
                     color = Colors.White64,
                 )
 
-                Spacer(modifier = Modifier.weight(1f))
+                FillHeight()
 
                 Icon(
                     painter = painterResource(R.drawable.ic_touch_id),
@@ -129,7 +129,7 @@ private fun AskForBiometricsContent(
                     modifier = Modifier.size(134.dp),
                 )
 
-                Spacer(modifier = Modifier.weight(1f))
+                FillHeight()
 
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -152,7 +152,7 @@ private fun AskForBiometricsContent(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(32.dp))
+                VerticalSpacer(32.dp)
 
                 PrimaryButton(
                     text = stringResource(R.string.common__continue),
@@ -164,7 +164,7 @@ private fun AskForBiometricsContent(
             }
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
     }
 }
 
@@ -185,7 +185,7 @@ private fun ColumnScope.BioNotAvailableView(
             color = Colors.White64,
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         Image(
             painter = painterResource(R.drawable.cog),
@@ -195,7 +195,7 @@ private fun ColumnScope.BioNotAvailableView(
                 .aspectRatio(1f),
         )
 
-        Spacer(modifier = Modifier.weight(1f))
+        FillHeight()
 
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/to/bitkit/ui/settings/pin/PinChooseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/PinChooseScreen.kt
@@ -2,7 +2,6 @@ package to.bitkit.ui.settings.pin
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -19,10 +18,12 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.env.Env
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.KEY_DELETE
 import to.bitkit.ui.components.NumberPad
 import to.bitkit.ui.components.NumberPadType
 import to.bitkit.ui.components.PinDots
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppThemeSurface
@@ -44,7 +45,7 @@ fun PinChooseScreen(
     ) {
         SheetTopBar(titleText = stringResource(R.string.security__pin_choose_header), onBack = onBack)
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         BodyM(
             text = stringResource(R.string.security__pin_choose_text),
@@ -52,12 +53,12 @@ fun PinChooseScreen(
             modifier = Modifier.padding(horizontal = 32.dp),
         )
 
-        Spacer(modifier = Modifier.height(32.dp))
-        Spacer(modifier = Modifier.weight(1f))
+        VerticalSpacer(32.dp)
+        FillHeight()
 
         PinDots(pin = pin)
 
-        Spacer(modifier = Modifier.height(32.dp))
+        VerticalSpacer(32.dp)
 
         NumberPad(
             onPress = { key ->

--- a/app/src/main/java/to/bitkit/ui/settings/pin/PinConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/PinConfirmScreen.kt
@@ -3,7 +3,6 @@ package to.bitkit.ui.settings.pin
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -26,10 +25,12 @@ import to.bitkit.env.Env
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyS
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.KEY_DELETE
 import to.bitkit.ui.components.NumberPad
 import to.bitkit.ui.components.NumberPadType
 import to.bitkit.ui.components.PinDots
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppThemeSurface
@@ -93,7 +94,7 @@ private fun ConfirmPinContent(
             onBack = onBack,
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         BodyM(
             text = stringResource(R.string.security__pin_retype_text),
@@ -101,8 +102,8 @@ private fun ConfirmPinContent(
             modifier = Modifier.padding(horizontal = 32.dp),
         )
 
-        Spacer(modifier = Modifier.height(32.dp))
-        Spacer(modifier = Modifier.weight(1f))
+        VerticalSpacer(32.dp)
+        FillHeight()
 
         AnimatedVisibility(visible = showError) {
             BodyS(
@@ -116,11 +117,11 @@ private fun ConfirmPinContent(
             )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         PinDots(pin = pin)
 
-        Spacer(modifier = Modifier.height(32.dp))
+        VerticalSpacer(32.dp)
 
         NumberPad(
             onPress = onKeyPress,

--- a/app/src/main/java/to/bitkit/ui/settings/pin/PinPromptScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/PinPromptScreen.kt
@@ -4,14 +4,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,9 +22,11 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BottomSheetPreview
 import to.bitkit.ui.components.Display
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.SheetSize
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.shared.util.gradientBackground
@@ -76,14 +75,14 @@ fun PinPromptScreen(
 
             Display(text = stringResource(R.string.security__pin_security_title).withAccent(accentColor = Colors.Green))
 
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
 
             BodyM(
                 text = stringResource(R.string.security__pin_security_text),
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Row(
                 modifier = Modifier.fillMaxWidth()
@@ -97,7 +96,7 @@ fun PinPromptScreen(
                             .testTag("SecureWalletContinue")
                     )
 
-                    Spacer(modifier = Modifier.width(16.dp))
+                    HorizontalSpacer(16.dp)
                 }
 
                 PrimaryButton(
@@ -109,7 +108,7 @@ fun PinPromptScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/pin/PinResultScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/pin/PinResultScreen.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -26,7 +24,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMSB
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.settingsViewModel
 import to.bitkit.ui.shared.modifiers.clickableAlpha
@@ -70,7 +70,7 @@ private fun PinResultContent(
     ) {
         SheetTopBar(stringResource(R.string.security__success_title))
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
 
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -88,7 +88,7 @@ private fun PinResultContent(
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Image(
                 painter = painterResource(R.drawable.check),
@@ -97,7 +97,7 @@ private fun PinResultContent(
                     .size(256.dp)
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -115,7 +115,7 @@ private fun PinResultContent(
                 )
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             PrimaryButton(
                 text = stringResource(R.string.common__ok),
@@ -124,7 +124,7 @@ private fun PinResultContent(
             )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        VerticalSpacer(16.dp)
     }
 }
 

--- a/app/src/main/java/to/bitkit/ui/settings/quickPay/QuickPaySettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/quickPay/QuickPaySettingsScreen.kt
@@ -2,7 +2,6 @@ package to.bitkit.ui.settings.quickPay
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -21,7 +20,9 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyS
 import to.bitkit.ui.components.Caption13Up
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.StepSlider
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsSwitchRow
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -67,7 +68,7 @@ fun QuickPaySettingsScreenContent(
         Column(
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             SettingsSwitchRow(
                 title = stringResource(R.string.settings__quickpay__settings__toggle),
@@ -76,7 +77,7 @@ fun QuickPaySettingsScreenContent(
                 modifier = Modifier.testTag("QuickpayToggle")
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             BodyM(
                 text = stringResource(R.string.settings__quickpay__settings__text)
@@ -84,14 +85,14 @@ fun QuickPaySettingsScreenContent(
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             Caption13Up(
                 text = stringResource(R.string.settings__quickpay__settings__label),
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             StepSlider(
                 value = quickPayAmount,
@@ -100,7 +101,7 @@ fun QuickPaySettingsScreenContent(
                 modifier = Modifier.testTag("quickpay_amount_slider")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
             Image(
                 painter = painterResource(R.drawable.fast_forward),
                 contentDescription = null,
@@ -108,14 +109,14 @@ fun QuickPaySettingsScreenContent(
                     .fillMaxWidth()
                     .height(256.dp)
             )
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             BodyS(
                 text = stringResource(R.string.settings__quickpay__settings__note),
                 color = Colors.White64,
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/support/ReportIssueResultScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/support/ReportIssueResultScreen.kt
@@ -2,9 +2,7 @@ package to.bitkit.ui.settings.support
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -41,7 +40,7 @@ fun ReportIssueResultScreen(
         Column(
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             BodyM(
                 text = if (isSuccess) {
@@ -68,7 +67,7 @@ fun ReportIssueResultScreen(
                 },
                 onClick = { if (isSuccess) onClose() else onBack() }
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/support/ReportIssueScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/support/ReportIssueScreen.kt
@@ -1,9 +1,7 @@
 package to.bitkit.ui.settings.support
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
@@ -23,6 +21,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.TextInput
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -75,7 +74,7 @@ fun ReportIssueContent(
                 .padding(horizontal = 16.dp)
                 .testTag(ReportIssueTestTags.SCREEN)
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             BodyM(
                 text = stringResource(R.string.settings__support__report_text),
@@ -83,7 +82,7 @@ fun ReportIssueContent(
                 modifier = Modifier.testTag(ReportIssueTestTags.DESCRIPTION)
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             BodyM(
                 text = stringResource(R.string.settings__support__label_address),
@@ -91,7 +90,7 @@ fun ReportIssueContent(
                 modifier = Modifier.testTag(ReportIssueTestTags.EMAIL_LABEL)
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
 
             TextInput(
                 placeholder = stringResource(R.string.settings__support__placeholder_address),
@@ -110,7 +109,7 @@ fun ReportIssueContent(
                     .testTag(ReportIssueTestTags.EMAIL_INPUT)
             )
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             BodyM(
                 text = stringResource(R.string.settings__support__label_message),
@@ -118,7 +117,7 @@ fun ReportIssueContent(
                 modifier = Modifier.testTag(ReportIssueTestTags.MESSAGE_LABEL)
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
 
             TextInput(
                 placeholder = stringResource(R.string.settings__support__placeholder_message),
@@ -131,7 +130,7 @@ fun ReportIssueContent(
                     .testTag(ReportIssueTestTags.MESSAGE_INPUT)
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
 
             PrimaryButton(
                 text = stringResource(R.string.settings__support__text_button),
@@ -141,7 +140,7 @@ fun ReportIssueContent(
                 modifier = Modifier.testTag(ReportIssueTestTags.SEND_BUTTON)
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/support/SupportScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/support/SupportScreen.kt
@@ -3,9 +3,7 @@ package to.bitkit.ui.settings.support
 import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -21,6 +19,7 @@ import to.bitkit.R
 import to.bitkit.env.Env
 import to.bitkit.ui.Routes
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.Links
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.scaffold.AppTopBar
@@ -63,11 +62,11 @@ private fun Content(
         Column(
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             BodyM(text = stringResource(R.string.settings__support__text), color = Colors.White64)
 
-            Spacer(modifier = Modifier.height(32.dp))
+            VerticalSpacer(32.dp)
 
             SettingsButtonRow(title = stringResource(R.string.settings__support__report), onClick = onClickReportIssue)
             SettingsButtonRow(title = stringResource(R.string.settings__support__help), onClick = onClickHelpCenter)
@@ -87,7 +86,7 @@ private fun Content(
 
             Links(modifier = Modifier.fillMaxWidth())
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/transactionSpeed/CustomFeeSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/transactionSpeed/CustomFeeSettingsScreen.kt
@@ -1,7 +1,6 @@
 package to.bitkit.ui.settings.transactionSpeed
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,11 +24,13 @@ import to.bitkit.models.ConvertedAmount
 import to.bitkit.models.TransactionSpeed
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Caption13Up
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.KEY_DELETE
 import to.bitkit.ui.components.LargeRow
 import to.bitkit.ui.components.NumberPad
 import to.bitkit.ui.components.NumberPadType
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.currencyViewModel
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -114,7 +115,7 @@ private fun CustomFeeSettingsContent(
         ) {
             Caption13Up(text = stringResource(R.string.common__sat_vbyte), color = Colors.White64)
 
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
             LargeRow(
                 prefix = null,
                 text = input.ifEmpty { "0" },
@@ -123,11 +124,11 @@ private fun CustomFeeSettingsContent(
             )
 
             if (isValid) {
-                Spacer(modifier = Modifier.height(8.dp))
+                VerticalSpacer(8.dp)
                 BodyM(totalFeeText, color = Colors.White64)
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             NumberPad(
                 onPress = onKeyPress,
@@ -140,7 +141,7 @@ private fun CustomFeeSettingsContent(
                 text = stringResource(R.string.common__continue),
                 modifier = Modifier.testTag("Continue")
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            VerticalSpacer(16.dp)
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/sheets/NewTransactionSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/NewTransactionSheet.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -37,8 +35,10 @@ import to.bitkit.ui.LocalSettingsViewModel
 import to.bitkit.ui.components.BalanceHeaderView
 import to.bitkit.ui.components.BottomSheet
 import to.bitkit.ui.components.BottomSheetPreview
+import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.shared.util.gradientBackground
@@ -152,7 +152,7 @@ fun NewTransactionSheetView(
 
             SheetTopBar(titleText)
 
-            Spacer(modifier = Modifier.height(24.dp))
+            VerticalSpacer(24.dp)
 
             BalanceHeaderView(
                 sats = details.sats,
@@ -161,7 +161,7 @@ fun NewTransactionSheetView(
                     .testTag("ReceivedTransaction")
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            FillHeight()
 
             if (details.direction == NewTransactionSheetDirection.SENT) {
                 Row(
@@ -193,7 +193,7 @@ fun NewTransactionSheetView(
                     modifier = Modifier.testTag("ReceivedTransactionButton")
                 )
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            VerticalSpacer(8.dp)
         }
     }
 }


### PR DESCRIPTION
### Description

This PR:
1. Adds a `modifier` parameter to all custom spacer components in `Spacers.kt` — `VerticalSpacer`, `HorizontalSpacer`, `FillHeight`, `FillWidth`, `StatusBarSpacer`, `TopBarSpacer`
2. Replaces all raw `Spacer(modifier = Modifier.height/width/weight(...))` calls across 110 files with the appropriate semantic component

Each raw call was replaced according to context:
- `Modifier.height(X)` → `VerticalSpacer(X)`
- `Modifier.width(X)` → `HorizontalSpacer(X)`
- `Modifier.weight(1f)` in Column → `FillHeight()`
- `Modifier.weight(1f)` in Row → `FillWidth()`

Unused `androidx.compose.foundation.layout.Spacer`, `height`, and `width` imports were removed from each modified file. The `FillHeight`/`FillWidth` scope constraints (`ColumnScope`/`RowScope`) provide compile-time safety — any misidentified context would have caused a build failure.

### Preview

N/A — pure refactor, no visual changes.

### QA Notes

This is a structural refactor with no behaviour changes. Each custom spacer delegates to the same underlying `Spacer` with the same modifier. The Kotlin compiler enforces correct scope usage for `FillHeight`/`FillWidth`. Manual spot-check recommended on the highest-impact screens:

1. ExternalConnectionScreen
2. SendConfirmScreen
3. ActivityDetailScreen
4. HomeScreen
5. ReceiveQrScreen
6. ReportIssueScreen
7. SweepSettingsScreen
8. SavingsProgressScreen
9. LiquidityScreen
10. PinBiometricsScreen

For each screen: verify layout, spacing, and alignment look unchanged compared to master.

#### Automated checks
- [x] `./gradlew compileDevDebugKotlin` — passes
- [x] `./gradlew detekt` — passes (import ordering auto-corrected)
- [x] `./gradlew testDevDebugUnitTest` — 566 pass, 3 pre-existing `CurrencyTest` failures (locale-sensitive, unrelated to this PR, pass on CI)