### PR TITLE
feat: add transfer from savings button on empty spending screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show loading state on Spending tab when node is not running #875
 
 ### Added
-- Transfer from Savings button on empty Spending screen when savings balance exists
+- Transfer from Savings button on empty Spending screen when savings balance exists #882
 - Connection issues overlay with connectivity fixes across Send, Receive, and Transfer flows #878
 - Lightning Connections empty state with onboarding screen #857
 - Unified PIN management screen (enable/disable/change in one place) #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show loading state on Spending tab when node is not running #875
 
 ### Added
+- Transfer from Savings button on empty Spending screen when savings balance exists
 - Connection issues overlay with connectivity fixes across Send, Receive, and Transfer flows #878
 - Lightning Connections empty state with onboarding screen #857
 - Unified PIN management screen (enable/disable/change in one place) #857

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -815,6 +815,7 @@ private fun NavGraphBuilder.home(
     }
     composableWithDefaultTransitions<Routes.Spending> {
         val hasSeenSavingsIntro by settingsViewModel.hasSeenSavingsIntro.collectAsStateWithLifecycle()
+        val hasSeenSpendingIntro by settingsViewModel.hasSeenSpendingIntro.collectAsStateWithLifecycle()
         val lightningState by walletViewModel.lightningState.collectAsStateWithLifecycle()
         val lightningActivities by activityListViewModel.lightningActivities.collectAsStateWithLifecycle()
 
@@ -829,6 +830,13 @@ private fun NavGraphBuilder.home(
                     navController.navigateToTransferSavingsIntro()
                 } else {
                     navController.navigateToTransferSavingsAvailability()
+                }
+            },
+            onTransferFromSavingsClick = {
+                if (!hasSeenSpendingIntro) {
+                    navController.navigateToTransferSpendingIntro()
+                } else {
+                    navController.navigateToTransferSpendingAmount()
                 }
             },
             onBackClick = { navController.popBackStack() },

--- a/app/src/main/java/to/bitkit/ui/components/Button.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Button.kt
@@ -201,7 +201,7 @@ fun SecondaryButton(
                 } else {
                     Modifier
                 }
