### PR TITLE
feat: update funding screen to match v60 design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
-- Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Replace Advanced button with Manual Setup shortcut on Funding screen #885
 - Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Replace Advanced button with Manual Setup shortcut on Funding screen #885
+- Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857
 - Selected values displayed on right side of settings rows #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
+- Replace Advanced button with Manual Setup shortcut on Funding screen
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857
 - Selected values displayed on right side of settings rows #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
-- Replace Advanced button with Manual Setup shortcut on Funding screen
+- Replace Advanced button with Manual Setup shortcut on Funding screen #885
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857
 - Icons added to all settings rows for faster scanning #857
 - Selected values displayed on right side of settings rows #857

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mnemonic warning text transitions on reveal #857
 
 ### Changed
-- Replace Advanced button with Manual Setup shortcut on Funding screen #885
+- Update funding screen: replace Advanced with Manual Setup, fix Use Other Wallet navigation to open amount entry, and add Fund Wallet button to no-funds dialog #885
 - Updated design of the success screen in the manual channel setup flow #883
 - Unified send flow with payment method switcher, details toggle, Lightning support for BIP21 payments, and improved fee rate defaults #863
 - Settings redesigned with tabbed navigation (General/Security/Advanced) with swipe support #857

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -670,7 +670,7 @@ private fun RootNavHost(
                             appViewModel.showSheet(Sheet.Receive)
                         }
                     },
-                    onAdvanced = { navController.navigateTo(Routes.FundingAdvanced) },
+                    onManual = { navController.navigateTo(Routes.ExternalNav) },
                     onBackClick = { navController.popBackStack() },
                     isGeoBlocked = isGeoBlocked,
                 )

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -100,6 +100,7 @@ import to.bitkit.ui.screens.wallets.activity.ActivityExploreScreen
 import to.bitkit.ui.screens.wallets.activity.AllActivityScreen
 import to.bitkit.ui.screens.wallets.activity.DateRangeSelectorSheet
 import to.bitkit.ui.screens.wallets.activity.TagSelectorSheet
+import to.bitkit.ui.screens.wallets.receive.ReceiveRoute
 import to.bitkit.ui.screens.wallets.receive.ReceiveSheet
 import to.bitkit.ui.screens.wallets.suggestion.BuyIntroScreen
 import to.bitkit.ui.screens.widgets.AddWidgetsScreen
