### PR TITLE
Update updater to v2.0.3 (build 177) with critical flag

### DIFF
--- a/.github/release.json
+++ b/.github/release.json
@@ -2,12 +2,12 @@
   "platforms": {
     "ios": null,
     "android": {
-      "version": "v2.0.2",
-      "buildNumber": 176,
-      "notes": "https://github.com/synonymdev/bitkit/releases/tag/v2.0.2",
-      "pub_date": "2026-02-16T23:20:07Z",
+      "version": "v2.0.3",
+      "buildNumber": 177,
+      "notes": "https://github.com/synonymdev/bitkit-android/releases/tag/v2.0.3",
+      "pub_date": "2026-02-24T08:49:44Z",
       "url": "https://play.google.com/store/apps/details?id=to.bitkit",
-      "critical": false
+      "critical": true
     }
   }
 }


### PR DESCRIPTION
Update updater release asset to point to v2.0.3 (build 177) with `critical: true` to force users on old builds to update.

### Description

- Bump updater version from v2.0.2 (build 176) to v2.0.3 (build 177)
- Set `critical: true` to enable the blocking update screen
- Update `notes` URL to point to the correct bitkit-android release tag
- Update `pub_date` to current release timestamp

### Preview

N/A — metadata-only change.

### QA Notes

After merging, the release asset needs to be replaced:
```bash
gh release delete-asset updater release.json --repo synonymdev/bitkit-android --yes
gh release upload updater .github/release.json#release.json --repo synonymdev/bitkit-android
```

Then verify:
```bash
curl -sL https://github.com/synonymdev/bitkit-android/releases/download/updater/release.json | python3 -m json.tool
```

Should return `"version": "v2.0.3"` with `"critical": true`.