### PR TITLE
fix(ui): prevent screen rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
             android:name=".ui.MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.App.Splash"
             android:windowSoftInputMode="adjustResize|stateHidden">
             <intent-filter>


### PR DESCRIPTION
### Description

Prevent screen rotation / putting app in landscape mode

### QA Notes

Try to put app in landscape mode, it shouldn't let you.