### PR TITLE
chore: update ldk-node to rc.29

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.28" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.29" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }


### PR DESCRIPTION
## Summary
- Bumps ldk-node from `v0.7.0-rc.28` to `v0.7.0-rc.29`
- Companion to synonymdev/ldk-node#66

## Changes in ldk-node
- Bumped feerate and tx broadcast timeouts from 5s to 15s (fixes `FeerateEstimationUpdateTimeout` on slow Electrum servers)
- Fixed external scores sync task type (was using wrong spawn function, causing `debug_assert` panic)

## Test plan
- rely on e2e & CI