### PR TITLE
chore: bump github actions for node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decode google-services.json
         run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > app/google-services.json
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew testDevDebugUnitTest
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: unit_test_report_${{ github.run_number }}
           path: app/build/reports/tests/testDevDebugUnitTest/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
       actions: read        # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for git operations
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       code: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.code == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
@@ -45,16 +45,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "adopt"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decode google-services.json
         run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > app/google-services.json
@@ -76,7 +76,7 @@ jobs:
           mv "$apk" app/build/outputs/apk/dev/debug/bitkit_e2e.apk
 
       - name: Upload APK (local)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bitkit-e2e-apk_${{ github.run_number }}
           path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
@@ -88,16 +88,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "adopt"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decode google-services.json
         run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > app/google-services.json
@@ -120,7 +120,7 @@ jobs:
           mv "$apk" app/build/outputs/apk/dev/debug/bitkit_e2e.apk
 
       - name: Upload APK (regtest)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bitkit-e2e-apk-regtest_${{ github.run_number }}
           path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
@@ -159,7 +159,7 @@ jobs:
         run: echo $E2E_BRANCH
 
       - name: Clone E2E tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: synonymdev/bitkit-e2e-tests
           path: bitkit-e2e-tests
@@ -172,7 +172,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: avd-cache
         with:
           path: |
@@ -194,7 +194,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Download APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: bitkit-e2e-apk_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -203,12 +203,12 @@ jobs:
         run: ls -l bitkit-e2e-tests/aut
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
       - name: Cache npm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -286,7 +286,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-artifacts_${{ matrix.shard.name }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/
@@ -315,7 +315,7 @@ jobs:
         run: echo $E2E_BRANCH
 
       - name: Clone E2E tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: synonymdev/bitkit-e2e-tests
           path: bitkit-e2e-tests
@@ -328,7 +328,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: avd-cache
         with:
           path: |
@@ -350,7 +350,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Download APK (regtest)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: bitkit-e2e-apk-regtest_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -359,12 +359,12 @@ jobs:
         run: ls -l bitkit-e2e-tests/aut
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
       - name: Cache npm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -429,7 +429,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-artifacts-regtest_${{ matrix.shard.name }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/

--- a/.github/workflows/e2e_migration.yml
+++ b/.github/workflows/e2e_migration.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "adopt"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decode google-services.json
         run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > app/google-services.json
@@ -57,7 +57,7 @@ jobs:
           mv "$apk" app/build/outputs/apk/dev/debug/bitkit_e2e.apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bitkit-e2e-apk_${{ github.run_number }}
           path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
@@ -96,7 +96,7 @@ jobs:
         run: echo $E2E_BRANCH
 
       - name: Clone E2E tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: synonymdev/bitkit-e2e-tests
           path: bitkit-e2e-tests
@@ -109,7 +109,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: avd-cache
         with:
           path: |
@@ -131,7 +131,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Download APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: bitkit-e2e-apk_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -145,12 +145,12 @@ jobs:
         run: ls -l bitkit-e2e-tests/aut
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 
       - name: Cache npm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.scenario.name }})
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-artifacts_${{ matrix.scenario.name }}_${{ matrix.rn_version }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Run Detekt Analysis
         run: |
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload lint report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lint_report_${{ github.run_number }}
           path: app/build/reports/detekt/

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -16,16 +16,16 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'adopt'
 
       - name: Cache gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -59,7 +59,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: avd-cache
         with:
           path: |
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload UI test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: compose_test_report
           path: |


### PR DESCRIPTION
### Description

This PR bumps official GitHub Actions to releases that target Node.js 24 on runners (`actions/checkout` v6, `actions/cache` v5, `actions/upload-artifact` / `download-artifact` v6, `actions/setup-node` v5, `actions/setup-java` v5, `gradle/actions/setup-gradle` v5), addressing the deprecation warning for Node.js 20–based action runtimes.

### Preview

### QA Notes

#### 1. CI
1. Open a workflow run for this branch (CI, lint, unit tests, or E2E as appropriate).
2. Confirm the run completes successfully.
3. Confirm the job summary no longer lists the updated actions under the Node.js 20 deprecation notice.
