### PR TITLE
chore: use e2e updater url for e2e builds

### DIFF
--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -130,7 +130,11 @@ internal object Env {
     const val PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=to.bitkit"
 
     const val REPO_URL = "https://github.com/synonymdev/bitkit-android"
-    const val RELEASE_URL = "$REPO_URL/releases/download/updater/release.json"
+    val RELEASE_URL = if (isE2eTest) {
+        "https://github.com/synonymdev/bitkit-e2e-tests/releases/download/updater/release.json"
+    } else {
+        "$REPO_URL/releases/download/updater/release.json"
+    }
     const val EXCHANGES_URL = "https://bitcoin.org/en/exchanges#international"
     const val BTC_MAP_URL = "https://btcmap.org/map"
     const val BITKIT_WEBSITE = "https://bitkit.to/"


### PR DESCRIPTION
This PR points E2E builds to a separate updater release.json hosted in bitkit-e2e-tests, so production critical updates don't block E2E test runs.

### Description

The production updater currently has `critical: true` for both platforms. E2E builds from master with lower build numbers hit the blocking CriticalUpdate screen immediately, making all tests fail.

When `isE2eTest` is true, `RELEASE_URL` now resolves to:
`https://github.com/synonymdev/bitkit-e2e-tests/releases/download/updater/release.json`

That file has `buildNumber: 0, critical: false` by default, so E2E builds are never blocked. When update flow testing is needed, the E2E release.json can be updated independently.

### Preview

N/A

### QA Notes

1. Build with `E2E=true` and verify the app does not show a critical update screen on startup
2. Build without `E2E=true` and verify the production updater still works as before

Made with [Cursor](https://cursor.com)