### PR TITLE
feat: support hardware keys in numpad

### DIFF
--- a/app/src/main/java/to/bitkit/ui/components/NumberPad.kt
+++ b/app/src/main/java/to/bitkit/ui/components/NumberPad.kt
@@ -1,6 +1,7 @@
 package to.bitkit.ui.components
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -12,10 +13,19 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -63,7 +73,20 @@ fun NumberPad(
     availableHeight: Dp = defaultHeight,
     errorKey: String? = null,
 ) {
-    BoxWithConstraints(modifier = modifier) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .focusRequester(focusRequester)
+            .onPreviewKeyEvent { keyEvent ->
+                if (keyEvent.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                val mapped = mapHardwareKey(keyEvent.key, type) ?: return@onPreviewKeyEvent false
+                onPress(mapped)
+                true
+            }
+            .focusable()
+    ) {
         val buttonHeight = when {
             constraints.hasFixedHeight -> maxHeight / ROWS
             else -> (availableHeight / ROWS).coerceIn(minButtonHeight, idealButtonHeight)
@@ -150,6 +173,27 @@ fun NumberPad(
 }
 
 enum class NumberPadType { SIMPLE, INTEGER, DECIMAL }
+
+private val hardwareKeyMap = mapOf(
+    Key.Zero to "0", Key.NumPad0 to "0",
+    Key.One to "1", Key.NumPad1 to "1",
+    Key.Two to "2", Key.NumPad2 to "2",
+    Key.Three to "3", Key.NumPad3 to "3",
+    Key.Four to "4", Key.NumPad4 to "4",
+    Key.Five to "5", Key.NumPad5 to "5",
+    Key.Six to "6", Key.NumPad6 to "6",
+    Key.Seven to "7", Key.NumPad7 to "7",
+    Key.Eight to "8", Key.NumPad8 to "8",
+    Key.Nine to "9", Key.NumPad9 to "9",
+    Key.Backspace to KEY_DELETE, Key.Delete to KEY_DELETE,
+    Key.Period to KEY_DECIMAL, Key.NumPadDot to KEY_DECIMAL,
+)
+
+private fun mapHardwareKey(key: Key, type: NumberPadType): String? {
+    val mapped = hardwareKeyMap[key] ?: return null
+    if (mapped == KEY_DECIMAL && type != NumberPadType.DECIMAL) return null
+    return mapped
+}
 
 @Composable
 fun NumberPadKeyButton(


### PR DESCRIPTION
### Description

This PR adds hardware keyboard support to the custom `NumberPad` composable, enabling digit keys (0-9), backspace, delete, and period to trigger the same input callbacks as touch. Useful when running in emulator or with a phone connected via Android Studio.

The change is scoped to the primary `NumberPad` composable only, so all 15+ screens using it (PIN entry, amount input, fee input, etc.) get keyboard support automatically.

### Preview

https://github.com/user-attachments/assets/e37ed4b0-0bbd-4293-ac1b-baad9579e755

### QA Notes

#### 1. Emulator keyboard input
- Open any screen with a numpad (e.g. Send > Amount, or PIN entry)
- Type digits 0-9 using the computer keyboard
- Verify digits appear as if tapping the on-screen numpad
- Press Backspace or Delete to remove last digit
- Verify both work identically to the on-screen delete button

#### 2. Decimal key filtering
- Open Send > Amount screen (uses DECIMAL numpad type)
- Press the period key on the keyboard
- Verify the decimal point is entered
- Open a PIN entry screen (uses SIMPLE numpad type)
- Press the period key
- Verify nothing happens (period is ignored)

#### 3. Touch input still works
- On any numpad screen, verify tapping on-screen buttons still works as before alongside keyboard input

#### 4. NumPad keys (extended keyboard)
- If using an extended keyboard, verify NumPad 0-9 and NumPad dot also work