### PR TITLE
feat: ignore critical update on debug

### DIFF
--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -2396,7 +2396,7 @@ class AppViewModel @Inject constructor(
     fun dismissTimedSheet() = timedSheetManager.dismissCurrentSheet()
 
     private suspend fun checkCriticalAppUpdate() = withContext(bgDispatcher) {
-        if (!Env.isE2eTest && Env.isDebug) return@withContext
+        if (Env.isDebug) return@withContext
 
         delay(SCREEN_TRANSITION_DELAY)
 


### PR DESCRIPTION
This PR skips the critical update check on debug builds, so the blocking CriticalUpdate screen doesn't interfere during development.

### Description

Adds an early return in the critical update flow when `Env.isDebug` is true, bypassing the remote release check entirely on debug builds.

### Preview

N/A

### QA Notes

1. Build a debug APK and launch — verify no critical update screen appears regardless of the remote release.json state
2. Build a release APK and verify the critical update check still works as expected