@@ -381,6 +382,7 @@ fun ContentView(
                         is Sheet.Receive -> {
                             val walletState by walletViewModel.walletState.collectAsStateWithLifecycle()
                             ReceiveSheet(
+                                startRoute = sheet.route,
                                 walletState = walletState,
                                 navigateToExternalConnection = {
                                     navController.navigateTo(ExternalConnection())
@@ -475,7 +477,7 @@ fun ContentView(
                     if (showTabBar) {
                         TabBar(
                             onSendClick = { appViewModel.showSheet(Sheet.Send()) },
-                            onReceiveClick = { appViewModel.showSheet(Sheet.Receive) },
+                            onReceiveClick = { appViewModel.showSheet(Sheet.Receive()) },
                             onScanClick = { appViewModel.showScannerSheet() },
                         )
                     }
@@ -664,10 +666,9 @@ private fun RootNavHost(
                     },
                     onFund = {
                         scope.launch {
-                            // TODO show receive sheet -> ReceiveAmount
                             navController.navigateToHome()
                             delay(500) // Wait for nav to actually finish
-                            appViewModel.showSheet(Sheet.Receive)
+                            appViewModel.showSheet(Sheet.Receive(route = ReceiveRoute.Amount))
                         }
                     },
                     onManual = { navController.navigateTo(Routes.ExternalNav) },
@@ -792,7 +793,7 @@ private fun NavGraphBuilder.home(
             onchainActivities = onchainActivities ?: persistentListOf(),
             onAllActivityButtonClick = { navController.navigateToAllActivity(activityListViewModel::clearFilters) },
             onActivityItemClick = { navController.navigateToActivityItem(it) },
-            onEmptyActivityRowClick = { appViewModel.showSheet(Sheet.Receive) },
+            onEmptyActivityRowClick = { appViewModel.showSheet(Sheet.Receive()) },
             onTransferToSpendingClick = {
                 if (!hasSeenSpendingIntro) {
                     navController.navigateToTransferSpendingIntro()
@@ -814,7 +815,7 @@ private fun NavGraphBuilder.home(
             lightningActivities = lightningActivities ?: persistentListOf(),
             onAllActivityButtonClick = { navController.navigateToAllActivity(activityListViewModel::clearFilters) },
             onActivityItemClick = { navController.navigateToActivityItem(it) },
-            onEmptyActivityRowClick = { appViewModel.showSheet(Sheet.Receive) },
+            onEmptyActivityRowClick = { appViewModel.showSheet(Sheet.Receive()) },
             onTransferToSavingsClick = {
                 if (!hasSeenSavingsIntro) {
                     navController.navigateToTransferSavingsIntro()

--- a/app/src/main/java/to/bitkit/ui/components/SheetHost.kt
+++ b/app/src/main/java/to/bitkit/ui/components/SheetHost.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import to.bitkit.ui.shared.modifiers.clickableAlpha
+import to.bitkit.ui.screens.wallets.receive.ReceiveRoute
 import to.bitkit.ui.sheets.BackupRoute
 import to.bitkit.ui.sheets.PinRoute
 import to.bitkit.ui.sheets.SendRoute
@@ -37,7 +38,7 @@ private val sheetContainerColor = Color(0xFF141414) // Equivalent to White08 on 
 @Stable
 sealed interface Sheet {
     data class Send(val route: SendRoute = SendRoute.Recipient) : Sheet
-    data object Receive : Sheet
+    data class Receive(val route: ReceiveRoute = ReceiveRoute.QR) : Sheet
     data class Pin(val route: PinRoute = PinRoute.Prompt()) : Sheet
     data object ChangePin : Sheet
     data object DisablePin : Sheet

--- a/app/src/main/java/to/bitkit/ui/scaffold/AppAlertDialog.kt
+++ b/app/src/main/java/to/bitkit/ui/scaffold/AppAlertDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -30,6 +31,8 @@ fun AppAlertDialog(
     modifier: Modifier = Modifier,
     confirmText: String = stringResource(R.string.common__ok),
     dismissText: String = stringResource(R.string.common__dialog_cancel),
+    confirmTextColor: Color = Color.Unspecified,
+    dismissTextColor: Color = Colors.White64,
     onDismissRequest: () -> Unit = onDismiss,
     properties: DialogProperties = DialogProperties(
         dismissOnClickOutside = false,
@@ -43,6 +46,8 @@ fun AppAlertDialog(
         modifier = modifier,
         confirmText = confirmText,
         dismissText = dismissText,
+        confirmTextColor = confirmTextColor,
+        dismissTextColor = dismissTextColor,
         onDismissRequest = onDismissRequest,
         properties = properties,
         textContent = { BodyM(text = text, color = Colors.White64) },
@@ -57,6 +62,8 @@ fun AppAlertDialog(
     modifier: Modifier = Modifier,
     confirmText: String = stringResource(R.string.common__ok),
     dismissText: String = stringResource(R.string.common__dialog_cancel),
+    confirmTextColor: Color = Color.Unspecified,
+    dismissTextColor: Color = Colors.White64,
     onDismissRequest: () -> Unit = onDismiss,
     properties: DialogProperties = DialogProperties(
         dismissOnClickOutside = false,
@@ -71,7 +78,7 @@ fun AppAlertDialog(
                 onClick = rememberDebouncedClick(onClick = onConfirm),
                 modifier = Modifier.testTag("DialogConfirm")
             ) {
-                BodyMSB(text = confirmText)
+                BodyMSB(text = confirmText, color = confirmTextColor)
             }
         },
         dismissButton = {
@@ -79,7 +86,7 @@ fun AppAlertDialog(
                 onClick = rememberDebouncedClick(onClick = onDismiss),
                 modifier = Modifier.testTag("DialogCancel")
             ) {
-                BodyMSB(text = dismissText, color = Colors.White64)
+                BodyMSB(text = dismissText, color = dismissTextColor)
             }
         },
         title = { Title(text = title) },

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/FundingScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/FundingScreen.kt
@@ -7,9 +7,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -24,9 +21,9 @@ import to.bitkit.R
 import to.bitkit.env.Defaults
 import to.bitkit.ui.LocalBalances
 import to.bitkit.ui.components.BodyM
-import to.bitkit.ui.components.BodyMB
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.RectangleButton
+import to.bitkit.ui.scaffold.AppAlertDialog
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -116,20 +113,16 @@ fun FundingScreen(
             }
         }
         if (showNoFundsAlert) {
-            AlertDialog(
-                onDismissRequest = { showNoFundsAlert = false },
-                confirmButton = {
-                    TextButton(onClick = { showNoFundsAlert = false }) {
-                        BodyM(text = stringResource(R.string.common__ok), color = Colors.Purple)
-                    }
+            AppAlertDialog(
+                title = stringResource(R.string.lightning__no_funds__title),
+                text = stringResource(R.string.lightning__no_funds__description),
+                confirmText = stringResource(R.string.lightning__no_funds__fund_wallet),
+                confirmTextColor = Colors.Purple,
+                onConfirm = {
+                    showNoFundsAlert = false
+                    onFund()
                 },
-                title = {
-                    BodyMB(text = stringResource(R.string.lightning__no_funds__title))
-                },
-                text = {
-                    BodyM(text = stringResource(R.string.lightning__no_funds__description))
-                },
-                shape = MaterialTheme.shapes.small,
+                onDismiss = { showNoFundsAlert = false },
             )
         }
     }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/FundingScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/FundingScreen.kt
@@ -40,7 +40,7 @@ fun FundingScreen(
     isGeoBlocked: Boolean,
     onTransfer: () -> Unit = {},
     onFund: () -> Unit = {},
-    onAdvanced: () -> Unit = {},
+    onManual: () -> Unit = {},
     onBackClick: () -> Unit = {},
 ) {
     val balances = LocalBalances.current
@@ -106,11 +106,12 @@ fun FundingScreen(
                     modifier = Modifier.testTag("FundReceive")
                 )
                 RectangleButton(
-                    label = stringResource(R.string.lightning__funding__button3),
-                    icon = R.drawable.ic_share_purple,
+                    label = stringResource(R.string.lightning__funding_advanced__button2),
+                    icon = R.drawable.ic_pencil_full,
                     iconTint = Colors.Purple,
-                    onClick = onAdvanced,
-                    modifier = Modifier.testTag("FundCustom")
+                    iconSize = 13.37.dp,
+                    onClick = onManual,
+                    modifier = Modifier.testTag("FundManual")
                 )
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -70,7 +70,7 @@ fun AllActivityScreen(
         onTagClick = { app.showSheet(Sheet.ActivityTagSelector) },
         onDateRangeClick = { app.showSheet(Sheet.ActivityDateRangeSelector) },
         onActivityItemClick = onActivityItemClick,
-        onEmptyActivityRowClick = { app.showSheet(Sheet.Receive) },
+        onEmptyActivityRowClick = { app.showSheet(Sheet.Receive()) },
     )
 }
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
@@ -31,6 +31,7 @@ import to.bitkit.viewmodels.SettingsViewModel
 fun ReceiveSheet(
     navigateToExternalConnection: () -> Unit,
     walletState: WalletState,
+    startRoute: ReceiveRoute = ReceiveRoute.QR,
     editInvoiceAmountViewModel: AmountInputViewModel = hiltViewModel(),
     settingsViewModel: SettingsViewModel = hiltViewModel(),
 ) {
@@ -47,6 +48,12 @@ fun ReceiveSheet(
     LaunchedEffect(Unit) {
         wallet.resetPreActivityMetadataTagsForCurrentInvoice()
         wallet.refreshReceiveState()
+    }
+
+    LaunchedEffect(startRoute) {
+        if (startRoute != ReceiveRoute.QR) {
+            navController.navigateTo(startRoute)
+        }
     }
 
     Column(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">حد HTLC الصادر التالي</string>
     <string name="lightning__next_outbound_htlc_min">الحد الأدنى لـ HTLC الصادر التالي</string>
     <string name="lightning__no_funds__description">قبل أن تتمكن من تحويل الأموال من رصيد مدخراتك، تحتاج إلى إرسال Bitcoin إلى محفظة Bitkit الخاصة بك.</string>
+    <string name="lightning__no_funds__fund_wallet">تمويل المحفظة</string>
     <string name="lightning__no_funds__title">لا توجد أموال متاحة</string>
     <string name="lightning__node_id">معرّف عقدة LDK</string>
     <string name="lightning__node_info">عقدة Lightning</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">تحويل\n&lt;accent&gt;إجباري&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">تحويل من المدخرات</string>
     <string name="lightning__funding__button2">استخدم محفظة أخرى</string>
-    <string name="lightning__funding__button3">متقدم</string>
     <string name="lightning__funding__nav_title">رصيد الإنفاق</string>
-    <string name="lightning__funding__text">يمكنك استخدام مدخرات Bitkit أو إرسال Bitcoin من محفظة مختلفة.</string>
+    <string name="lightning__funding__text">أسهل خيار هو استخدام مدخرات Bitkit الخاصة بك أو إرسال بيتكوين من محفظة مختلفة.</string>
     <string name="lightning__funding__text_blocked">لا يوفر Bitkit حاليًا خدمات Lightning في بلدك، لكن يمكنك الاتصال بعقد أخرى مباشرة.</string>
     <string name="lightning__funding__text_blocked_cjit">لا يوفر Bitkit حاليًا خدمات Lightning في بلدك، لكن يمكنك الاتصال بعقد أخرى مباشرة.</string>
     <string name="lightning__funding__title">موّل &lt;accent&gt;رصيد الإنفاق&lt;/accent&gt;</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">Límite del próximo HTLC saliente</string>
     <string name="lightning__next_outbound_htlc_min">Mínimo del próximo HTLC saliente</string>
     <string name="lightning__no_funds__description">Para transferir fondos a su saldo de ahorros, primero tiene que enviar bitcoin a su billetera Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Financiar billetera</string>
     <string name="lightning__no_funds__title">Sin fondos disponibles</string>
     <string name="lightning__node_id">ID del nodo LDK</string>
     <string name="lightning__node_info">Nodo Lightning</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">Forzar\n&lt;accent&gt;Transferencia&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Transferir desde Ahorros</string>
     <string name="lightning__funding__button2">Usar Otra Billetera</string>
-    <string name="lightning__funding__button3">Avanzado</string>
     <string name="lightning__funding__nav_title">Saldo de gastos</string>
-    <string name="lightning__funding__text">Puedes usar tu balance de ahorros en Bitkit o enviar fondos desde otra cartera.</string>
+    <string name="lightning__funding__text">La forma más fácil es usar tus ahorros de Bitkit o enviar bitcoin desde una billetera diferente.</string>
     <string name="lightning__funding__text_blocked">Bitkit no tiene soporte Lightning en tu región, pero puedes usar nodos externos manualmente.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit no tiene soporte Lightning en tu región, pero puedes usar nodos externos manualmente.</string>
     <string name="lightning__funding__title">Fondee su &lt;accent&gt;saldo de gastos&lt;/accent&gt;</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">Límit del pròxim HTLC de sortida</string>
     <string name="lightning__next_outbound_htlc_min">Mínim del pròxim HTLC de sortida</string>
     <string name="lightning__no_funds__description">Abans de poder transferir fons del teu saldo d\'estalvis, has d\'enviar bitcoin a la teva cartera Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Finançar cartera</string>
     <string name="lightning__no_funds__title">No hi ha fons disponibles</string>
     <string name="lightning__node_id">ID de Node LDK</string>
     <string name="lightning__node_info">Node de Lightning</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">Forçar\n&lt;accent&gt;transferència&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Transferir des d\'estalvis</string>
     <string name="lightning__funding__button2">Utilitza un altre moneder</string>
-    <string name="lightning__funding__button3">Avançat</string>
     <string name="lightning__funding__nav_title">Balanç de despesa</string>
-    <string name="lightning__funding__text">Pots utilitzar els teus estalvis de Bitkit o enviar bitcoin des d\'una altra cartera.</string>
+    <string name="lightning__funding__text">La forma més fàcil és utilitzar els teus estalvis de Bitkit o enviar bitcoin des d\'una altra cartera.</string>
     <string name="lightning__funding__text_blocked">Bitkit no ofereix serveis Lightning al teu país, però encara pots connectar-te a altres nodes directament.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit no ofereix serveis Lightning al teu país, però encara pots connectar-te a altres nodes directament.</string>
     <string name="lightning__funding__title">Finança el teu &lt;accent&gt;saldo de despesa&lt;/accent&gt;</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">Limit dalšího odchozího HTLC</string>
     <string name="lightning__next_outbound_htlc_min">Min dalšího odchozího HTLC</string>
     <string name="lightning__no_funds__description">Než budete moci převést prostředky ze svého zůstatku na spořicím účtu, musíte poslat bitcoiny do peněženky Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Financovat peněženku</string>
     <string name="lightning__no_funds__title">Žádné dostupné prostředky</string>
     <string name="lightning__node_id">ID uzlu LDK</string>
     <string name="lightning__node_info">Lightning uzel</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">Vynutit\n&lt;accent&gt;Převod&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Převod z úspor</string>
     <string name="lightning__funding__button2">Použijte jinou peněženku</string>
-    <string name="lightning__funding__button3">Pokročilé</string>
     <string name="lightning__funding__nav_title">Dostupný zůstatek</string>
-    <string name="lightning__funding__text">Můžete použít své úspory na BitKitu nebo poslat bitcoin z jiné peněženky.</string>
+    <string name="lightning__funding__text">Nejjednodušší možností je použít úspory z Bitkitu nebo poslat bitcoin z jiné peněženky.</string>
     <string name="lightning__funding__text_blocked">Bitkit v současné době neposkytuje služby lightning ve vaší zemi, ale stále se můžete připojit k jiným uzlům přímo.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit v současné době neposkytuje služby lightning ve vaší zemi, ale stále se můžete připojit k jiným uzlům přímo.</string>
     <string name="lightning__funding__title">Navyšte svůj &lt;accent&gt;disponibilní zůstatek&lt;/accent&gt;</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -88,12 +88,11 @@
     <string name="lightning__transfer_intro__button">Los geht\'s</string>
     <string name="lightning__funding__nav_title">Spending Balance</string>
     <string name="lightning__funding__title">Fund your &lt;accent&gt;spending balance&lt;/accent&gt;</string>
-    <string name="lightning__funding__text">Du kannst dein Bitkit-Sparkonto verwenden oder Bitcoin aus einer anderen Wallet senden.</string>
+    <string name="lightning__funding__text">Am einfachsten ist es, deine Bitkit-Ersparnisse zu verwenden oder Bitcoin von einer anderen Wallet zu senden.</string>
     <string name="lightning__funding__text_blocked">Bitkit bietet derzeit keine Lightning-Dienste in deinem Land an,  aber du kannst dich trotzdem direkt mit anderen Knotenpunkten verbinden.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit bietet derzeit keine Lightning-Dienste in deinem Land an,  aber du kannst dich trotzdem direkt mit anderen Knotenpunkten verbinden.</string>
     <string name="lightning__funding__button1">Von Sparkonto übertragen</string>
     <string name="lightning__funding__button2">Anderes Wallet verwenden</string>
-    <string name="lightning__funding__button3">Fortgeschritten</string>
     <string name="lightning__funding_advanced__nav_title">Ausgabenkonto</string>
     <string name="lightning__funding_advanced__title">Fortgeschrittene&lt;accent&gt;setup&lt;/accent&gt;</string>
     <string name="lightning__funding_advanced__text">Scannen Sie einen QR-Code, um Ihren LNURL-Kanal von einem anderen LSP zu beanspruchen, oder wählen Sie die manuelle Einrichtung.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -100,6 +100,7 @@
     <string name="lightning__funding_advanced__button2">Manuelle Einrichtung</string>
     <string name="lightning__no_funds__title">Keine verfügbaren Mittel</string>
     <string name="lightning__no_funds__description">Bevor du Geld von deinem Sparkonto übertragen kannst, musst du Bitcoin zu deiner Bitkit Wallet senden.</string>
+    <string name="lightning__no_funds__fund_wallet">Wallet aufladen</string>
     <string name="lightning__transfer__nav_title">Übertrage Guthaben</string>
     <string name="lightning__transfer__confirm">Bitte\n&lt;accent&gt;bestätige&lt;/accent&gt;</string>
     <string name="lightning__transfer__custom_fee">Benutzerdefiniert &lt;accent&gt;fee&lt;/accent&gt;</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">Αναγκαστική\n&lt;accent&gt;μεταφορά&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Μεταφορά από αποταμιεύσεις</string>
     <string name="lightning__funding__button2">Χρήση άλλου πορτοφολιού</string>
-    <string name="lightning__funding__button3">Για προχωρημένους</string>
     <string name="lightning__funding__nav_title">Υπόλοιπο δαπανών</string>
-    <string name="lightning__funding__text">Μπορείς να χρησιμοποιήσεις τις αποταμιεύσεις του Bitkit ή να στείλεις bitcoin από διαφορετικό πορτοφόλι.</string>
+    <string name="lightning__funding__text">Ο ευκολότερος τρόπος είναι να χρησιμοποιήσεις τις αποταμιεύσεις Bitkit ή να στείλεις bitcoin από διαφορετικό πορτοφόλι.</string>
     <string name="lightning__funding__text_blocked">Το Bitkit δεν παρέχει προς το παρόν υπηρεσίες Lightning στη χώρα σου, αλλά μπορείς να συνδεθείς απευθείας σε άλλους κόμβους.</string>
     <string name="lightning__funding__text_blocked_cjit">Το Bitkit δεν παρέχει προς το παρόν υπηρεσίες Lightning στη χώρα σου, αλλά μπορείς να συνδεθείς απευθείας σε άλλους κόμβους.</string>
     <string name="lightning__funding__title">Χρηματοδότησε το &lt;accent&gt;υπόλοιπο δαπανών&lt;/accent&gt;</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">Όριο επόμενου εξερχόμενου HTLC</string>
     <string name="lightning__next_outbound_htlc_min">Ελάχιστο επόμενο εξερχόμενο HTLC</string>
     <string name="lightning__no_funds__description">Πριν μπορέσεις να μεταφέρεις κεφάλαια από το υπόλοιπο αποταμιεύσεων, πρέπει να στείλεις bitcoin στο πορτοφόλι Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Χρηματοδότηση πορτοφολιού</string>
     <string name="lightning__no_funds__title">Δεν υπάρχουν διαθέσιμα κεφάλαια</string>
     <string name="lightning__node_id">LDK Node ID</string>
     <string name="lightning__node_info">Κόμβος Lightning</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">Límite del siguiente HTLC saliente</string>
     <string name="lightning__next_outbound_htlc_min">Mínimo del siguiente HTLC saliente</string>
     <string name="lightning__no_funds__description">Antes de que pueda transferir fondos a su saldo de ahorros, tiene que enviar bitcoin a su monedero Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Financiar monedero</string>
     <string name="lightning__no_funds__title">No hay fondos disponibles</string>
     <string name="lightning__node_id">ID del nodo LDK</string>
     <string name="lightning__node_info">Nodo Lightning</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">Forzar\n&lt;accent&gt;Transferencia&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Transferir desde Ahorros</string>
     <string name="lightning__funding__button2">Usar Otro Monedero</string>
-    <string name="lightning__funding__button3">Avanzado</string>
     <string name="lightning__funding__nav_title">Saldo de gastos</string>
-    <string name="lightning__funding__text">Puede usar sus ahorros en Bitkit o enviar bitcoin desde un monedero diferente.</string>
+    <string name="lightning__funding__text">La forma más fácil es usar sus ahorros en Bitkit o enviar bitcoin desde un monedero diferente.</string>
     <string name="lightning__funding__text_blocked">Bitkit actualmente no ofrece servicios Lightning en tu país, pero aún puedes conectarte directamente a otros nodos.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit actualmente no ofrece servicios Lightning en tu país, pero aún puedes conectarte directamente a otros nodos.</string>
     <string name="lightning__funding__title">Rellene su &lt;accent&gt;saldo de gastos&lt;/accent&gt;</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -173,6 +173,7 @@
     <string name="lightning__funding_advanced__nav_title">Saldo de gastos</string>
     <string name="lightning__no_funds__title">No hay fondos disponibles</string>
     <string name="lightning__no_funds__description">Antes de que pueda transferir fondos a su saldo de ahorros, tiene que enviar bitcoin a su monedero Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Financiar monedero</string>
     <string name="lightning__transfer__nav_title">Transferir fondos</string>
     <string name="lightning__transfer__confirm">Por favor,\n&lt;accent&gt;confirme&lt;/accent&gt;</string>
     <string name="lightning__transfer__swipe">Deslizar para transferir</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -167,10 +167,9 @@
     <string name="lightning__transfer_intro__button">Empezar</string>
     <string name="lightning__funding__nav_title">Saldo de gastos</string>
     <string name="lightning__funding__title">Rellene su &lt;accent&gt;saldo de gastos&lt;/accent&gt;</string>
-    <string name="lightning__funding__text">Puede usar sus ahorros en Bitkit o enviar bitcoin desde un monedero diferente.</string>
+    <string name="lightning__funding__text">La forma más fácil es usar tus ahorros de Bitkit o enviar bitcoin desde un monedero diferente.</string>
     <string name="lightning__funding__button1">Transferir desde Ahorros</string>
     <string name="lightning__funding__button2">Usar Otro Monedero</string>
-    <string name="lightning__funding__button3">Avanzado</string>
     <string name="lightning__funding_advanced__nav_title">Saldo de gastos</string>
     <string name="lightning__no_funds__title">No hay fondos disponibles</string>
     <string name="lightning__no_funds__description">Antes de que pueda transferir fondos a su saldo de ahorros, tiene que enviar bitcoin a su monedero Bitkit.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -100,6 +100,7 @@
     <string name="lightning__funding_advanced__button2">Configuration manuelle</string>
     <string name="lightning__no_funds__title">Pas de fonds disponibles</string>
     <string name="lightning__no_funds__description">Avant de pouvoir transférer des fonds depuis votre solde d\'épargne, vous devez envoyer des bitcoins à votre portefeuille Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Approvisionner le portefeuille</string>
     <string name="lightning__transfer__nav_title">Transfert de fonds</string>
     <string name="lightning__transfer__confirm">Veuillez\n&lt;accent&gt;confirmer&lt;/accent&gt;</string>
     <string name="lightning__transfer__custom_fee">&lt;accent&gt;Frais&lt;/accent&gt; sur mesure</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -88,12 +88,11 @@
     <string name="lightning__transfer_intro__button">Commencer</string>
     <string name="lightning__funding__nav_title">Solde Dépenses</string>
     <string name="lightning__funding__title">Financez votre &lt;accent&gt;solde Dépenses&lt;/accent&gt;</string>
-    <string name="lightning__funding__text">Vous pouvez utiliser votre épargne Bitkit ou envoyer des bitcoins à partir d\'un autre portefeuille.</string>
+    <string name="lightning__funding__text">Le plus simple est d\'utiliser vos économies Bitkit ou d\'envoyer des bitcoins depuis un autre portefeuille.</string>
     <string name="lightning__funding__text_blocked">Bitkit ne fournit pas actuellement de services Lightning dans votre pays, mais vous pouvez toujours vous connecter directement à d\'autres nœuds.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit ne fournit pas actuellement de services Lightning dans votre pays, mais vous pouvez toujours vous connecter directement à d\'autres nœuds.</string>
     <string name="lightning__funding__button1">Transfert depuis l\'épargne</string>
     <string name="lightning__funding__button2">Utiliser un autre portefeuille</string>
-    <string name="lightning__funding__button3">Avancé</string>
     <string name="lightning__funding_advanced__nav_title">Solde Dépenses</string>
     <string name="lightning__funding_advanced__title">&lt;accent&gt;Configuration&lt;/accent&gt; avancée</string>
     <string name="lightning__funding_advanced__text">Scannez un QR code pour réclamer votre canal LNURL à un autre LSP, ou choisissez la configuration manuelle.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">Trasferimento\n&lt;accent&gt;forzoso&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Trasferimento da risparmio</string>
     <string name="lightning__funding__button2">Usa un altro portafoglio</string>
-    <string name="lightning__funding__button3">Avanzate</string>
     <string name="lightning__funding__nav_title">Conto di Spesa</string>
-    <string name="lightning__funding__text">Puoi utilizzare i tuoi risparmi Bitkit o inviare bitcoin da un portafoglio diverso.</string>
+    <string name="lightning__funding__text">Il modo più semplice è usare i tuoi risparmi Bitkit o inviare bitcoin da un portafoglio diverso.</string>
     <string name="lightning__funding__text_blocked">Bitkit attualmente non fornisce servizi Lightning nel tuo paese, ma puoi comunque connetterti direttamente ad altri nodi.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit attualmente non fornisce servizi Lightning nel tuo paese, ma puoi comunque connetterti direttamente ad altri nodi.</string>
     <string name="lightning__funding__title">Manda fondi al tuo &lt;accent&gt;conto di spesa&lt;/accent&gt;</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">Limite HTLC in Uscita Successivo</string>
     <string name="lightning__next_outbound_htlc_min">HTLC Min in Uscita Successivo</string>
     <string name="lightning__no_funds__description">Prima di poter trasferire fondi dal tuo conto di risparmio, devi inviare bitcoin al tuo portafoglio Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Finanzia portafoglio</string>
     <string name="lightning__no_funds__title">Nessun fondo disponibile</string>
     <string name="lightning__node_id">ID Nodo LDK</string>
     <string name="lightning__node_info">Nodo Lightning</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">Volgende uitgaande HTLC-limiet</string>
     <string name="lightning__next_outbound_htlc_min">Volgende uitgaande HTLC min</string>
     <string name="lightning__no_funds__description">Voordat je geld van je spaargeld kunt overboeken, moet je bitcoin naar je Bitkit-wallet sturen.</string>
+    <string name="lightning__no_funds__fund_wallet">Wallet financieren</string>
     <string name="lightning__no_funds__title">Geen beschikbaar geld</string>
     <string name="lightning__node_id">LDK Node ID</string>
     <string name="lightning__node_info">Lightning Node</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">Forceer\n&lt;accent&gt;overboeking&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Overboeken van spaargeld</string>
     <string name="lightning__funding__button2">Andere wallet gebruiken</string>
-    <string name="lightning__funding__button3">Geavanceerd</string>
     <string name="lightning__funding__nav_title">Bestedingssaldo</string>
-    <string name="lightning__funding__text">Je kunt je Bitkit spaargeld gebruiken of bitcoin versturen vanaf een andere wallet.</string>
+    <string name="lightning__funding__text">De makkelijkste optie is om je Bitkit-spaargeld te gebruiken of bitcoin te versturen vanuit een andere wallet.</string>
     <string name="lightning__funding__text_blocked">Bitkit biedt momenteel geen Lightning-services in jouw land, maar je kunt nog steeds rechtstreeks verbinding maken met andere nodes.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit biedt momenteel geen Lightning-services in jouw land, maar je kunt nog steeds rechtstreeks verbinding maken met andere nodes.</string>
     <string name="lightning__funding__title">Vul je &lt;accent&gt;bestedingssaldo&lt;/accent&gt;</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -88,12 +88,11 @@
     <string name="lightning__transfer_intro__button">Rozpocznij</string>
     <string name="lightning__funding__nav_title">Saldo wydatków</string>
     <string name="lightning__funding__title">Zasil swoje &lt;accent&gt;saldo wydatków&lt;/accent&gt;</string>
-    <string name="lightning__funding__text">Możesz użyć oszczędności zgromadzonych w Twoim portfelu Bitkit lub wysłać bitcoiny z innego portfela.</string>
+    <string name="lightning__funding__text">Najłatwiejszą opcją jest użycie oszczędności Bitkit lub wysłanie bitcoinów z innego portfela.</string>
     <string name="lightning__funding__text_blocked">Bitkit nie świadczy obecnie usług Lightning w Twoim kraju, ale nadal możesz łączyć się z innymi węzłami.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit nie świadczy obecnie usług Lightning w Twoim kraju, ale nadal możesz łączyć się bezpośrednio z innymi węzłami.</string>
     <string name="lightning__funding__button1">Prześlij z Oszczędności</string>
     <string name="lightning__funding__button2">Użyj innego portfela</string>
-    <string name="lightning__funding__button3">Zaawansowane</string>
     <string name="lightning__funding_advanced__nav_title">Saldo do wydawania</string>
     <string name="lightning__funding_advanced__title">&lt;accent&gt;Ustawienia&lt;/accent&gt; zaawansowane</string>
     <string name="lightning__funding_advanced__text">Zeskanuj kod QR, aby odebrać swój kanał LNURL od innego LSP, lub wybierz ręczną konfigurację.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -100,6 +100,7 @@
     <string name="lightning__funding_advanced__button2">Konfiguracja ręczna</string>
     <string name="lightning__no_funds__title">Brak dostępnych środków</string>
     <string name="lightning__no_funds__description">Zanim będzie można przelać środki z salda oszczędności, należy wysłać bitcoiny do portfela Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Doładuj portfel</string>
     <string name="lightning__transfer__nav_title">Prześlij środki</string>
     <string name="lightning__transfer__confirm">Proszę \n&lt;accent&gt;potwierdzić&lt;/accent&gt;</string>
     <string name="lightning__transfer__custom_fee">&lt;accent&gt;Niestandardowa&lt;/accent&gt; opłata transakcyjna</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -168,6 +168,7 @@
     <string name="lightning__next_outbound_htlc_limit">Limite do Próximo HTLC de Saída</string>
     <string name="lightning__next_outbound_htlc_min">HTLC de Saída Mín Próximo</string>
     <string name="lightning__no_funds__description">Antes de transferir fundos de seu saldo de poupança, receba bitcoin na sua carteira Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Financiar Carteira</string>
     <string name="lightning__no_funds__title">Não há Fundos Disponíveis</string>
     <string name="lightning__node_id">ID do LDK Node </string>
     <string name="lightning__node_info">Nó Lightning</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -146,9 +146,8 @@
     <string name="lightning__force_title">Forçar\n&lt;accent&gt;Transferência&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Transferir do Saldo de Poupança</string>
     <string name="lightning__funding__button2">Transferir de Outra Carteira</string>
-    <string name="lightning__funding__button3">Avançado</string>
     <string name="lightning__funding__nav_title">Saldo de Gastos</string>
-    <string name="lightning__funding__text">Use seu saldo de poupança ou receba bitcoin de outra carteira.</string>
+    <string name="lightning__funding__text">A forma mais fácil é usar suas economias do Bitkit ou enviar bitcoin de uma carteira diferente.</string>
     <string name="lightning__funding__text_blocked">Bitkit não fornece serviços de Lightning no seu paús atualmente, mas você ainda pode se conectar diretamente a outros nodes</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit não fornece serviços de Lightning no seu paús atualmente, mas você ainda pode se conectar diretamente a outros nodes</string>
     <string name="lightning__funding__title">Transfira para seu &lt;accent&gt;saldo de gastos&lt;/accent&gt;</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -88,12 +88,11 @@
     <string name="lightning__transfer_intro__button">Começar</string>
     <string name="lightning__funding__nav_title">Saldo de Gastos</string>
     <string name="lightning__funding__title">Transfira para seu &lt;accent&gt;saldo de gastos&lt;/accent&gt;</string>
-    <string name="lightning__funding__text">Use seu saldo de poupança ou receba bitcoin de outra carteira.</string>
+    <string name="lightning__funding__text">A forma mais fácil é usar as suas poupanças Bitkit ou enviar bitcoin de uma carteira diferente.</string>
     <string name="lightning__funding__text_blocked">Bitkit não fornece serviços de Lightning no seu paús atualmente, mas você ainda pode se conectar diretamente a outros nodes</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit não fornece serviços de Lightning no seu paús atualmente, mas você ainda pode se conectar diretamente a outros nodes</string>
     <string name="lightning__funding__button1">Transferir do Saldo de Poupança</string>
     <string name="lightning__funding__button2">Transferir de Outra Carteira</string>
-    <string name="lightning__funding__button3">Avançado</string>
     <string name="lightning__funding_advanced__nav_title">Saldo de Gastos</string>
     <string name="lightning__funding_advanced__title">&lt;accent&gt;Configuração&lt;/accent&gt; avançada</string>
     <string name="lightning__funding_advanced__text">Escaneie um QR para reivindicar seu canal LNURL de outro LSP ou escolha o setup manual.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -100,6 +100,7 @@
     <string name="lightning__funding_advanced__button2">Setup Manual</string>
     <string name="lightning__no_funds__title">Não há Fundos Disponíveis</string>
     <string name="lightning__no_funds__description">Antes de transferir fundos de seu saldo de poupança, receba bitcoin na sua carteira Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Financiar Carteira</string>
     <string name="lightning__transfer__nav_title">Transf. fundos</string>
     <string name="lightning__transfer__confirm">Por favor\n&lt;accent&gt;confirme&lt;/accent&gt;</string>
     <string name="lightning__transfer__custom_fee">&lt;accent&gt;Taxa&lt;/accent&gt; personalizada</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -154,9 +154,8 @@
     <string name="lightning__force_title">Принудительный\n&lt;accent&gt;Перевод&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Перевести из Сбережений</string>
     <string name="lightning__funding__button2">Использовать Другой Кошелёк</string>
-    <string name="lightning__funding__button3">Дополнительно</string>
     <string name="lightning__funding__nav_title">Баланс Расходов</string>
-    <string name="lightning__funding__text">Вы можете использовать свои сбережения Bitkit или отправить биткойны из другого кошелька.</string>
+    <string name="lightning__funding__text">Самый простой вариант — использовать ваши сбережения Bitkit или отправить биткоин с другого кошелька.</string>
     <string name="lightning__funding__text_blocked">Bitkit в настоящее время не предоставляет услуги Lightning в вашей стране, но вы всё ещё можете подключаться к другим нодам напрямую.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit в настоящее время не предоставляет услуги Lightning в вашей стране, но вы всё ещё можете подключаться к другим нодам напрямую.</string>
     <string name="lightning__funding__title">Пополните свой &lt;accent&gt;Баланс Расходов&lt;/accent&gt;</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -180,6 +180,7 @@
     <string name="lightning__next_outbound_htlc_limit">Лимит след. исходящего HTLC</string>
     <string name="lightning__next_outbound_htlc_min">Мин. след. исходящего HTLC</string>
     <string name="lightning__no_funds__description">Прежде чем вы сможете перевести средства со своего баланса сбережений, вам нужно отправить биткойны в ваш кошелёк Bitkit.</string>
+    <string name="lightning__no_funds__fund_wallet">Пополнить кошелёк</string>
     <string name="lightning__no_funds__title">Недостаточно Средств</string>
     <string name="lightning__node_id">ID Узла LDK</string>
     <string name="lightning__node_info">Lightning Узел</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,9 +152,8 @@
     <string name="lightning__force_title">Force\n&lt;accent&gt;Transfer&lt;/accent&gt;</string>
     <string name="lightning__funding__button1">Transfer from Savings</string>
     <string name="lightning__funding__button2">Use Other Wallet</string>
-    <string name="lightning__funding__button3">Advanced</string>
     <string name="lightning__funding__nav_title">Spending Balance</string>
-    <string name="lightning__funding__text">You can use your Bitkit savings or send bitcoin from a different wallet.</string>
+    <string name="lightning__funding__text">The easiest option is to use your Bitkit savings or send bitcoin from a different wallet.</string>
     <string name="lightning__funding__text_blocked">Bitkit does not currently provide Lightning services in your country, but you can still connect to other nodes directly.</string>
     <string name="lightning__funding__text_blocked_cjit">Bitkit does not currently provide Lightning services in your country, but you can still connect to other nodes directly.</string>
     <string name="lightning__funding__title">Fund your &lt;accent&gt;spending balance&lt;/accent&gt;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <string name="lightning__next_outbound_htlc_limit">Next Outbound HTLC Limit</string>
     <string name="lightning__next_outbound_htlc_min">Next Outbound HTLC Min</string>
     <string name="lightning__no_funds__description">Before you can transfer funds from your savings balance, you need to send bitcoin to your Bitkit wallet.</string>
+    <string name="lightning__no_funds__fund_wallet">Fund Wallet</string>
     <string name="lightning__no_funds__title">No Available Funds</string>
     <string name="lightning__node_id">LDK Node ID</string>
     <string name="lightning__node_info">Lightning Node</string>


### PR DESCRIPTION
Closes #873 

[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=36003-105771&m=dev) 

This PR:
1. Replaces the Advanced button with a Manual Setup shortcut on the Funding screen, navigating directly to the external node connection flow
2. Updates the funding screen description text to match the latest Figma design
3. Fix the "User other wallet" navigation to display CJIT flow
4. Updates all 15 locale translations accordingly

### Preview

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/3d638047-0816-4634-ba43-5822ede58e89" />

[from-dialog.webm](https://github.com/user-attachments/assets/76694499-dd6c-44c1-b9f5-1ccca524f04f)

[other-wallet-button.webm](https://github.com/user-attachments/assets/d56105c9-0286-4ee5-a42f-db4331fcfd4a)

[transfer-button.webm](https://github.com/user-attachments/assets/7dc9b509-2b25-4bbb-b826-2afd82489921)

[geobleckd.webm](https://github.com/user-attachments/assets/ca62e4e4-102e-4d0c-a3cd-1f71e2bc9a66)


### QA Notes

1. Navigate to the Funding screen (App Drawer -> Lightning connections -> Add connection)
2. Verify the third button now shows "Manual Setup" with a pencil icon instead of "Advanced" with a share icon
3. Tap "Manual Setup" and confirm it navigates directly to the External Node connection screen (skipping the old Advanced screen)
4. Verify the description text reads "The easiest option is to use your Bitkit savings or send bitcoin from a different wallet."
5. Tap "Use other wallet" and verify it opens the Receive sheet at the CJIT amount entry screen (not the QR screen)
6. Enter an amount above the minimum and tap Continue — verify a CJIT entry is created and the confirmation screen shows fees
7. Tap Continue on the confirmation screen and verify it navigates to the QR screen with the CJIT invoice
8. When geo-blocked, verify the "Use other wallet" button is disabled