### PR TITLE
fix: cap onchain send amount to balance

### DIFF
--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -1169,7 +1169,10 @@ class AppViewModel @Inject constructor(
                 }
             }
 
-            SendMethod.ONCHAIN -> amount > Defaults.dustLimit.toULong()
+            SendMethod.ONCHAIN -> {
+                val maxSendable = walletRepo.balanceState.value.maxSendOnchainSats
+                amount > Defaults.dustLimit.toULong() && amount <= maxSendable
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #611

This PR caps the on-chain send amount to the available balance, disabling the Continue button when the entered amount exceeds spendable sats.

### Description

The `validateAmount` function in `AppViewModel` only checked that the on-chain amount was above dust limit — it never compared against `maxSendOnchainSats`. This allowed users to proceed with amounts exceeding their balance. Lightning already had this check in place.

The fix adds `amount <= maxSendOnchainSats` to the on-chain validation branch, matching the Lightning behavior.

### Preview


https://github.com/user-attachments/assets/db602ba9-1e57-4fff-aace-d19c064f0ac0



### QA Notes

1. Fund an on-chain wallet with a known balance
2. Initiate an on-chain send (scan a BTC address QR)
3. Enter an amount greater than your available balance
4. Verify the Continue button is disabled
5. Enter an amount within balance — verify the Continue button is enabled
6. Verify Lightning send behavior is unchanged (should still cap correctly)

E2E test coverage: https://github.com/synonymdev/bitkit-e2e-tests/pull/137

Made with [Cursor](https://cursor.com)