### PR TITLE
Fix: simplify dismissed suggestions filtering with mapNotNull

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -20,7 +20,6 @@ import to.bitkit.models.BannerItem
 import to.bitkit.models.Suggestion
 import to.bitkit.models.TransferType
 import to.bitkit.models.WidgetType
-import to.bitkit.models.toSuggestionOrNull
 import to.bitkit.models.widget.ArticleModel
 import to.bitkit.models.widget.toArticleModel
 import to.bitkit.models.widget.toBlockModel
@@ -293,7 +292,6 @@ class HomeViewModel @Inject constructor(
                 )
             }
         }
-        val dismissedList = settings.dismissedSuggestions.mapNotNull { it.toSuggestionOrNull() }
-        baseSuggestions.filterNot { it in dismissedList }
+        baseSuggestions.mapNotNull { it.takeIf { suggestion -> suggestion.name !in settings.dismissedSuggestions } }
     }
 }


### PR DESCRIPTION
## Summary
Simplifies the dismissed suggestions filtering in `createSuggestionsFlow()` by replacing the two-step approach (converting strings back to `Suggestion` enum values via `toSuggestionOrNull`, then filtering) with a single `mapNotNull` expression that directly checks each suggestion's `name` against the raw `dismissedSuggestions: List<String>`.

## Changes
- `HomeViewModel.kt`: Replace intermediate `dismissedList` variable + `filterNot` with a single `mapNotNull { it.takeIf { suggestion -> suggestion.name !in settings.dismissedSuggestions } }`
- `HomeViewModel.kt`: Remove now-unused `import to.bitkit.models.toSuggestionOrNull`

## Testing
- Behaviour is unchanged: dismissed suggestions are still excluded from the displayed list
- `toSuggestionOrNull` in `Suggestion.kt` is preserved as it may be used elsewhere