### PR TITLE
chore: align release command with ios conventions

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -163,12 +163,17 @@ Create `.ai/` directory if it doesn't exist. Save to `.ai/release-notes-{newVers
 Then prepend the English summary to the draft release body on GitHub:
 
 ```bash
-# Read existing body and prepend store summary via temp file (avoids shell expansion issues)
-EXISTING=$(gh release view v{newVersionName} --json body --jq .body)
-printf '%s\n\n%s\n\n---\n\n%s\n' \
-  '## Store Release Notes' \
-  '{english summary}' \
-  "$EXISTING" > /tmp/release-notes.md
+# Write store summary via heredoc (avoids shell expansion of apostrophes, $, backticks)
+cat > /tmp/release-notes.md <<'NOTES_EOF'
+## Store Release Notes
+
+{english summary}
+
+---
+
+NOTES_EOF
+# Append existing auto-generated notes
+gh release view v{newVersionName} --json body --jq .body >> /tmp/release-notes.md
 gh release edit v{newVersionName} --notes-file /tmp/release-notes.md
 ```
 


### PR DESCRIPTION
This PR aligns the Android `/release` command with the conventions established in the iOS release automation ([bitkit-ios#478](https://github.com/synonymdev/bitkit-ios/pull/478)).

### Description

1. Uses `release-{version}` branch naming (e.g. `release-2.1.0`) instead of `release/{versionCode}`
2. Fixes stale master bug by adding conditional `git pull` when branching from master (skip for tags)
3. Uses `--notes-file` with a temp file for prepending store release notes, avoiding shell expansion issues with backticks and `$` in PR titles

### Preview

N/A

### QA Notes

N/A — changes only affect the `/release` automation command, no app code modified.

Made with [Cursor](https://cursor.com)