### PR TITLE
chore: bump ldk-node v0.7.0-rc.31

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.29" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.31" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }


### PR DESCRIPTION
## Summary
- Bump `ldk-node-android` from `0.7.0-rc.29` to `0.7.0-rc.31`

See [ldk-node PR #71](https://github.com/synonymdev/ldk-node/pull/71) for full details.

## Test plan
- [ ] Verify CI passes (dependency resolves from GitHub Packages)
- [ ] Verify e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)