### PR TITLE
test: split android e2e local and regtest (e2e multiple address)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
         required: false
         default: "default-feature-branch"
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 env:
   TERM: xterm-256color


### PR DESCRIPTION
### Description

This PR updates Android E2E workflow sharding to run regtest-only multi-address coverage on regtest build artifacts and keep the remaining multi-address scenarios on local.

- Splits workflow into `build-local` and `build-regtest`.
- Adds `e2e-tests-local` and `e2e-tests-regtest`.
- Runs `@multi_address_2` only in `e2e-tests-regtest` with `BACKEND=regtest`.
- Adds a dedicated local shard for `@multi_address_1|@multi_address_3|@multi_address_4`.
- Updates final status check to require both local and regtest jobs.

### Preview

N/A (CI workflow changes only)

### QA Notes

1. Open a PR from `test/multiple-addresses-types` to `feat/multiple-addresses-types` and confirm both workflows are triggered.
2. Confirm `e2e-tests-regtest - multi_address_2_regtest` runs with regtest APK artifact and `BACKEND=regtest`.
3. Confirm local job includes `multi_address_local` shard running `@multi_address_1|@multi_address_3|@multi_address_4`.
4. Confirm `e2e-status` fails if either local or regtest job fails.
