### PR TITLE
feat: update external success screen text and image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
+- Update external success screen title and image to match new design #883
 - Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Update external success screen title and image to match new design #883
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
-- Update external success screen title and image to match new design #883
+- Updated design of the success screen in the manual channel setup flow #883
 - Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
-- Update external success screen title and image to match new design
+- Update external success screen title and image to match new design #883
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857
 - Selected values displayed on right side of settings rows #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update external success screen title and image to match new design #883
 - Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
-- Update external success screen title and image to match new design #883
+- Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857
 - Selected values displayed on right side of settings rows #857
 - Support screen redesigned with About content merged in #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update external success screen title and image to match new design #883
 - Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Update external success screen title and image to match new design #883
-- Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857
 - Selected values displayed on right side of settings rows #857
 - Support screen redesigned with About content merged in #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
+- Update external success screen title and image to match new design
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857
 - Selected values displayed on right side of settings rows #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
-- Update external success screen title and image to match new design #883
+- Updated design of the success screen in the manual channel setup  flow #883
 - Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857

--- a/app/src/main/java/to/bitkit/ui/components/Button.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Button.kt
@@ -201,7 +201,7 @@ fun SecondaryButton(
                 } else {
                     Modifier
                 }
-            ),
+            )
     ) {
         OutlinedButton(
             onClick = rememberDebouncedClick(onClick = onClick),

--- a/app/src/main/java/to/bitkit/ui/components/Button.kt
+++ b/app/src/main/java/to/bitkit/ui/components/Button.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
@@ -83,6 +82,7 @@ enum class ButtonSize {
             Small -> 8.dp
             Large -> 6.dp
         }
+
     fun secondaryBorder(enabled: Boolean): BorderStroke = when (this) {
         Large -> BorderStroke(2.dp, if (enabled) Colors.Gray4 else Color.Transparent)
         Small -> BorderStroke(1.dp, if (enabled) Colors.White16 else Color.Transparent)
@@ -183,6 +183,7 @@ fun SecondaryButton(
     // and AFTER size modifiers (Haze needs to know dimensions)
     val buttonShape = MaterialTheme.shapes.extraLarge
     Box(
+        propagateMinConstraints = true,
         modifier = modifier
             .then(if (fullWidth) Modifier.fillMaxWidth() else Modifier)
             .requiredHeight(size.height)
@@ -200,7 +201,7 @@ fun SecondaryButton(
                 } else {
                     Modifier
                 }
-            )
+            ),
     ) {
         OutlinedButton(
             onClick = rememberDebouncedClick(onClick = onClick),
@@ -208,7 +209,6 @@ fun SecondaryButton(
             colors = AppButtonDefaults.secondaryColors.copy(contentColor = contentColor),
             contentPadding = contentPadding,
             border = border,
-            modifier = if (fullWidth) Modifier.fillMaxSize() else Modifier,
         ) {
             if (isLoading) {
                 GradientCircularProgressIndicator(
@@ -488,6 +488,25 @@ private fun SecondaryButtonPreview() {
                         )
                     },
                 )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    SecondaryButton(
+                        text = "Secondary",
+                        fullWidth = false,
+                        hazeState = hazeState,
+                        onClick = {},
+                        modifier = Modifier.weight(1f)
+                    )
+                    SecondaryButton(
+                        text = "Secondary",
+                        fullWidth = false,
+                        hazeState = hazeState,
+                        onClick = {},
+                        modifier = Modifier.weight(1f)
+                    )
+                }
                 SecondaryButton(
                     text = "Secondary Small",
                     size = ButtonSize.Small,
@@ -588,6 +607,23 @@ private fun TertiaryButtonPreview() {
                 },
                 onClick = {}
             )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TertiaryButton(
+                    text = "Tertiary",
+                    fullWidth = false,
+                    onClick = {},
+                    modifier = Modifier.weight(1f)
+                )
+                TertiaryButton(
+                    text = "Tertiary",
+                    fullWidth = false,
+                    onClick = {},
+                    modifier = Modifier.weight(1f)
+                )
+            }
             TertiaryButton(
                 text = "Tertiary Small",
                 size = ButtonSize.Small,

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalSuccessScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/external/ExternalSuccessScreen.kt
@@ -17,10 +17,10 @@ fun ExternalSuccessScreen(
     onContinue: () -> Unit,
 ) {
     InfoScreenContent(
-        navTitle = stringResource(R.string.lightning__external__nav_title),
+        navTitle = stringResource(R.string.lightning__external_success__nav_title),
         title = stringResource(R.string.lightning__external_success__title).withAccent(accentColor = Colors.Purple),
         description = stringResource(R.string.lightning__external_success__text).withAccentBoldBright(),
-        image = painterResource(R.drawable.switch_box),
+        image = painterResource(R.drawable.lightning),
         buttonText = localizedRandom(R.string.common__ok_random),
         onButtonClick = onContinue,
         testTag = "ExternalSuccess",

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -38,6 +38,7 @@ import to.bitkit.ui.components.EmptyStateView
 import to.bitkit.ui.components.IncomingTransfer
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.TabBar
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -113,7 +114,7 @@ fun SpendingWalletScreen(
                 }
 
                 if (!showEmptyState) {
-                    Spacer(modifier = Modifier.height(32.dp))
+                    VerticalSpacer(32.dp)
 
                     if (canTransfer) {
                         SecondaryButton(
@@ -123,7 +124,7 @@ fun SpendingWalletScreen(
                                 Icon(
                                     painter = painterResource(R.drawable.ic_transfer),
                                     contentDescription = null,
-                                    modifier = Modifier.size(16.dp),
+                                    modifier = Modifier.size(16.dp)
                                 )
                             },
                             modifier = Modifier.testTag("TransferToSavings")

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">مسح QR</string>
     <string name="lightning__external_manual__text">يمكنك استخدام عقدة خارجية لفتح اتصال Lightning يدويًا. أدخل تفاصيل العقدة للمتابعة.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;إعداد يدوي&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">رصيد الإنفاق</string>
     <string name="lightning__external_success__text">بدأ اتصال Lightning. ستتمكن من استخدام رصيد الإنفاق خلال &lt;accent&gt;±30 دقيقة&lt;/accent&gt; (يعتمد على إعدادات العقدة).</string>
-    <string name="lightning__external_success__title">بدأ\n&lt;accent&gt;الاتصال&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">القناة\n&lt;accent&gt;قيد الفتح&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">معدل الرسوم</string>
     <string name="lightning__fee_rate_update_time">وقت تحديث ذاكرة التخزين المؤقت لمعدل الرسوم</string>
     <string name="lightning__fees">الرسوم</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">Escanear QR</string>
     <string name="lightning__external_manual__text">Puedes usar un nodo externo para abrir una conexión Lightning manualmente. Ingresa los datos del nodo para continuar.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Config. manual&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Saldo de gasto</string>
     <string name="lightning__external_success__text">Conexión lightning iniciada. Podrá utilizar su saldo de gastos en &lt;accent&gt;±30 minutos&lt;/accent&gt; (depende de la config. del nodo).</string>
-    <string name="lightning__external_success__title">Conexión\n&lt;accent&gt;iniciada&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Apertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Tarifa</string>
     <string name="lightning__fee_rate_update_time">Hora de actualización de caché de tarifa</string>
     <string name="lightning__fees">Tarifa</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">Escaneja QR</string>
     <string name="lightning__external_manual__text">Pots utilitzar un node extern per obrir manualment una connexió Lightning. Introdueix els detalls del node per continuar.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Configuració manual&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Saldo de despesa</string>
     <string name="lightning__external_success__text">Connexió Lightning iniciada. Podràs utilitzar el teu saldo de despesa en &lt;accent&gt;±30 minuts&lt;/accent&gt; (depèn de la configuració del node).</string>
-    <string name="lightning__external_success__title">Connexió\n&lt;accent&gt;iniciada&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Obertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Taxa de tarifa</string>
     <string name="lightning__fee_rate_update_time">Temps d\'actualització de la memòria cau de tarifes</string>
     <string name="lightning__fees">Tarifes</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">Skenovat QR</string>
     <string name="lightning__external_manual__text">Můžete použít externí uzel k ručnímu otevření lightning připojení. Zadejte údaje o uzlu pro pokračování.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Manuální nastavení&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Zůstatek k utracení</string>
     <string name="lightning__external_success__text">Iniciováno připojení lightning. Zůstatek na účtu budete moci použít do &lt;accent&gt;±30 minut&lt;/accent&gt; (závisí na konfiguraci uzlu).</string>
-    <string name="lightning__external_success__title">Připojení\n&lt;accent&gt;iniciováno&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Otevírání\n&lt;accent&gt;kanálu&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Sazba poplatku</string>
     <string name="lightning__fee_rate_update_time">Čas aktualizace mezipaměti poplatků</string>
     <string name="lightning__fees">Poplatky</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -152,7 +152,6 @@
     <string name="lightning__external_manual__paste">Paste Node URI</string>
     <string name="lightning__external_manual__scan">QR-Code scannen</string>
     <string name="lightning__external_amount__title">Spending\n&lt;accent&gt;balance&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Kanal wird\n&lt;accent&gt;geöffnet&lt;/accent&gt;</string>
     <string name="lightning__external_success__nav_title">Ausgabenguthaben</string>
     <string name="lightning__external_success__title">Kanal wird\n&lt;accent&gt;geöffnet&lt;/accent&gt;</string>
     <string name="lightning__external_success__text">Lightning-Verbindung initiiert. Du kannst dein Guthaben in &lt;accent&gt;±30 Minuten&lt;/accent&gt; verwenden (abhängig von der Node-Konfiguration).</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -152,7 +152,8 @@
     <string name="lightning__external_manual__paste">Paste Node URI</string>
     <string name="lightning__external_manual__scan">QR-Code scannen</string>
     <string name="lightning__external_amount__title">Spending\n&lt;accent&gt;balance&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Verbindung\n&lt;accent&gt;initiiert&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Kanal wird\n&lt;accent&gt;geöffnet&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Ausgabenguthaben</string>
     <string name="lightning__external_success__text">Lightning-Verbindung initiiert. Du kannst dein Guthaben in &lt;accent&gt;±30 Minuten&lt;/accent&gt; verwenden (abhängig von der Node-Konfiguration).</string>
     <string name="lightning__error_channel_purchase">Einrichtung der Instant-Zahlungen fehlgeschlagen</string>
     <string name="lightning__error_channel_setup_msg">Ein Fehler ist bei der Einrichtung deines Sofortguthabens aufgetreten. {raw}</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -154,6 +154,7 @@
     <string name="lightning__external_amount__title">Spending\n&lt;accent&gt;balance&lt;/accent&gt;</string>
     <string name="lightning__external_success__title">Kanal wird\n&lt;accent&gt;geöffnet&lt;/accent&gt;</string>
     <string name="lightning__external_success__nav_title">Ausgabenguthaben</string>
+    <string name="lightning__external_success__title">Kanal wird\n&lt;accent&gt;geöffnet&lt;/accent&gt;</string>
     <string name="lightning__external_success__text">Lightning-Verbindung initiiert. Du kannst dein Guthaben in &lt;accent&gt;±30 Minuten&lt;/accent&gt; verwenden (abhängig von der Node-Konfiguration).</string>
     <string name="lightning__error_channel_purchase">Einrichtung der Instant-Zahlungen fehlgeschlagen</string>
     <string name="lightning__error_channel_setup_msg">Ein Fehler ist bei der Einrichtung deines Sofortguthabens aufgetreten. {raw}</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">Σάρωση QR</string>
     <string name="lightning__external_manual__text">Μπορείς να χρησιμοποιήσεις έναν εξωτερικό κόμβο για να ανοίξεις χειροκίνητα μια σύνδεση Lightning. Εισάγαγε τα στοιχεία του κόμβου για να συνεχίσεις.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Χειροκίνητη ρύθμιση&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Υπόλοιπο δαπανών</string>
     <string name="lightning__external_success__text">Η σύνδεση Lightning ξεκίνησε. Θα μπορείς να χρησιμοποιήσεις το υπόλοιπο δαπανών σε &lt;accent&gt;±30 λεπτά&lt;/accent&gt; (εξαρτάται από τη διαμόρφωση του κόμβου).</string>
-    <string name="lightning__external_success__title">Η σύνδεση\n&lt;accent&gt;ξεκίνησε&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Άνοιγμα\n&lt;accent&gt;καναλιού&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Ποσοστό τέλους</string>
     <string name="lightning__fee_rate_update_time">Χρόνος ενημέρωσης cache τελών</string>
     <string name="lightning__fees">Τέλη</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">Escanear QR</string>
     <string name="lightning__external_manual__text">Puedes usar un nodo externo para abrir manualmente una conexión Lightning. Introduce los datos del nodo para continuar.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Configuración manual&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Saldo de gasto</string>
     <string name="lightning__external_success__text">Conexión Lightning iniciada. Podrá usar su balance para pagar en &lt;accent&gt;±30 minutos&lt;/accent&gt; (depende de la configuración del nodo).</string>
-    <string name="lightning__external_success__title">Conexión\n&lt;accent&gt;iniciada&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Apertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Tasa de comisión</string>
     <string name="lightning__fee_rate_update_time">Hora de actualización de caché de tasas</string>
     <string name="lightning__fees">Comisiones</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -109,6 +109,8 @@
     <string name="lightning__external_manual__paste">Pegar URI del nodo</string>
     <string name="lightning__external_manual__text">Puedes usar un nodo externo para abrir manualmente una conexión Lightning. Introduce los datos del nodo para continuar.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Configuración manual&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Saldo de gasto</string>
+    <string name="lightning__external_success__text">Conexión Lightning iniciada. Podrá usar su balance para pagar en &lt;accent&gt;±30 minutos&lt;/accent&gt; (depende de la configuración del nodo).</string>
     <string name="lightning__external_success__title">Apertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Tasa de comisión</string>
     <string name="lightning__fee_rate_update_time">Hora de actualización de caché de comisiones</string>
@@ -201,8 +203,6 @@
     <string name="lightning__external_manual__host">Servidor</string>
     <string name="lightning__external_manual__port">Puerto</string>
     <string name="lightning__external_manual__scan">Escanear QR</string>
-    <string name="lightning__external_success__nav_title">Saldo de gasto</string>
-    <string name="lightning__external_success__text">Conexión Lightning iniciada. Podrá usar su balance para pagar en &lt;accent&gt;±30 minutos&lt;/accent&gt; (depende de la configuración del nodo).</string>
     <string name="lightning__error_channel_purchase">Error en la Configuración de Pago Instántaneo</string>
     <string name="lightning__spending">Gasto</string>
     <string name="lightning__savings">Ahorro</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -109,7 +109,7 @@
     <string name="lightning__external_manual__paste">Pegar URI del nodo</string>
     <string name="lightning__external_manual__text">Puedes usar un nodo externo para abrir manualmente una conexión Lightning. Introduce los datos del nodo para continuar.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Configuración manual&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Conexión\n&lt;accent&gt;iniciada&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Apertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Tasa de comisión</string>
     <string name="lightning__fee_rate_update_time">Hora de actualización de caché de comisiones</string>
     <string name="lightning__fees">Comisiones</string>
@@ -201,6 +201,7 @@
     <string name="lightning__external_manual__host">Servidor</string>
     <string name="lightning__external_manual__port">Puerto</string>
     <string name="lightning__external_manual__scan">Escanear QR</string>
+    <string name="lightning__external_success__nav_title">Saldo de gasto</string>
     <string name="lightning__external_success__text">Conexión Lightning iniciada. Podrá usar su balance para pagar en &lt;accent&gt;±30 minutos&lt;/accent&gt; (depende de la configuración del nodo).</string>
     <string name="lightning__error_channel_purchase">Error en la Configuración de Pago Instántaneo</string>
     <string name="lightning__spending">Gasto</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -152,7 +152,8 @@
     <string name="lightning__external_manual__paste">Coller l\'URI du nœud</string>
     <string name="lightning__external_manual__scan">Scanner QR</string>
     <string name="lightning__external_amount__title">Dépenses \n&lt;accent&gt;solde&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Connexion \n&lt;accent&gt;initiée&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Ouverture\n&lt;accent&gt;du canal&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Solde de dépenses</string>
     <string name="lightning__external_success__text">La connexion Lightning est initiée. Vous pourrez utiliser votre compte courant dans &lt;accent&gt;±30 minutes&lt;/accent&gt; (en fonction de la configuration du nœud).</string>
     <string name="lightning__error_channel_purchase">Échec de la configuration des paiements instantanés</string>
     <string name="lightning__error_channel_setup_msg">Une erreur s\'est produite lors de l\'établissement de votre solde du compte courant. {raw}</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -152,8 +152,8 @@
     <string name="lightning__external_manual__paste">Coller l\'URI du nœud</string>
     <string name="lightning__external_manual__scan">Scanner QR</string>
     <string name="lightning__external_amount__title">Dépenses \n&lt;accent&gt;solde&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Ouverture\n&lt;accent&gt;du canal&lt;/accent&gt;</string>
     <string name="lightning__external_success__nav_title">Solde de dépenses</string>
+    <string name="lightning__external_success__title">Ouverture\n&lt;accent&gt;du canal&lt;/accent&gt;</string>
     <string name="lightning__external_success__text">La connexion Lightning est initiée. Vous pourrez utiliser votre compte courant dans &lt;accent&gt;±30 minutes&lt;/accent&gt; (en fonction de la configuration du nœud).</string>
     <string name="lightning__error_channel_purchase">Échec de la configuration des paiements instantanés</string>
     <string name="lightning__error_channel_setup_msg">Une erreur s\'est produite lors de l\'établissement de votre solde du compte courant. {raw}</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">Scansiona QR</string>
     <string name="lightning__external_manual__text">Puoi usare un nodo esterno per aprire manualmente una connessione Lightning. Inserisci i dettagli del nodo per continuare.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Configurazione manuale&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Saldo di spesa</string>
     <string name="lightning__external_success__text">Connessione Lightning avviata. Potrai utilizzare il tuo conto di spesa in &lt;accent&gt;±30 minuti&lt;/accent&gt; (dipende dalla configurazione del nodo).</string>
-    <string name="lightning__external_success__title">Connessione\n&lt;accent&gt;avviata&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Apertura\n&lt;accent&gt;del canale&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Tasso di commissione</string>
     <string name="lightning__fee_rate_update_time">Tempo di Aggiornamento Cache Commissioni</string>
     <string name="lightning__fees">Commissioni</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">QR scannen</string>
     <string name="lightning__external_manual__text">Je kunt een externe node gebruiken om handmatig een Lightning-verbinding te openen. Voer de node-gegevens in om door te gaan.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Handmatige configuratie&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Uitgavenbalans</string>
     <string name="lightning__external_success__text">Lightning-verbinding gestart. Je kunt je bestedingssaldo gebruiken in &lt;accent&gt;±30 minuten&lt;/accent&gt; (afhankelijk van node-configuratie).</string>
-    <string name="lightning__external_success__title">Verbinding\n&lt;accent&gt;gestart&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Kanaal wordt\n&lt;accent&gt;geopend&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Vergoedingstarief</string>
     <string name="lightning__fee_rate_update_time">Vergoedingstarief cache update tijd</string>
     <string name="lightning__fees">Vergoedingen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -152,7 +152,8 @@
     <string name="lightning__external_manual__paste">Wklej adres URI węzła</string>
     <string name="lightning__external_manual__scan">Skanuj QR</string>
     <string name="lightning__external_amount__title">Saldo\n&lt;accent&gt;wydatków&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Połączenie\n&lt;accent&gt;zainicjowane&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Otwieranie\n&lt;accent&gt;kanału&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Saldo wydatków</string>
     <string name="lightning__external_success__text">Połączenie Lightning zostało zainicjowane. Będą Państwo mogli wykorzystać swoje saldo wydatków w ciągu &lt;accent&gt;±30 minut&lt;/accent&gt; (w zależności od konfiguracji węzła).</string>
     <string name="lightning__error_channel_purchase">Konfiguracja płatności natychmiastowych nie powiodła się</string>
     <string name="lightning__error_channel_setup_msg">Wystąpił błąd podczas konfigurowania salda natychmiastowego. {raw}</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -152,8 +152,8 @@
     <string name="lightning__external_manual__paste">Wklej adres URI węzła</string>
     <string name="lightning__external_manual__scan">Skanuj QR</string>
     <string name="lightning__external_amount__title">Saldo\n&lt;accent&gt;wydatków&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Otwieranie\n&lt;accent&gt;kanału&lt;/accent&gt;</string>
     <string name="lightning__external_success__nav_title">Saldo wydatków</string>
+    <string name="lightning__external_success__title">Otwieranie\n&lt;accent&gt;kanału&lt;/accent&gt;</string>
     <string name="lightning__external_success__text">Połączenie Lightning zostało zainicjowane. Będą Państwo mogli wykorzystać swoje saldo wydatków w ciągu &lt;accent&gt;±30 minut&lt;/accent&gt; (w zależności od konfiguracji węzła).</string>
     <string name="lightning__error_channel_purchase">Konfiguracja płatności natychmiastowych nie powiodła się</string>
     <string name="lightning__error_channel_setup_msg">Wystąpił błąd podczas konfigurowania salda natychmiastowego. {raw}</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -130,8 +130,9 @@
     <string name="lightning__external_manual__scan">Escanear QR</string>
     <string name="lightning__external_manual__text">Você pode usar um nó externo para abrir manualmente uma conexão Lightning. Digite os detalhes do nó para continuar.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Setup manual&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Saldo de gastos</string>
     <string name="lightning__external_success__text">Conexão Lightning iniciada. Você poderá usar seu saldo de gastos em &lt;accent&gt;±30 minutos&lt;/accent&gt; (depende da configuração do nó).</string>
-    <string name="lightning__external_success__title">Conexão\n&lt;accent&gt;iniciada&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Abertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Taxa por bytes</string>
     <string name="lightning__fee_rate_update_time">Atualização do Cache de Taxa</string>
     <string name="lightning__fees">Taxas</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -152,7 +152,8 @@
     <string name="lightning__external_manual__paste">Colar URI do nó</string>
     <string name="lightning__external_manual__scan">Escanear QR</string>
     <string name="lightning__external_amount__title">Saldo de\n&lt;accent&gt;gastos&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Conexão\n&lt;accent&gt;iniciada&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Abertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Saldo de gastos</string>
     <string name="lightning__external_success__text">Conexão Lightning iniciada. Você poderá usar seu saldo de gastos em &lt;accent&gt;±30 minutos&lt;/accent&gt; (depende da configuração do nó).</string>
     <string name="lightning__error_channel_purchase">Setup dos Pagamentos Instantâneos falhou</string>
     <string name="lightning__error_channel_setup_msg">Ocorreu um erro ao configurar seu saldo de gastos. {raw}</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -152,8 +152,8 @@
     <string name="lightning__external_manual__paste">Colar URI do nó</string>
     <string name="lightning__external_manual__scan">Escanear QR</string>
     <string name="lightning__external_amount__title">Saldo de\n&lt;accent&gt;gastos&lt;/accent&gt;</string>
-    <string name="lightning__external_success__title">Abertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
     <string name="lightning__external_success__nav_title">Saldo de gastos</string>
+    <string name="lightning__external_success__title">Abertura\n&lt;accent&gt;de canal&lt;/accent&gt;</string>
     <string name="lightning__external_success__text">Conexão Lightning iniciada. Você poderá usar seu saldo de gastos em &lt;accent&gt;±30 minutos&lt;/accent&gt; (depende da configuração do nó).</string>
     <string name="lightning__error_channel_purchase">Setup dos Pagamentos Instantâneos falhou</string>
     <string name="lightning__error_channel_setup_msg">Ocorreu um erro ao configurar seu saldo de gastos. {raw}</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -138,8 +138,9 @@
     <string name="lightning__external_manual__scan">Сканировать QR</string>
     <string name="lightning__external_manual__text">Вы можете использовать внешний узел для ручного открытия Lightning соединения. Введите данные узла, чтобы продолжить.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Ручная Настройка&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Баланс расходов</string>
     <string name="lightning__external_success__text">Lightning соединение инициировано. Вы сможете использовать ваш баланс расходов через &lt;accent&gt;±30 минут&lt;/accent&gt; (зависит от конфигурации узла).</string>
-    <string name="lightning__external_success__title">Соединение\n&lt;accent&gt;Инициировано&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Открытие\n&lt;accent&gt;канала&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Ставка Комиссии</string>
     <string name="lightning__fee_rate_update_time">Время обновления кэша комиссии</string>
     <string name="lightning__fees">Комиссии</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,8 +136,9 @@
     <string name="lightning__external_manual__scan">Scan QR</string>
     <string name="lightning__external_manual__text">You can use an external node to manually open a Lightning connection. Enter the node details to continue.</string>
     <string name="lightning__external_manual__title">&lt;accent&gt;Manual setup&lt;/accent&gt;</string>
+    <string name="lightning__external_success__nav_title">Spending Balance</string>
     <string name="lightning__external_success__text">Lightning connection initiated. You will be able to use your spending balance in &lt;accent&gt;±30 minutes&lt;/accent&gt; (depends on node configuration).</string>
-    <string name="lightning__external_success__title">Connection\n&lt;accent&gt;initiated&lt;/accent&gt;</string>
+    <string name="lightning__external_success__title">Channel\n&lt;accent&gt;opening&lt;/accent&gt;</string>
     <string name="lightning__fee_rate">Fee rate</string>
     <string name="lightning__fee_rate_update_time">Fee Rate Cache Update Time</string>
     <string name="lightning__fees">Fees</string>


### PR DESCRIPTION
[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=38095-276493&m=dev)

This PR:
1. Updates the external success screen title from "Connection initiated" to "Channel opening"
2. Replaces the switch box image with a lightning bolt illustration
3. Adds a dedicated "Spending Balance" nav title for the success screen
4. Translates all new and updated strings across 15 locales

### Description

Updates the external node connection success screen to match the new Figma design. The title now reads "Channel Opening" (with "Opening" accented in purple), the illustration is a lightning bolt, and the nav bar shows "Spending Balance" instead of the shared "Lightning Connection" title.

### Preview

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/ad66950f-8fbe-447b-8c4e-0f2a3c7bb6f9" />

### QA Notes

#### Flow 1: Manual External Node Setup
1. From Home, tap the Lightning suggestion card (or navigate to Transfer Intro > Continue)
2. On the "Fund your spending balance" screen, tap **Advanced**
3. On the "Advanced setup" screen, tap **Manual Setup**
4. Complete the external connection flow (enter node URI, set amount, confirm)
5. Verify the success screen shows:
   - Nav title: "Spending Balance"
   - Title: "Channel" on line 1, "opening" on line 2 in purple
   - Lightning bolt illustration (not the old switch box)
   - Description text unchanged

[manual.webm](https://github.com/user-attachments/assets/7a3ac026-fe6f-44d2-8059-4375429e8b58)

#### Flow 2: LNURL Channel (QR Scan)
1. From the "Advanced setup" screen, tap **Scan LNURL**
2. Scan a valid LNURL-channel QR code
3. Confirm the connection
4. Verify the same success screen appears with the updated design