### PR TITLE
fix: account for routing fees in lightning send validation

### DIFF
--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -1146,18 +1146,26 @@ class AppViewModel @Inject constructor(
         if (amount == 0uL) return false
 
         return when (payMethod) {
-            SendMethod.LIGHTNING -> when (val lnurl = _sendUiState.value.lnurl) {
-                null -> lightningRepo.canSend(amount)
-                is LnurlParams.LnurlWithdraw -> amount < lnurl.data.maxWithdrawableSat()
-                is LnurlParams.LnurlPay -> {
-                    val maxSat = lnurl.data.maxSendableSat()
-
-                    amount <= maxSat && lightningRepo.canSend(amount)
+            SendMethod.LIGHTNING -> {
+                val maxSendable = maxSendableLightningSats()
+                when (val lnurl = _sendUiState.value.lnurl) {
+                    null -> amount <= maxSendable && lightningRepo.canSend(amount)
+                    is LnurlParams.LnurlWithdraw -> amount < lnurl.data.maxWithdrawableSat()
+                    is LnurlParams.LnurlPay -> {
+                        val maxSat = lnurl.data.maxSendableSat()
+                        amount <= maxSat && amount <= maxSendable && lightningRepo.canSend(amount)
+                    }
                 }
             }
 
             SendMethod.ONCHAIN -> amount > Defaults.dustLimit.toULong()
         }
+    }
+
+    private fun maxSendableLightningSats(): ULong {
+        val max = walletRepo.balanceState.value.maxSendLightningSats
+        val fee = _sendUiState.value.estimatedRoutingFee
+        return max.safe() - fee.safe()
     }
 
     private fun onPasteClick() {


### PR DESCRIPTION
Fixes #790

This PR caps the Lightning send amount validation to account for estimated routing fees, preventing users from entering amounts that pass validation but fail at send time.

### Description

When sending max or near-max Lightning payments, `validateAmount()` only checked raw channel HTLC capacity via `canSend(amount)` without subtracting routing fees. This meant amounts between the fee-adjusted max and the raw HTLC limit would pass validation but fail when LDK tried to route the payment (since routing fees consume part of the channel capacity).

The fix adds a `maxSendableLightningSats()` helper that computes `maxSendLightningSats - estimatedRoutingFee` (using saturating arithmetic), and uses it in `validateAmount()` for both direct Lightning and LNURL-pay flows. This makes the validation consistent with the "Max available" amount already displayed in the UI.

When `estimatedRoutingFee` is 0 (e.g. fee estimation hasn't run yet), it falls back to the existing `canSend()` behavior.

### Preview

<!-- VIDEO_1: Record the send flow showing that Max available amount now succeeds when sending a Lightning payment -->

### QA Notes

#### 1. Bolt11 zero-amount invoice (fee estimation available at amount screen)
1. Create a zero-amount invoice on another wallet
2. Scan it in Bitkit
3. Tap "Max available" on the amount screen
4. Confirm and send
5. Payment should succeed (previously failed for amounts near max)

#### 2. Manual amount entry near max
1. Same setup as above
2. Try manually entering amounts slightly above "Max available"
3. The input should be marked invalid (continue button disabled)

#### 3. LNURL-pay / Lightning address
1. Send to a Lightning address
2. Tap Max or enter the maximum amount
3. Behavior is same as before (fee estimation is not available at the amount screen for LNURL-pay since no decoded invoice exists yet)