### PR TITLE
refactor: simplify ui stability changes

### DIFF
--- a/app/src/main/java/to/bitkit/ui/NodeInfoScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/NodeInfoScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -35,7 +34,6 @@ import androidx.navigation.NavController
 import com.synonym.bitkitcore.ILspNode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-
 import org.lightningdevkit.ldknode.BalanceDetails
 import org.lightningdevkit.ldknode.BalanceSource
 import org.lightningdevkit.ldknode.BestBlock

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import com.synonym.bitkitcore.Activity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.models.BalanceState
 import to.bitkit.ui.LocalBalances
@@ -159,7 +158,7 @@ private fun Preview() {
         Box {
             SavingsWalletScreen(
                 isGeoBlocked = false,
-                onchainActivities = previewOnchainActivityItems().toImmutableList(),
+                onchainActivities = previewOnchainActivityItems(),
                 onAllActivityButtonClick = {},
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},
@@ -179,7 +178,7 @@ private fun PreviewTransfer() {
         Box {
             SavingsWalletScreen(
                 isGeoBlocked = false,
-                onchainActivities = previewOnchainActivityItems().toImmutableList(),
+                onchainActivities = previewOnchainActivityItems(),
                 onAllActivityButtonClick = {},
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},
@@ -222,7 +221,7 @@ private fun PreviewGeoBlocked() {
         Box {
             SavingsWalletScreen(
                 isGeoBlocked = true,
-                onchainActivities = previewOnchainActivityItems().toImmutableList(),
+                onchainActivities = previewOnchainActivityItems(),
                 onAllActivityButtonClick = {},
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import com.synonym.bitkitcore.Activity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import org.lightningdevkit.ldknode.ChannelDetails
 import to.bitkit.R
 import to.bitkit.ext.createChannelDetails
@@ -159,7 +158,7 @@ private fun Preview() {
         Box {
             SpendingWalletScreen(
                 channels = persistentListOf(createChannelDetails()),
-                lightningActivities = previewLightningActivityItems().toImmutableList(),
+                lightningActivities = previewLightningActivityItems(),
                 onAllActivityButtonClick = {},
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},
@@ -179,7 +178,7 @@ private fun PreviewTransfer() {
         Box {
             SpendingWalletScreen(
                 channels = persistentListOf(createChannelDetails()),
-                lightningActivities = previewLightningActivityItems().toImmutableList(),
+                lightningActivities = previewLightningActivityItems(),
                 onAllActivityButtonClick = {},
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityDetailScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityDetailScreen.kt
@@ -52,7 +52,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.ext.create
 import to.bitkit.ext.ellipsisMiddle
@@ -227,7 +226,7 @@ fun ActivityDetailScreen(
                     )
                     ActivityDetailContent(
                         item = item,
-                        tags = tags.toImmutableList(),
+                        tags = tags,
                         onRemoveTag = { detailViewModel.removeTag(it) },
                         onAddTagClick = { showAddTagSheet = true },
                         onAssignClick = { showAssignSheet = true },

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -24,7 +23,6 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.collections.immutable.toImmutableSet
 import to.bitkit.R
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.Sheet
@@ -54,7 +52,7 @@ fun AllActivityScreen(
     val startDate by viewModel.startDate.collectAsStateWithLifecycle()
 
     val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
-    val tabs = remember { ActivityTab.entries.toImmutableList() }
+    val tabs = activityTabs
     val currentTabIndex = tabs.indexOf(selectedTab)
 
     AllActivityScreenContent(
@@ -62,7 +60,7 @@ fun AllActivityScreen(
         searchText = searchText,
         onSearchTextChange = { viewModel.setSearchText(it) },
         hasTagFilter = selectedTags.isNotEmpty(),
-        selectedTags = selectedTags.toImmutableSet(),
+        selectedTags = selectedTags,
         hasDateRangeFilter = startDate != null,
         tabs = tabs,
         currentTabIndex = currentTabIndex,
@@ -146,18 +144,20 @@ private fun AllActivityScreenContent(
     }
 }
 
+private val activityTabs = ActivityTab.entries.toImmutableList()
+
 @Preview(showSystemUi = true)
 @Composable
 private fun Preview() {
     AppThemeSurface {
         AllActivityScreenContent(
-            filteredActivities = previewActivityItems.toImmutableList(),
+            filteredActivities = previewActivityItems,
             searchText = "",
             onSearchTextChange = {},
             hasTagFilter = false,
             selectedTags = persistentSetOf(),
             hasDateRangeFilter = false,
-            tabs = ActivityTab.entries.toImmutableList(),
+            tabs = activityTabs,
             currentTabIndex = 0,
             onTabChange = {},
             onBackClick = {},
@@ -181,7 +181,7 @@ private fun PreviewEmpty() {
             hasTagFilter = false,
             selectedTags = persistentSetOf("tag1", "tag2"),
             hasDateRangeFilter = false,
-            tabs = ActivityTab.entries.toImmutableList(),
+            tabs = activityTabs,
             currentTabIndex = 0,
             onTabChange = {},
             onBackClick = {},

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/TagSelectorSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/TagSelectorSheet.kt
@@ -22,7 +22,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
-import kotlinx.collections.immutable.toImmutableSet
 import to.bitkit.R
 import to.bitkit.ui.activityListViewModel
 import to.bitkit.ui.appViewModel
@@ -49,7 +48,7 @@ fun TagSelectorSheet() {
 
     Content(
         availableTags = availableTags,
-        selectedTags = selectedTags.toImmutableSet(),
+        selectedTags = selectedTags,
         onTagClick = {
             activity.toggleTag(it)
             app.hideSheet()

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListFilter.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListFilter.kt
@@ -117,6 +117,8 @@ enum class ActivityTab : TabItem {
         }
 }
 
+private val previewTabs = ActivityTab.entries.toImmutableList()
+
 @Preview
 @Composable
 private fun Preview() {
@@ -128,7 +130,7 @@ private fun Preview() {
             onTagClick = {},
             hasDateRangeFilter = false,
             onDateRangeClick = {},
-            tabs = ActivityTab.entries.toImmutableList(),
+            tabs = previewTabs,
             currentTabIndex = 0,
             onTabChange = {},
             modifier = Modifier.padding(16.dp)
@@ -147,7 +149,7 @@ private fun PreviewWithTags() {
             onTagClick = {},
             hasDateRangeFilter = false,
             onDateRangeClick = {},
-            tabs = ActivityTab.entries.toImmutableList(),
+            tabs = previewTabs,
             currentTabIndex = 0,
             onTabChange = {},
             selectedTags = persistentSetOf("Tag1", "Tag2"),

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.dp
 import com.synonym.bitkitcore.Activity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.ext.rawId
 import to.bitkit.ui.components.BodyM
@@ -68,6 +67,7 @@ fun ActivityListGrouped(
                                 is Activity.Lightning -> "lightning_${item.rawId()}"
                                 is Activity.Onchain -> "onchain_${item.rawId()}"
                             }
+
                             else -> "item_$index"
                         }
                     }
@@ -207,7 +207,7 @@ private fun Preview() {
     AppThemeSurface {
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
             ActivityListGrouped(
-                items = previewActivityItems.toImmutableList(),
+                items = previewActivityItems,
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},
             )

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListSimple.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListSimple.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import com.synonym.bitkitcore.Activity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.ui.components.TertiaryButton
 import to.bitkit.ui.components.VerticalSpacer
@@ -54,7 +53,7 @@ fun ActivityListSimple(
 private fun Preview() {
     AppThemeSurface {
         ActivityListSimple(
-            items = previewActivityItems.toImmutableList(),
+            items = previewActivityItems,
             onAllActivityClick = {},
             onActivityItemClick = {},
         )

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/utils/PreviewItems.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/utils/PreviewItems.kt
@@ -5,10 +5,12 @@ import com.synonym.bitkitcore.LightningActivity
 import com.synonym.bitkitcore.OnchainActivity
 import com.synonym.bitkitcore.PaymentState
 import com.synonym.bitkitcore.PaymentType
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.ext.create
 import java.util.Calendar
 
-val previewActivityItems = buildList {
+val previewActivityItems: ImmutableList<Activity> = buildList {
     val today: Calendar = Calendar.getInstance()
     val yesterday: Calendar = Calendar.getInstance().apply { add(Calendar.DATE, -1) }
     val thisWeek: Calendar = Calendar.getInstance().apply { add(Calendar.DATE, -3) }
@@ -107,7 +109,7 @@ val previewActivityItems = buildList {
             )
         )
     )
-}
+}.toImmutableList()
 
-fun previewOnchainActivityItems() = previewActivityItems.filter { it is Activity.Onchain }
-fun previewLightningActivityItems() = previewActivityItems.filter { it is Activity.Lightning }
+fun previewOnchainActivityItems() = previewActivityItems.filterIsInstance<Activity.Onchain>().toImmutableList()
+fun previewLightningActivityItems() = previewActivityItems.filterIsInstance<Activity.Lightning>().toImmutableList()

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveQrScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveQrScreen.kt
@@ -731,7 +731,7 @@ private fun PreviewAutoMode() {
                 ),
                 lightningState = LightningState(
                     nodeLifecycleState = NodeLifecycleState.Running,
-                    channels = listOf(mockChannel).toImmutableList(),
+                    channels = persistentListOf(mockChannel),
                 ),
                 onClickEditInvoice = {},
                 modifier = Modifier.sheetHeight(),
@@ -798,7 +798,7 @@ private fun PreviewSpendingMode() {
                 ),
                 lightningState = LightningState(
                     nodeLifecycleState = NodeLifecycleState.Running,
-                    channels = listOf(mockChannel).toImmutableList(),
+                    channels = persistentListOf(mockChannel),
                 ),
                 onClickEditInvoice = {},
                 modifier = Modifier.sheetHeight(),

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/AddTagScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/AddTagScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import to.bitkit.R
 import to.bitkit.ui.components.BottomSheetPreview
@@ -157,7 +157,7 @@ private fun Preview() {
         BottomSheetPreview {
             AddTagContent(
                 uiState = AddTagUiState(
-                    tagsSuggestions = listOf("Lunch", "Mom", "Dad", "Dinner", "Tip", "Gift").toImmutableList()
+                    tagsSuggestions = persistentListOf("Lunch", "Mom", "Dad", "Dinner", "Tip", "Gift")
                 ),
                 onTagSelected = {},
                 onInputUpdated = {},

--- a/app/src/main/java/to/bitkit/ui/settings/general/TagsSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/general/TagsSettingsScreen.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.ui.components.TagButton
 import to.bitkit.ui.components.settings.SectionHeader
@@ -35,7 +34,7 @@ fun TagsSettingsScreen(
     val tags by settings.lastUsedTags.collectAsStateWithLifecycle()
 
     TagsSettingsContent(
-        tags = tags.toImmutableList(),
+        tags = tags,
         onClickTag = { tag ->
             settings.deleteLastUsedTag(tag)
             if (tags.size == 1) {

--- a/app/src/main/java/to/bitkit/ui/settings/lightning/ChannelDetailViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/lightning/ChannelDetailViewModel.kt
@@ -14,7 +14,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -75,8 +74,8 @@ class ChannelDetailViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 channelLoadState = ChannelLoadState.Success(channelUi),
-                paidOrders = blocktankRepo.blocktankState.value.paidOrders.toImmutableList(),
-                cjitEntries = blocktankRepo.blocktankState.value.cjitEntries.toImmutableList(),
+                paidOrders = blocktankRepo.blocktankState.value.paidOrders,
+                cjitEntries = blocktankRepo.blocktankState.value.cjitEntries,
                 isClosedChannel = isClosedChannel,
                 nodeId = lightningRepo.getNodeId().orEmpty(),
             )
@@ -175,8 +174,8 @@ class ChannelDetailViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             channelLoadState = ChannelLoadState.Success(updatedChannel),
-                            paidOrders = blocktankState.paidOrders.toImmutableList(),
-                            cjitEntries = blocktankState.cjitEntries.toImmutableList(),
+                            paidOrders = blocktankState.paidOrders,
+                            cjitEntries = blocktankState.cjitEntries,
                             nodeId = lightningRepo.getNodeId().orEmpty(),
                         )
                     }
@@ -190,8 +189,8 @@ class ChannelDetailViewModel @Inject constructor(
                             it.copy(
                                 channelLoadState = ChannelLoadState.Success(closedChannel),
                                 isClosedChannel = true,
-                                paidOrders = blocktankState.paidOrders.toImmutableList(),
-                                cjitEntries = blocktankState.cjitEntries.toImmutableList(),
+                                paidOrders = blocktankState.paidOrders,
+                                cjitEntries = blocktankState.cjitEntries,
                                 nodeId = lightningRepo.getNodeId().orEmpty(),
                             )
                         }

--- a/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsScreen.kt
@@ -162,7 +162,7 @@ private fun Content(
                     Caption13Up(stringResource(R.string.lightning__conn_pending), color = Colors.White64)
                     ChannelList(
                         status = ChannelStatusUi.PENDING,
-                        channels = uiState.pendingConnections.reversed().toImmutableList(),
+                        channels = uiState.pendingConnections,
                         onClickChannel = onClickChannel,
                     )
                 }
@@ -173,7 +173,7 @@ private fun Content(
                     Caption13Up(stringResource(R.string.lightning__conn_open), color = Colors.White64)
                     ChannelList(
                         status = ChannelStatusUi.OPEN,
-                        channels = uiState.openChannels.reversed().toImmutableList(),
+                        channels = uiState.openChannels,
                         onClickChannel = onClickChannel,
                     )
                 }
@@ -185,7 +185,7 @@ private fun Content(
                         Caption13Up(stringResource(R.string.lightning__conn_failed), color = Colors.White64)
                         ChannelList(
                             status = ChannelStatusUi.CLOSED,
-                            channels = uiState.failedOrders.reversed().toImmutableList(),
+                            channels = uiState.failedOrders,
                             onClickChannel = onClickChannel,
                         )
                     }

--- a/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsViewModel.kt
@@ -107,13 +107,13 @@ class LightningConnectionsViewModel @Inject constructor(
                         isNodeRunning = lightningState.nodeLifecycleState.isRunning(),
                         openChannels = channels.filterOpen().map { channel ->
                             channel.mapToUiModel(channels, blocktankState.paidOrders, connectionText)
-                        }.toImmutableList(),
+                        }.reversed().toImmutableList(),
                         pendingConnections = getPendingConnections(channels, blocktankState.paidOrders)
                             .map { it.mapToUiModel(channels, blocktankState.paidOrders, connectionText) }
-                            .toImmutableList(),
+                            .reversed().toImmutableList(),
                         failedOrders = getFailedOrdersAsChannels(blocktankState.paidOrders)
                             .map { it.mapToUiModel(channels, blocktankState.paidOrders, connectionText) }
-                            .toImmutableList(),
+                            .reversed().toImmutableList(),
                         localBalance = calculateLocalBalance(channels),
                         remoteBalance = channels.calculateRemoteBalance(),
                     )

--- a/app/src/main/java/to/bitkit/ui/shared/toast/ToastQueueManager.kt
+++ b/app/src/main/java/to/bitkit/ui/shared/toast/ToastQueueManager.kt
@@ -1,8 +1,5 @@
 package to.bitkit.ui.shared.toast
 
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -35,7 +32,7 @@ class ToastQueueManager(private val scope: CoroutineScope) {
     val currentToast: StateFlow<Toast?> = _currentToast.asStateFlow()
 
     // Internal queue state
-    private val _queue = MutableStateFlow<ImmutableList<Toast>>(persistentListOf())
+    private val _queue = MutableStateFlow<List<Toast>>(emptyList())
     private var timerJob: Job? = null
     private var isPaused = false
 
@@ -46,9 +43,9 @@ class ToastQueueManager(private val scope: CoroutineScope) {
         _queue.update { current ->
             val newQueue = if (current.size >= MAX_QUEUE_SIZE) {
                 // Drop oldest (first item) when queue full
-                (current.drop(1) + toast).toImmutableList()
+                current.drop(1) + toast
             } else {
-                (current + toast).toImmutableList()
+                current + toast
             }
             newQueue
         }
@@ -94,7 +91,7 @@ class ToastQueueManager(private val scope: CoroutineScope) {
      */
     fun clear() {
         cancelTimer()
-        _queue.value = persistentListOf()
+        _queue.value = emptyList()
         _currentToast.value = null
         isPaused = false
     }
@@ -103,7 +100,7 @@ class ToastQueueManager(private val scope: CoroutineScope) {
         val nextToast = _queue.value.firstOrNull() ?: return
 
         // Remove from queue
-        _queue.update { it.drop(1).toImmutableList() }
+        _queue.update { it.drop(1) }
 
         // Display toast
         _currentToast.value = nextToast

--- a/app/src/main/java/to/bitkit/viewmodels/ActivityDetailViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/ActivityDetailViewModel.kt
@@ -8,7 +8,10 @@ import com.synonym.bitkitcore.IBtOrder
 import com.synonym.bitkitcore.TransactionDetails
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -39,7 +42,7 @@ class ActivityDetailViewModel @Inject constructor(
     private val _txDetails = MutableStateFlow<TransactionDetails?>(null)
     val txDetails = _txDetails.asStateFlow()
 
-    private val _tags = MutableStateFlow<List<String>>(emptyList())
+    private val _tags = MutableStateFlow<ImmutableList<String>>(persistentListOf())
     val tags = _tags.asStateFlow()
 
     private val _boostSheetVisible = MutableStateFlow(false)
@@ -50,11 +53,6 @@ class ActivityDetailViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(ActivityDetailUiState())
     val uiState: StateFlow<ActivityDetailUiState> = _uiState.asStateFlow()
-
-    fun setActivity(activity: Activity) {
-        this.activity = activity
-        loadTags()
-    }
 
     fun loadActivity(activityId: String) {
         viewModelScope.launch(bgDispatcher) {
@@ -95,7 +93,7 @@ class ActivityDetailViewModel @Inject constructor(
         observeJob = null
         _uiState.update { it.copy(activityLoadState = ActivityLoadState.Initial) }
         activity = null
-        _tags.value = emptyList()
+        _tags.update { persistentListOf() }
     }
 
     private fun observeActivityChanges(activityId: String) {
@@ -120,7 +118,7 @@ class ActivityDetailViewModel @Inject constructor(
             }
             .onFailure { error ->
                 Logger.warn("Failed to reload activity $activityId", error, context = TAG)
-                // Keep showing last known state on reload failure
+                // Keep showing the last known state on reload failure
             }
     }
 
@@ -129,11 +127,11 @@ class ActivityDetailViewModel @Inject constructor(
         viewModelScope.launch(bgDispatcher) {
             activityRepo.getActivityTags(id)
                 .onSuccess { activityTags ->
-                    _tags.value = activityTags
+                    _tags.update { activityTags.toImmutableList() }
                 }
-                .onFailure { e ->
-                    Logger.error("Failed to load tags for activity $id", e, TAG)
-                    _tags.value = emptyList()
+                .onFailure {
+                    Logger.error("Failed to load tags for activity $id", it, TAG)
+                    _tags.update { persistentListOf() }
                 }
         }
     }
@@ -145,8 +143,8 @@ class ActivityDetailViewModel @Inject constructor(
                 .onSuccess {
                     loadTags()
                 }
-                .onFailure { e ->
-                    Logger.error("Failed to remove tag $tag from activity $id", e, TAG)
+                .onFailure {
+                    Logger.error("Failed to remove tag $tag from activity $id", it, TAG)
                 }
         }
     }
@@ -159,8 +157,8 @@ class ActivityDetailViewModel @Inject constructor(
                     settingsStore.addLastUsedTag(tag)
                     loadTags()
                 }
-                .onFailure { e ->
-                    Logger.error("Failed to add tag $tag to activity $id", e, TAG)
+                .onFailure {
+                    Logger.error("Failed to add tag $tag to activity $id", it, TAG)
                 }
         }
     }
@@ -190,9 +188,8 @@ class ActivityDetailViewModel @Inject constructor(
         _boostSheetVisible.update { false }
     }
 
-    suspend fun getBoostTxDoesExist(boostTxIds: List<String>): ImmutableMap<String, Boolean> {
-        return activityRepo.getBoostTxDoesExist(boostTxIds).toImmutableMap()
-    }
+    suspend fun getBoostTxDoesExist(boostTxIds: List<String>): ImmutableMap<String, Boolean> =
+        activityRepo.getBoostTxDoesExist(boostTxIds).toImmutableMap()
 
     suspend fun isCpfpChildTransaction(txId: String): Boolean {
         return activityRepo.isCpfpChildTransaction(txId)

--- a/app/src/main/java/to/bitkit/viewmodels/ActivityListViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/ActivityListViewModel.kt
@@ -106,8 +106,8 @@ class ActivityListViewModel @Inject constructor(
         val all = activityRepo.getActivities(filter = ActivityFilter.ALL).getOrNull() ?: emptyList()
         val filtered = filterOutReplacedSentTransactions(all)
         _latestActivities.update { filtered.take(SIZE_LATEST).toImmutableList() }
-        _lightningActivities.update { filtered.filter { it is Activity.Lightning }.toImmutableList() }
-        _onchainActivities.update { filtered.filter { it is Activity.Onchain }.toImmutableList() }
+        _lightningActivities.update { filtered.filterIsInstance<Activity.Lightning>().toImmutableList() }
+        _onchainActivities.update { filtered.filterIsInstance<Activity.Onchain>().toImmutableList() }
     }
 
     private suspend fun fetchFilteredActivities(filters: ActivityFilters): List<Activity>? {

--- a/app/src/main/java/to/bitkit/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/SettingsViewModel.kt
@@ -3,6 +3,8 @@ package to.bitkit.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -31,6 +33,7 @@ class SettingsViewModel @Inject constructor(
             settingsStore.update { it.copy(notificationsGranted = granted) }
         }
     }
+
     val showNotificationDetails = settingsStore.data.map { it.showNotificationDetails }
         .asStateFlow(initialValue = false)
 
@@ -166,8 +169,8 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    val lastUsedTags = settingsStore.data.map { it.lastUsedTags }
-        .asStateFlow(initialValue = emptyList())
+    val lastUsedTags = settingsStore.data.map { it.lastUsedTags.toImmutableList() }
+        .asStateFlow(initialValue = persistentListOf())
 
     fun deleteLastUsedTag(tag: String) {
         viewModelScope.launch {


### PR DESCRIPTION
This PR simplifies the immutable collections refactor (#839) by removing redundant conversions, fixing view-layer violations, and cleaning up preview data patterns.

### Description

1. Removes redundant `.toImmutableList()`/`.toImmutableSet()` calls on already-immutable data (BlocktankState fields, selectedTags)
2. Moves view-layer conversions to source layer (ActivityDetailViewModel, SettingsViewModel, LightningConnectionsViewModel)
3. Converts `previewActivityItems` to `ImmutableList` at source, eliminating 8 call-site conversions
4. Replaces `listOf().toImmutableList()` with `persistentListOf()` in previews
5. Reverts `ToastQueueManager` internal queue to plain `List` (not exposed to Compose)
6. Extracts repeated `ActivityTab.entries.toImmutableList()` into file-scope vals

### Preview

N/A — no visual changes, refactoring only.

### QA Notes

#### 1. Regression Checks
1. Open the app and navigate through wallet screens (Home, Savings, Spending)
2. Verify activity lists display correctly
3. Open Lightning Connections settings and verify channels display in correct order
4. Verify tag selector and activity filtering work as expected

**Note for reviewer:** Relying on e2e suite should be enough, PR changes were tested manually, and it's only updating coding cosmetics of previous PR.