-            ),
+            )
     ) {
         OutlinedButton(
             onClick = rememberDebouncedClick(onClick = onClick),

--- a/app/src/main/java/to/bitkit/ui/components/Button.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Button.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
@@ -83,6 +82,7 @@ enum class ButtonSize {
             Small -> 8.dp
             Large -> 6.dp
         }
+
     fun secondaryBorder(enabled: Boolean): BorderStroke = when (this) {
         Large -> BorderStroke(2.dp, if (enabled) Colors.Gray4 else Color.Transparent)
         Small -> BorderStroke(1.dp, if (enabled) Colors.White16 else Color.Transparent)
@@ -183,6 +183,7 @@ fun SecondaryButton(
     // and AFTER size modifiers (Haze needs to know dimensions)
     val buttonShape = MaterialTheme.shapes.extraLarge
     Box(
+        propagateMinConstraints = true,
         modifier = modifier
             .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
             .requiredHeight(size.height)
@@ -200,7 +201,7 @@ fun SecondaryButton(
                 } else {
                     Modifier
                 }
-            )
+            ),
     ) {
         OutlinedButton(
             onClick = rememberDebouncedClick(onClick = onClick),
@@ -208,7 +209,6 @@ fun SecondaryButton(
             colors = AppButtonDefaults.secondaryColors.copy(contentColor = contentColor),
             contentPadding = contentPadding,
             border = border,
-            modifier = if (fullWidth) Modifier.fillMaxSize() else Modifier,
         ) {
             if (isLoading) {
                 GradientCircularProgressIndicator(
@@ -488,6 +488,25 @@ private fun SecondaryButtonPreview() {
                         )
                     },
                 )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    SecondaryButton(
+                        text = "Secondary",
+                        fullWidth = false,
+                        hazeState = hazeState,
+                        onClick = {},
+                        modifier = Modifier.weight(1f)
+                    )
+                    SecondaryButton(
+                        text = "Secondary",
+                        fullWidth = false,
+                        hazeState = hazeState,
+                        onClick = {},
+                        modifier = Modifier.weight(1f)
+                    )
+                }
                 SecondaryButton(
                     text = "Secondary Small",
                     size = ButtonSize.Small,
@@ -588,6 +607,23 @@ private fun TertiaryButtonPreview() {
                 },
                 onClick = {}
             )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TertiaryButton(
+                    text = "Tertiary",
+                    fullWidth = false,
+                    onClick = {},
+                    modifier = Modifier.weight(1f)
+                )
+                TertiaryButton(
+                    text = "Tertiary",
+                    fullWidth = false,
+                    onClick = {},
+                    modifier = Modifier.weight(1f)
+                )
+            }
             TertiaryButton(
                 text = "Tertiary Small",
                 size = ButtonSize.Small,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -56,6 +56,7 @@ fun SpendingWalletScreen(
     onActivityItemClick: (String) -> Unit,
     onEmptyActivityRowClick: () -> Unit,
     onTransferToSavingsClick: () -> Unit,
+    onTransferFromSavingsClick: () -> Unit,
     onBackClick: () -> Unit,
     balances: BalanceState = LocalBalances.current,
 ) {
@@ -68,6 +69,9 @@ fun SpendingWalletScreen(
         val hasLnBalance = balances.totalLightningSats > 0uL
         val hasChannels = channels.isNotEmpty()
         mutableStateOf(hasLnBalance && hasChannels)
+    }
+    val canTransferFromSavings by remember(showEmptyState, balances.totalOnchainSats) {
+        mutableStateOf(showEmptyState && balances.totalOnchainSats > 0uL)
     }
 
     Box(
@@ -109,6 +113,23 @@ fun SpendingWalletScreen(
                     IncomingTransfer(
                         amount = balances.balanceInTransferToSpending,
                         modifier = Modifier.padding(vertical = 8.dp)
+                    )
+                }
+
+                if (canTransferFromSavings) {
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    SecondaryButton(
+                        onClick = onTransferFromSavingsClick,
+                        text = stringResource(R.string.lightning__funding__button1),
+                        icon = {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_transfer),
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        modifier = Modifier.testTag("TransferFromSavings")
                     )
                 }
 
@@ -163,6 +184,7 @@ private fun Preview() {
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},
                 onTransferToSavingsClick = {},
+                onTransferFromSavingsClick = {},
                 onBackClick = {},
                 balances = BalanceState(totalLightningSats = 50_000u),
             )
@@ -183,6 +205,7 @@ private fun PreviewTransfer() {
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},
                 onTransferToSavingsClick = {},
+                onTransferFromSavingsClick = {},
                 onBackClick = {},
                 balances = BalanceState(
                     totalLightningSats = 50_000u,
@@ -206,6 +229,7 @@ private fun PreviewNoActivity() {
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},
                 onTransferToSavingsClick = {},
+                onTransferFromSavingsClick = {},
                 onBackClick = {},
                 balances = BalanceState(totalLightningSats = 50_000u),
             )
@@ -226,7 +250,29 @@ private fun PreviewEmpty() {
                 onActivityItemClick = {},
                 onEmptyActivityRowClick = {},
                 onTransferToSavingsClick = {},
+                onTransferFromSavingsClick = {},
                 onBackClick = {},
+            )
+            TabBar()
+        }
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun PreviewEmptyWithSavings() {
+    AppThemeSurface {
+        Box {
+            SpendingWalletScreen(
+                channels = persistentListOf(),
+                lightningActivities = persistentListOf(),
+                onAllActivityButtonClick = {},
+                onActivityItemClick = {},
+                onEmptyActivityRowClick = {},
+                onTransferToSavingsClick = {},
+                onTransferFromSavingsClick = {},
+                onBackClick = {},
+                balances = BalanceState(totalOnchainSats = 100_000u),
             )
             TabBar()
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -126,7 +126,7 @@ fun SpendingWalletScreen(
                             Icon(
                                 painter = painterResource(R.drawable.ic_transfer),
                                 contentDescription = null,
-                                modifier = Modifier.size(16.dp),
+                                modifier = Modifier.size(16.dp)
                             )
                         },
                         modifier = Modifier.testTag("TransferFromSavings")

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -38,6 +38,7 @@ import to.bitkit.ui.components.EmptyStateView
 import to.bitkit.ui.components.IncomingTransfer
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.TabBar
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -135,7 +135,7 @@ fun SpendingWalletScreen(
                 }
 
                 if (!showEmptyState) {
-                    Spacer(modifier = Modifier.height(32.dp))
+                    VerticalSpacer(32.dp)
 
                     if (canTransfer) {
                         SecondaryButton(
@@ -145,7 +145,7 @@ fun SpendingWalletScreen(
                                 Icon(
                                     painter = painterResource(R.drawable.ic_transfer),
                                     contentDescription = null,
-                                    modifier = Modifier.size(16.dp),
+                                    modifier = Modifier.size(16.dp)
                                 )
                             },
                             modifier = Modifier.testTag("TransferToSavings")

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -117,7 +117,7 @@ fun SpendingWalletScreen(
                 }
 
                 if (canTransferFromSavings) {
-                    Spacer(modifier = Modifier.height(32.dp))
+                    VerticalSpacer(32.dp)
 
                     SecondaryButton(
                         onClick = onTransferFromSavingsClick,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -144,6 +144,7 @@ fun SpendingWalletScreen(
                                 modifier = Modifier.size(16.dp)
                             )
                         },
+                        hazeState = hazeState,
                         modifier = Modifier.testTag("TransferFromSavings")
                     )
                 }


### PR DESCRIPTION
Related to #873 

[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=36003-107371&m=dev)

This PR adds a "Transfer From Savings" button to the Spending wallet empty state, shown when the user has on-chain savings balance. This helps users discover the transfer flow without needing to navigate to the Savings screen first.

Stacked PR on:
- #878

### Description

- Adds a `SecondaryButton` with transfer icon to the Spending screen empty state
- Button is visible only when the spending balance is zero, there's no activity, and savings balance is greater than zero
- Navigates to the existing transfer-to-spending flow (intro or amount screen, based on whether the user has seen the intro)
- Reuses the existing localized string `lightning__funding__button1` ("Transfer from Savings")

### Preview

[Screen_recording_20260402_141812.webm](https://github.com/user-attachments/assets/515feb3e-c51e-475a-b0db-b96c6e915751)


### QA Notes

1. Ensure you have on-chain savings balance but zero Lightning spending balance and no Lightning activity
2. Open the Spending wallet screen
3. Verify the "Transfer From Savings" button appears below the balance header
4. Tap the button and verify it navigates to the transfer-to-spending intro (first time) or amount screen (returning user)
5. With zero savings balance and zero spending balance, verify the button does NOT appear
6. With non-zero spending balance, verify the existing "Transfer To Savings" button still works as before