### PR TITLE
fix: use send-all fee for channel funding

### DIFF
--- a/app/src/main/java/to/bitkit/usecases/DeriveBalanceStateUseCase.kt
+++ b/app/src/main/java/to/bitkit/usecases/DeriveBalanceStateUseCase.kt
@@ -111,8 +111,9 @@ class DeriveBalanceStateUseCase @Inject constructor(
         if (fundableBalance == 0uL) return 0u
 
         val fallback = (fundableBalance.toDouble() * FALLBACK_FEE_PERCENT).toULong()
-        val fee = lightningRepo.calculateTotalFee(
-            amountSats = fundableBalance,
+        val speed = settingsStore.data.first().defaultTransactionSpeed
+        val fee = lightningRepo.estimateSendAllFee(
+            speed = speed,
         ).onFailure {
             Logger.debug("Could not calculate channel funding fee, using fallback of: $fallback", context = TAG)
         }.getOrDefault(fallback)

--- a/app/src/test/java/to/bitkit/usecases/DeriveBalanceStateUseCaseTest.kt
+++ b/app/src/test/java/to/bitkit/usecases/DeriveBalanceStateUseCaseTest.kt
@@ -43,9 +43,6 @@ class DeriveBalanceStateUseCaseTest : BaseUnitTest() {
             wheneverBlocking { lightningRepo.listSpendableOutputs() }.thenReturn(Result.success(emptyList()))
             wheneverBlocking { lightningRepo.getChannelFundableBalance() }.thenReturn(0uL)
             wheneverBlocking {
-                lightningRepo.calculateTotalFee(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
-            }.thenReturn(Result.success(1000uL))
-            wheneverBlocking {
                 lightningRepo.estimateSendAllFee(anyOrNull(), anyOrNull(), anyOrNull())
             }.thenReturn(Result.success(1000uL))
         }
@@ -107,7 +104,7 @@ class DeriveBalanceStateUseCaseTest : BaseUnitTest() {
         whenever(lightningRepo.getChannels()).thenReturn(emptyList())
         whenever(transferRepo.activeTransfers).thenReturn(flowOf(emptyList()))
         wheneverBlocking {
-            lightningRepo.calculateTotalFee(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+            lightningRepo.estimateSendAllFee(anyOrNull(), anyOrNull(), anyOrNull())
         }.thenReturn(Result.success(fee))
 
         val result = sut()
@@ -133,7 +130,7 @@ class DeriveBalanceStateUseCaseTest : BaseUnitTest() {
         whenever(lightningRepo.getChannels()).thenReturn(emptyList())
         whenever(transferRepo.activeTransfers).thenReturn(flowOf(emptyList()))
         wheneverBlocking {
-            lightningRepo.calculateTotalFee(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+            lightningRepo.estimateSendAllFee(anyOrNull(), anyOrNull(), anyOrNull())
         }.thenReturn(Result.failure(Exception("Fee estimation failed")))
 
         val result = sut()


### PR DESCRIPTION
This PR fixes the fee estimation for channel funding when using the full onchain balance.

### Description

`getMaxChannelFundableAmount()` was using `calculateTotalFee()` which builds a regular transaction and fails with "Coin selection failed" when funding a channel with the entire balance (produces dust change). This switches to `estimateSendAllFee()` which is designed for drain transactions, matching the pattern already used in `getMaxSendAmount()`.

### Preview

No UI changes, fixes bug causing error in logs about estimating fee for full wallet balance.

### QA Notes

1. Verify app logs don't show these errors anymore:
```log
2026-03-05 13:16:46.100 ERROR   [ldk_node::wallet:1173]              Failed to create transaction: Coin selection failed
2026-03-05 13:16:46.101 WARN    [LightningService.kt:867]            Error calculating fee for 1000 sats to bcrt1pr0kc8wpe8x2pekxfzcfc5ax4p3ak5gwy25ushfp2f67fglkde67qflgpsa, null UTXOs, satsPerVByte=1 [OnchainTxCreationFailed='On-chain transaction could not be created.'] - LightningService
2026-03-05 13:16:46.104 WARN    [LightningRepo.kt:1107]              calculateTotalFee error, using fallback of '1000' [AppError='LDK Node error: Failed to create on-chain transaction.'] - LightningRepo
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)