### PR TITLE
chore: update ldk-node to rc.28

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.26" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.28" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }


### PR DESCRIPTION
## Summary
- Bumps ldk-node from `v0.7.0-rc.26` to `v0.7.0-rc.28`
- Companion to synonymdev/ldk-node#63

## Changes in ldk-node
- Switched from forked rust-lightning to official upstream crates.io releases (lightning v0.2.2, lightning-transaction-sync v0.2.1)
- Fixed peer address upsert on connect (v0.7.0-rc.27)
- Regenerated all bindings

## Test plan
- rely on e2e & CI