### PR TITLE
refactor: add msat model to encapsulate conversions

### DIFF
--- a/app/src/main/java/to/bitkit/domain/commands/NotifyPaymentReceivedHandler.kt
+++ b/app/src/main/java/to/bitkit/domain/commands/NotifyPaymentReceivedHandler.kt
@@ -18,6 +18,7 @@ import to.bitkit.models.NotificationDetails
 import to.bitkit.models.PrimaryDisplay
 import to.bitkit.models.formatToModernDisplay
 import to.bitkit.repositories.ActivityRepo
+import to.bitkit.models.MSat
 import to.bitkit.repositories.CurrencyRepo
 import to.bitkit.utils.Logger
 import javax.inject.Inject
@@ -97,7 +98,7 @@ class NotifyPaymentReceivedHandler @Inject constructor(
             is NotifyPaymentReceived.Command.Onchain -> command.event.txid
         },
         sats = when (command) {
-            is NotifyPaymentReceived.Command.Lightning -> ((command.event.amountMsat + 999u) / 1000u).toLong()
+            is NotifyPaymentReceived.Command.Lightning -> MSat(command.event.amountMsat).ceil().toLong()
             is NotifyPaymentReceived.Command.Onchain -> command.event.details.amountSats
         },
     )

--- a/app/src/main/java/to/bitkit/domain/commands/NotifyPaymentReceivedHandler.kt
+++ b/app/src/main/java/to/bitkit/domain/commands/NotifyPaymentReceivedHandler.kt
@@ -18,7 +18,7 @@ import to.bitkit.models.NotificationDetails
 import to.bitkit.models.PrimaryDisplay
 import to.bitkit.models.formatToModernDisplay
 import to.bitkit.repositories.ActivityRepo
-import to.bitkit.models.MSat
+import to.bitkit.models.msatCeilOf
 import to.bitkit.repositories.CurrencyRepo
 import to.bitkit.utils.Logger
 import javax.inject.Inject
@@ -98,7 +98,7 @@ class NotifyPaymentReceivedHandler @Inject constructor(
             is NotifyPaymentReceived.Command.Onchain -> command.event.txid
         },
         sats = when (command) {
-            is NotifyPaymentReceived.Command.Lightning -> MSat(command.event.amountMsat).ceil().toLong()
+            is NotifyPaymentReceived.Command.Lightning -> msatCeilOf(command.event.amountMsat).toLong()
             is NotifyPaymentReceived.Command.Onchain -> command.event.details.amountSats
         },
     )

--- a/app/src/main/java/to/bitkit/ext/ChannelDetails.kt
+++ b/app/src/main/java/to/bitkit/ext/ChannelDetails.kt
@@ -3,7 +3,7 @@ package to.bitkit.ext
 import org.lightningdevkit.ldknode.ChannelConfig
 import org.lightningdevkit.ldknode.ChannelDetails
 import org.lightningdevkit.ldknode.MaxDustHtlcExposure
-import to.bitkit.models.MSat
+import to.bitkit.models.msatFloorOf
 
 /**
  * Calculates our total balance in the channel (see `value_to_self_msat` in rust-lightning).
@@ -19,7 +19,7 @@ val ChannelDetails.amountOnClose: ULong
     @Suppress("ForbiddenComment")
     get() {
         // TODO: use channelDetails.claimableOnCloseSats
-        val outboundCapacitySat = MSat(this.outboundCapacityMsat).floor()
+        val outboundCapacitySat = msatFloorOf(this.outboundCapacityMsat)
         val ourReserve = this.unspendablePunishmentReserve ?: 0u
 
         return outboundCapacitySat + ourReserve
@@ -33,13 +33,13 @@ fun List<ChannelDetails>.filterPending(): List<ChannelDetails> = this.filterNot 
 
 /** Returns a limit in sats as close as possible to the HTLC limit we can currently send. */
 fun List<ChannelDetails>?.totalNextOutboundHtlcLimitSats(): ULong = this?.filter { it.isUsable }
-    ?.sumOf { MSat(it.nextOutboundHtlcLimitMsat).floor() }
+    ?.sumOf { msatFloorOf(it.nextOutboundHtlcLimitMsat) }
     ?: 0u
 
 /** Calculates the total remote balance (inbound capacity) from open channels. */
 fun List<ChannelDetails>.calculateRemoteBalance(): ULong = this
     .filterOpen()
-    .sumOf { MSat(it.inboundCapacityMsat).floor() }
+    .sumOf { msatFloorOf(it.inboundCapacityMsat) }
 
 fun createChannelDetails(): ChannelDetails = ChannelDetails(
     channelId = "channelId",

--- a/app/src/main/java/to/bitkit/ext/ChannelDetails.kt
+++ b/app/src/main/java/to/bitkit/ext/ChannelDetails.kt
@@ -3,6 +3,7 @@ package to.bitkit.ext
 import org.lightningdevkit.ldknode.ChannelConfig
 import org.lightningdevkit.ldknode.ChannelDetails
 import org.lightningdevkit.ldknode.MaxDustHtlcExposure
+import to.bitkit.models.MSat
 
 /**
  * Calculates our total balance in the channel (see `value_to_self_msat` in rust-lightning).
@@ -18,7 +19,7 @@ val ChannelDetails.amountOnClose: ULong
     @Suppress("ForbiddenComment")
     get() {
         // TODO: use channelDetails.claimableOnCloseSats
-        val outboundCapacitySat = this.outboundCapacityMsat / 1000u
+        val outboundCapacitySat = MSat(this.outboundCapacityMsat).floor()
         val ourReserve = this.unspendablePunishmentReserve ?: 0u
 
         return outboundCapacitySat + ourReserve
@@ -32,13 +33,13 @@ fun List<ChannelDetails>.filterPending(): List<ChannelDetails> = this.filterNot 
 
 /** Returns a limit in sats as close as possible to the HTLC limit we can currently send. */
 fun List<ChannelDetails>?.totalNextOutboundHtlcLimitSats(): ULong = this?.filter { it.isUsable }
-    ?.sumOf { it.nextOutboundHtlcLimitMsat / 1000u }
+    ?.sumOf { MSat(it.nextOutboundHtlcLimitMsat).floor() }
     ?: 0u
 
 /** Calculates the total remote balance (inbound capacity) from open channels. */
 fun List<ChannelDetails>.calculateRemoteBalance(): ULong = this
     .filterOpen()
-    .sumOf { it.inboundCapacityMsat / 1000u }
+    .sumOf { MSat(it.inboundCapacityMsat).floor() }
 
 fun createChannelDetails(): ChannelDetails = ChannelDetails(
     channelId = "channelId",

--- a/app/src/main/java/to/bitkit/ext/Lnurl.kt
+++ b/app/src/main/java/to/bitkit/ext/Lnurl.kt
@@ -28,7 +28,7 @@ fun LnurlPayData.isFixedAmount(): Boolean =
  * For variable-amount requests the user-selected sat amount is converted to msats.
  */
 fun LnurlPayData.callbackAmountMsats(userSats: ULong? = null): ULong =
-    if (isFixedAmount()) minSendable else (userSats ?: minSendableSat()) * 1000u
+    if (isFixedAmount()) minSendable else (userSats ?: minSendableSat()) * MSat.PER_SAT
 
 fun LnurlWithdrawData.minWithdrawableSat(): ULong = MSat(minWithdrawable ?: 0u).ceil()
 fun LnurlWithdrawData.maxWithdrawableSat(): ULong = MSat(maxWithdrawable).floor()

--- a/app/src/main/java/to/bitkit/ext/Lnurl.kt
+++ b/app/src/main/java/to/bitkit/ext/Lnurl.kt
@@ -3,10 +3,12 @@ package to.bitkit.ext
 import com.synonym.bitkitcore.LnurlPayData
 import com.synonym.bitkitcore.LnurlWithdrawData
 import to.bitkit.models.MSat
+import to.bitkit.models.msatCeilOf
+import to.bitkit.models.msatFloorOf
 
 fun LnurlPayData.commentAllowed(): Boolean = commentAllowed?.let { it > 0u } == true
-fun LnurlPayData.maxSendableSat(): ULong = MSat(maxSendable).floor()
-fun LnurlPayData.minSendableSat(): ULong = MSat(minSendable).ceil()
+fun LnurlPayData.maxSendableSat(): ULong = msatFloorOf(maxSendable)
+fun LnurlPayData.minSendableSat(): ULong = msatCeilOf(minSendable)
 
 /**
  * True when the LNURL-pay endpoint specifies a single exact amount.
@@ -30,8 +32,8 @@ fun LnurlPayData.isFixedAmount(): Boolean =
 fun LnurlPayData.callbackAmountMsats(userSats: ULong? = null): ULong =
     if (isFixedAmount()) minSendable else (userSats ?: minSendableSat()) * MSat.PER_SAT
 
-fun LnurlWithdrawData.minWithdrawableSat(): ULong = MSat(minWithdrawable ?: 0u).ceil()
-fun LnurlWithdrawData.maxWithdrawableSat(): ULong = MSat(maxWithdrawable).floor()
+fun LnurlWithdrawData.minWithdrawableSat(): ULong = msatCeilOf(minWithdrawable ?: 0u)
+fun LnurlWithdrawData.maxWithdrawableSat(): ULong = msatFloorOf(maxWithdrawable)
 
 /**
  * True when the LNURL-withdraw endpoint specifies a single exact amount,

--- a/app/src/main/java/to/bitkit/ext/Lnurl.kt
+++ b/app/src/main/java/to/bitkit/ext/Lnurl.kt
@@ -2,27 +2,11 @@ package to.bitkit.ext
 
 import com.synonym.bitkitcore.LnurlPayData
 import com.synonym.bitkitcore.LnurlWithdrawData
-
-private const val MSATS_PER_SAT: ULong = 1000u
-
-/**
- * LNURL amounts are expressed in millisatoshis (msat).
- *
- * When converting a minimum bound to whole sats we must round up:
- * `minSendable = 100500 msat` means the minimum payable amount is `101 sat` (not `100 sat`).
- */
-private fun msatsToSatsCeil(msats: ULong): ULong {
-    val quotient = msats / MSATS_PER_SAT
-    val remainder = msats % MSATS_PER_SAT
-    return when (remainder) {
-        0uL -> quotient
-        else -> quotient + 1uL
-    }
-}
+import to.bitkit.models.MSat
 
 fun LnurlPayData.commentAllowed(): Boolean = commentAllowed?.let { it > 0u } == true
-fun LnurlPayData.maxSendableSat(): ULong = maxSendable / MSATS_PER_SAT
-fun LnurlPayData.minSendableSat(): ULong = msatsToSatsCeil(minSendable)
+fun LnurlPayData.maxSendableSat(): ULong = MSat(maxSendable).floor()
+fun LnurlPayData.minSendableSat(): ULong = MSat(minSendable).ceil()
 
 /**
  * True when the LNURL-pay endpoint specifies a single exact amount.
@@ -44,10 +28,10 @@ fun LnurlPayData.isFixedAmount(): Boolean =
  * For variable-amount requests the user-selected sat amount is converted to msats.
  */
 fun LnurlPayData.callbackAmountMsats(userSats: ULong? = null): ULong =
-    if (isFixedAmount()) minSendable else (userSats ?: minSendableSat()) * MSATS_PER_SAT
+    if (isFixedAmount()) minSendable else (userSats ?: minSendableSat()) * 1000u
 
-fun LnurlWithdrawData.minWithdrawableSat(): ULong = msatsToSatsCeil(minWithdrawable ?: 0u)
-fun LnurlWithdrawData.maxWithdrawableSat(): ULong = maxWithdrawable / MSATS_PER_SAT
+fun LnurlWithdrawData.minWithdrawableSat(): ULong = MSat(minWithdrawable ?: 0u).ceil()
+fun LnurlWithdrawData.maxWithdrawableSat(): ULong = MSat(maxWithdrawable).floor()
 
 /**
  * True when the LNURL-withdraw endpoint specifies a single exact amount,

--- a/app/src/main/java/to/bitkit/ext/PaymentDetails.kt
+++ b/app/src/main/java/to/bitkit/ext/PaymentDetails.kt
@@ -1,6 +1,7 @@
 package to.bitkit.ext
 
 import org.lightningdevkit.ldknode.PaymentDetails
+import to.bitkit.models.MSat
 
 val PaymentDetails.amountSats: ULong?
-    get() = amountMsat?.let { (it + 999u) / 1000u }
+    get() = amountMsat?.let { MSat(it).ceil() }

--- a/app/src/main/java/to/bitkit/ext/PaymentDetails.kt
+++ b/app/src/main/java/to/bitkit/ext/PaymentDetails.kt
@@ -1,7 +1,7 @@
 package to.bitkit.ext
 
 import org.lightningdevkit.ldknode.PaymentDetails
-import to.bitkit.models.MSat
+import to.bitkit.models.msatCeilOf
 
 val PaymentDetails.amountSats: ULong?
-    get() = amountMsat?.let { MSat(it).ceil() }
+    get() = amountMsat?.let { msatCeilOf(it) }

--- a/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
+++ b/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
@@ -26,6 +26,7 @@ import to.bitkit.ext.amountOnClose
 import to.bitkit.ext.toUserMessage
 import to.bitkit.models.BITCOIN_SYMBOL
 import to.bitkit.models.BlocktankNotificationType
+import to.bitkit.models.MSat
 import to.bitkit.models.BlocktankNotificationType.cjitPaymentArrived
 import to.bitkit.models.BlocktankNotificationType.incomingHtlc
 import to.bitkit.models.BlocktankNotificationType.mutualClose
@@ -192,7 +193,7 @@ class WakeNodeWorker @AssistedInject constructor(
         showDetails: Boolean,
         hiddenBody: String,
     ) {
-        val sats = (event.amountMsat + 999u) / 1000u
+        val sats = MSat(event.amountMsat).ceil()
         // Save for UI to pick up
         cacheStore.setBackgroundReceive(
             NewTransactionSheetDetails(

--- a/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
+++ b/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
@@ -26,7 +26,7 @@ import to.bitkit.ext.amountOnClose
 import to.bitkit.ext.toUserMessage
 import to.bitkit.models.BITCOIN_SYMBOL
 import to.bitkit.models.BlocktankNotificationType
-import to.bitkit.models.MSat
+import to.bitkit.models.msatCeilOf
 import to.bitkit.models.BlocktankNotificationType.cjitPaymentArrived
 import to.bitkit.models.BlocktankNotificationType.incomingHtlc
 import to.bitkit.models.BlocktankNotificationType.mutualClose
@@ -193,7 +193,7 @@ class WakeNodeWorker @AssistedInject constructor(
         showDetails: Boolean,
         hiddenBody: String,
     ) {
-        val sats = MSat(event.amountMsat).ceil()
+        val sats = msatCeilOf(event.amountMsat)
         // Save for UI to pick up
         cacheStore.setBackgroundReceive(
             NewTransactionSheetDetails(

--- a/app/src/main/java/to/bitkit/models/MSat.kt
+++ b/app/src/main/java/to/bitkit/models/MSat.kt
@@ -1,0 +1,19 @@
+package to.bitkit.models
+
+/**
+ * A wrapper for millisatoshi [ULong] values that provides explicit sat conversions.
+ *
+ * Eliminates scattered `/ 1000u` and `(x + 999u) / 1000u` patterns by encoding
+ * the rounding intent directly in the API: [ceil] rounds up, [floor] truncates.
+ *
+ * Zero runtime overhead — this is an [inline value class][JvmInline].
+ */
+@JvmInline
+value class MSat(val value: ULong) {
+
+    /** Round up to the nearest whole sat. Use for payment/display amounts. */
+    fun ceil(): ULong = (value + 999u) / 1000u
+
+    /** Truncate sub-sat remainder. Use for fees and upper bounds. */
+    fun floor(): ULong = value / 1000u
+}

--- a/app/src/main/java/to/bitkit/models/MSat.kt
+++ b/app/src/main/java/to/bitkit/models/MSat.kt
@@ -1,19 +1,20 @@
 package to.bitkit.models
 
 /**
- * A wrapper for millisatoshi [ULong] values that provides explicit sat conversions.
+ * A non-boxing wrapper for millisatoshi [ULong] values that provides explicit sat conversions.
  *
- * Eliminates scattered `/ 1000u` and `(x + 999u) / 1000u` patterns by encoding
- * the rounding intent directly in the API: [ceil] rounds up, [floor] truncates.
- *
- * Zero runtime overhead — this is an [inline value class][JvmInline].
+ * Encapsulates the rounding intent directly in the API: [ceil] rounds up, [floor] truncates.
  */
 @JvmInline
 value class MSat(val value: ULong) {
 
+    companion object {
+        const val PER_SAT: ULong = 1000u
+    }
+
     /** Round up to the nearest whole sat. Use for payment/display amounts. */
-    fun ceil(): ULong = (value + 999u) / 1000u
+    fun ceil(): ULong = (value + PER_SAT - 1u) / PER_SAT
 
     /** Truncate sub-sat remainder. Use for fees and upper bounds. */
-    fun floor(): ULong = value / 1000u
+    fun floor(): ULong = value / PER_SAT
 }

--- a/app/src/main/java/to/bitkit/models/MSat.kt
+++ b/app/src/main/java/to/bitkit/models/MSat.kt
@@ -18,3 +18,9 @@ value class MSat(val value: ULong) {
     /** Truncate sub-sat remainder. Use for fees and upper bounds. */
     fun floor(): ULong = value / PER_SAT
 }
+
+/** Syntactic sugar for [MSat.ceil]. */
+fun msatCeilOf(msat: ULong): ULong = MSat(msat).ceil()
+
+/** Syntactic sugar for [MSat.floor]. */
+fun msatFloorOf(msat: ULong): ULong = MSat(msat).floor()

--- a/app/src/main/java/to/bitkit/models/MSat.kt
+++ b/app/src/main/java/to/bitkit/models/MSat.kt
@@ -19,8 +19,8 @@ value class MSat(val value: ULong) {
     fun floor(): ULong = value / PER_SAT
 }
 
-/** Syntactic sugar for [MSat.ceil]. */
+/** Round [msat] up to the nearest whole sat. Use for payment/display amounts. */
 fun msatCeilOf(msat: ULong): ULong = MSat(msat).ceil()
 
-/** Syntactic sugar for [MSat.floor]. */
+/** Truncate sub-sat remainder from [msat]. Use for fees and upper bounds. */
 fun msatFloorOf(msat: ULong): ULong = MSat(msat).floor()

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -32,7 +32,7 @@ import to.bitkit.ext.toHex
 import to.bitkit.models.ALL_ADDRESS_TYPE_STRINGS
 import to.bitkit.models.AddressModel
 import to.bitkit.models.BalanceState
-import to.bitkit.models.MSat
+import to.bitkit.models.msatFloorOf
 import to.bitkit.models.DEFAULT_ADDRESS_TYPE_STRING
 import to.bitkit.models.toDerivationPath
 import to.bitkit.services.CoreService
@@ -566,7 +566,7 @@ class WalletRepo @Inject constructor(
             val channels = lightningRepo.lightningState.value.channels
             if (channels.filterOpen().isEmpty()) return@runCatching false
 
-            val inboundBalanceSats = channels.sumOf { MSat(it.inboundCapacityMsat).floor() }
+            val inboundBalanceSats = channels.sumOf { msatFloorOf(it.inboundCapacityMsat) }
 
             return@runCatching (_walletState.value.bip21AmountSats ?: 0uL) >= inboundBalanceSats
         }.onFailure {

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -32,6 +32,7 @@ import to.bitkit.ext.toHex
 import to.bitkit.models.ALL_ADDRESS_TYPE_STRINGS
 import to.bitkit.models.AddressModel
 import to.bitkit.models.BalanceState
+import to.bitkit.models.MSat
 import to.bitkit.models.DEFAULT_ADDRESS_TYPE_STRING
 import to.bitkit.models.toDerivationPath
 import to.bitkit.services.CoreService
@@ -565,7 +566,7 @@ class WalletRepo @Inject constructor(
             val channels = lightningRepo.lightningState.value.channels
             if (channels.filterOpen().isEmpty()) return@runCatching false
 
-            val inboundBalanceSats = channels.sumOf { it.inboundCapacityMsat / 1000u }
+            val inboundBalanceSats = channels.sumOf { MSat(it.inboundCapacityMsat).floor() }
 
             return@runCatching (_walletState.value.bip21AmountSats ?: 0uL) >= inboundBalanceSats
         }.onFailure {

--- a/app/src/main/java/to/bitkit/services/CoreService.kt
+++ b/app/src/main/java/to/bitkit/services/CoreService.kt
@@ -72,6 +72,7 @@ import to.bitkit.data.CacheStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.env.Env
 import to.bitkit.ext.amountSats
+import to.bitkit.models.MSat
 import to.bitkit.ext.channelId
 import to.bitkit.ext.create
 import to.bitkit.ext.latestSpendingTxid
@@ -501,7 +502,7 @@ class ActivityService(
                 value = payment.amountSats ?: 0u,
                 invoice = kind.bolt11 ?: "Loading...",
                 timestamp = payment.latestUpdateTimestamp,
-                fee = (payment.feePaidMsat ?: 0u) / 1000u,
+                fee = MSat(payment.feePaidMsat ?: 0u).floor(),
                 message = kind.description.orEmpty(),
                 preimage = kind.preimage,
                 seenAt = null,
@@ -610,7 +611,7 @@ class ActivityService(
             ldkValue
         }
 
-        val ldkFeeSats = ldkFeeMsat / 1000u
+        val ldkFeeSats = MSat(ldkFeeMsat).floor()
         val updatedFee = if (existingActivity.v1.fee == 0uL && ldkFeeSats > 0uL) ldkFeeSats else existingActivity.v1.fee
 
         val updatedOnChain = existingActivity.v1.copy(
@@ -649,7 +650,7 @@ class ActivityService(
             txType = payment.direction.toPaymentType(),
             txId = kind.txid,
             value = payment.amountSats ?: 0u,
-            fee = (payment.feePaidMsat ?: 0u) / 1000u,
+            fee = MSat(payment.feePaidMsat ?: 0u).floor(),
             address = resolvedAddress ?: "Loading...",
             timestamp = activityTimestamp,
             confirmed = confirmationData.isConfirmed,

--- a/app/src/main/java/to/bitkit/services/CoreService.kt
+++ b/app/src/main/java/to/bitkit/services/CoreService.kt
@@ -72,7 +72,7 @@ import to.bitkit.data.CacheStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.env.Env
 import to.bitkit.ext.amountSats
-import to.bitkit.models.MSat
+import to.bitkit.models.msatFloorOf
 import to.bitkit.ext.channelId
 import to.bitkit.ext.create
 import to.bitkit.ext.latestSpendingTxid
@@ -502,7 +502,7 @@ class ActivityService(
                 value = payment.amountSats ?: 0u,
                 invoice = kind.bolt11 ?: "Loading...",
                 timestamp = payment.latestUpdateTimestamp,
-                fee = MSat(payment.feePaidMsat ?: 0u).floor(),
+                fee = msatFloorOf(payment.feePaidMsat ?: 0u),
                 message = kind.description.orEmpty(),
                 preimage = kind.preimage,
                 seenAt = null,
@@ -611,7 +611,7 @@ class ActivityService(
             ldkValue
         }
 
-        val ldkFeeSats = MSat(ldkFeeMsat).floor()
+        val ldkFeeSats = msatFloorOf(ldkFeeMsat)
         val updatedFee = if (existingActivity.v1.fee == 0uL && ldkFeeSats > 0uL) ldkFeeSats else existingActivity.v1.fee
 
         val updatedOnChain = existingActivity.v1.copy(
@@ -650,7 +650,7 @@ class ActivityService(
             txType = payment.direction.toPaymentType(),
             txId = kind.txid,
             value = payment.amountSats ?: 0u,
-            fee = MSat(payment.feePaidMsat ?: 0u).floor(),
+            fee = msatFloorOf(payment.feePaidMsat ?: 0u),
             address = resolvedAddress ?: "Loading...",
             timestamp = activityTimestamp,
             confirmed = confirmationData.isConfirmed,

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -49,7 +49,7 @@ import to.bitkit.env.Env
 import to.bitkit.ext.totalNextOutboundHtlcLimitSats
 import to.bitkit.ext.uByteList
 import to.bitkit.ext.uri
-import to.bitkit.models.MSat
+import to.bitkit.models.msatFloorOf
 import to.bitkit.models.OpenChannelResult
 import to.bitkit.models.toAddressType
 import to.bitkit.utils.AppError
@@ -695,7 +695,7 @@ class LightningService @Inject constructor(
             return@background runCatching {
                 val invoice = Bolt11Invoice.fromStr(bolt11)
                 val feesMsat = node.bolt11Payment().estimateRoutingFees(invoice)
-                val feeSat = MSat(feesMsat).floor()
+                val feeSat = msatFloorOf(feesMsat)
                 Result.success(feeSat)
             }.getOrElse {
                 Result.failure(if (it is NodeException) LdkError(it) else it)
@@ -711,7 +711,7 @@ class LightningService @Inject constructor(
                 val invoice = Bolt11Invoice.fromStr(bolt11)
                 val amountMsat = amountSats * 1000u
                 val feesMsat = node.bolt11Payment().estimateRoutingFeesUsingAmount(invoice, amountMsat)
-                val feeSat = MSat(feesMsat).floor()
+                val feeSat = msatFloorOf(feesMsat)
                 Result.success(feeSat)
             }.getOrElse {
                 Result.failure(if (it is NodeException) LdkError(it) else it)
@@ -729,7 +729,7 @@ class LightningService @Inject constructor(
 
         val invoiceAmountMsat = bolt11Invoice.amountMilliSatoshis()
         Logger.debug(
-            "sendProbes: invoiceAmountMsat=$invoiceAmountMsat (${invoiceAmountMsat?.let { MSat(it).floor() }} sats)",
+            "sendProbes: invoiceAmountMsat=$invoiceAmountMsat (${invoiceAmountMsat?.let { msatFloorOf(it) }} sats)",
             context = TAG
         )
 
@@ -752,8 +752,8 @@ class LightningService @Inject constructor(
 
         val invoiceAmountMsat = bolt11Invoice.amountMilliSatoshis()
         Logger.debug(
-            "sendProbesUsingAmount: customAmountMsat=$amountMsat (${MSat(amountMsat).floor()} sats), " +
-                "invoiceAmountMsat=$invoiceAmountMsat (${invoiceAmountMsat?.let { MSat(it).floor() }} sats)",
+            "sendProbesUsingAmount: customAmountMsat=$amountMsat (${msatFloorOf(amountMsat)} sats), " +
+                "invoiceAmountMsat=$invoiceAmountMsat (${invoiceAmountMsat?.let { msatFloorOf(it) }} sats)",
             context = TAG
         )
 

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -49,6 +49,7 @@ import to.bitkit.env.Env
 import to.bitkit.ext.totalNextOutboundHtlcLimitSats
 import to.bitkit.ext.uByteList
 import to.bitkit.ext.uri
+import to.bitkit.models.MSat
 import to.bitkit.models.OpenChannelResult
 import to.bitkit.models.toAddressType
 import to.bitkit.utils.AppError
@@ -694,7 +695,7 @@ class LightningService @Inject constructor(
             return@background runCatching {
                 val invoice = Bolt11Invoice.fromStr(bolt11)
                 val feesMsat = node.bolt11Payment().estimateRoutingFees(invoice)
-                val feeSat = feesMsat / 1000u
+                val feeSat = MSat(feesMsat).floor()
                 Result.success(feeSat)
             }.getOrElse {
                 Result.failure(if (it is NodeException) LdkError(it) else it)
@@ -710,7 +711,7 @@ class LightningService @Inject constructor(
                 val invoice = Bolt11Invoice.fromStr(bolt11)
                 val amountMsat = amountSats * 1000u
                 val feesMsat = node.bolt11Payment().estimateRoutingFeesUsingAmount(invoice, amountMsat)
-                val feeSat = feesMsat / 1000u
+                val feeSat = MSat(feesMsat).floor()
                 Result.success(feeSat)
             }.getOrElse {
                 Result.failure(if (it is NodeException) LdkError(it) else it)
@@ -728,7 +729,7 @@ class LightningService @Inject constructor(
 
         val invoiceAmountMsat = bolt11Invoice.amountMilliSatoshis()
         Logger.debug(
-            "sendProbes: invoiceAmountMsat=$invoiceAmountMsat (${invoiceAmountMsat?.let { it / 1000u }} sats)",
+            "sendProbes: invoiceAmountMsat=$invoiceAmountMsat (${invoiceAmountMsat?.let { MSat(it).floor() }} sats)",
             context = TAG
         )
 
@@ -751,8 +752,8 @@ class LightningService @Inject constructor(
 
         val invoiceAmountMsat = bolt11Invoice.amountMilliSatoshis()
         Logger.debug(
-            "sendProbesUsingAmount: customAmountMsat=$amountMsat (${amountMsat / 1000u} sats), " +
-                "invoiceAmountMsat=$invoiceAmountMsat (${invoiceAmountMsat?.let { it / 1000u }} sats)",
+            "sendProbesUsingAmount: customAmountMsat=$amountMsat (${MSat(amountMsat).floor()} sats), " +
+                "invoiceAmountMsat=$invoiceAmountMsat (${invoiceAmountMsat?.let { MSat(it).floor() }} sats)",
             context = TAG
         )
 

--- a/app/src/main/java/to/bitkit/ui/NodeInfoScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/NodeInfoScreen.kt
@@ -50,7 +50,7 @@ import to.bitkit.ext.createChannelDetails
 import to.bitkit.ext.ellipsisMiddle
 import to.bitkit.ext.formatToString
 import to.bitkit.ext.uri
-import to.bitkit.models.MSat
+import to.bitkit.models.msatFloorOf
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.NodePeer
 import to.bitkit.models.alias
@@ -337,8 +337,8 @@ private fun ChannelsSection(
                 }
                 LightningChannel(
                     capacity = (channel.channelValueSats).toLong(),
-                    localBalance = MSat(channel.outboundCapacityMsat).floor().toLong(),
-                    remoteBalance = MSat(channel.inboundCapacityMsat).floor().toLong(),
+                    localBalance = msatFloorOf(channel.outboundCapacityMsat).toLong(),
+                    remoteBalance = msatFloorOf(channel.inboundCapacityMsat).toLong(),
                     status = if (channel.isChannelReady) ChannelStatusUi.OPEN else ChannelStatusUi.PENDING,
                 )
                 VerticalSpacer(8.dp)
@@ -357,25 +357,25 @@ private fun ChannelsSection(
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__inbound_capacity),
-                    value = "₿ ${MSat(channel.inboundCapacityMsat).floor().formatToModernDisplay()}",
+                    value = "₿ ${msatFloorOf(channel.inboundCapacityMsat).formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__inbound_htlc_max),
                     value = "₿ ${
-                        (channel.inboundHtlcMaximumMsat?.let { MSat(it).floor() } ?: 0u).formatToModernDisplay()
+                        (channel.inboundHtlcMaximumMsat?.let { msatFloorOf(it) } ?: 0u).formatToModernDisplay()
                     }",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__inbound_htlc_min),
-                    value = "₿ ${MSat(channel.inboundHtlcMinimumMsat).floor().formatToModernDisplay()}",
+                    value = "₿ ${msatFloorOf(channel.inboundHtlcMinimumMsat).formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__next_outbound_htlc_limit),
-                    value = "₿ ${MSat(channel.nextOutboundHtlcLimitMsat).floor().formatToModernDisplay()}",
+                    value = "₿ ${msatFloorOf(channel.nextOutboundHtlcLimitMsat).formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__next_outbound_htlc_min),
-                    value = "₿ ${MSat(channel.nextOutboundHtlcMinimumMsat).floor().formatToModernDisplay()}",
+                    value = "₿ ${msatFloorOf(channel.nextOutboundHtlcMinimumMsat).formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.common__confirmations),

--- a/app/src/main/java/to/bitkit/ui/NodeInfoScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/NodeInfoScreen.kt
@@ -50,6 +50,7 @@ import to.bitkit.ext.createChannelDetails
 import to.bitkit.ext.ellipsisMiddle
 import to.bitkit.ext.formatToString
 import to.bitkit.ext.uri
+import to.bitkit.models.MSat
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.NodePeer
 import to.bitkit.models.alias
@@ -336,8 +337,8 @@ private fun ChannelsSection(
                 }
                 LightningChannel(
                     capacity = (channel.channelValueSats).toLong(),
-                    localBalance = (channel.outboundCapacityMsat / 1000u).toLong(),
-                    remoteBalance = (channel.inboundCapacityMsat / 1000u).toLong(),
+                    localBalance = MSat(channel.outboundCapacityMsat).floor().toLong(),
+                    remoteBalance = MSat(channel.inboundCapacityMsat).floor().toLong(),
                     status = if (channel.isChannelReady) ChannelStatusUi.OPEN else ChannelStatusUi.PENDING,
                 )
                 VerticalSpacer(8.dp)
@@ -356,23 +357,23 @@ private fun ChannelsSection(
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__inbound_capacity),
-                    value = "₿ ${(channel.inboundCapacityMsat / 1000u).formatToModernDisplay()}",
+                    value = "₿ ${MSat(channel.inboundCapacityMsat).floor().formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__inbound_htlc_max),
-                    value = "₿ ${(channel.inboundHtlcMaximumMsat?.div(1000u) ?: 0u).formatToModernDisplay()}",
+                    value = "₿ ${(channel.inboundHtlcMaximumMsat?.let { MSat(it).floor() } ?: 0u).formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__inbound_htlc_min),
-                    value = "₿ ${(channel.inboundHtlcMinimumMsat / 1000u).formatToModernDisplay()}",
+                    value = "₿ ${MSat(channel.inboundHtlcMinimumMsat).floor().formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__next_outbound_htlc_limit),
-                    value = "₿ ${(channel.nextOutboundHtlcLimitMsat / 1000u).formatToModernDisplay()}",
+                    value = "₿ ${MSat(channel.nextOutboundHtlcLimitMsat).floor().formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__next_outbound_htlc_min),
-                    value = "₿ ${(channel.nextOutboundHtlcMinimumMsat / 1000u).formatToModernDisplay()}",
+                    value = "₿ ${MSat(channel.nextOutboundHtlcMinimumMsat).floor().formatToModernDisplay()}",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.common__confirmations),

--- a/app/src/main/java/to/bitkit/ui/NodeInfoScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/NodeInfoScreen.kt
@@ -361,7 +361,9 @@ private fun ChannelsSection(
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__inbound_htlc_max),
-                    value = "₿ ${(channel.inboundHtlcMaximumMsat?.let { MSat(it).floor() } ?: 0u).formatToModernDisplay()}",
+                    value = "₿ ${
+                        (channel.inboundHtlcMaximumMsat?.let { MSat(it).floor() } ?: 0u).formatToModernDisplay()
+                    }",
                 )
                 ChannelDetailRow(
                     title = stringResource(R.string.lightning__inbound_htlc_min),

--- a/app/src/main/java/to/bitkit/ui/settings/lightning/ChannelDetailScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/lightning/ChannelDetailScreen.kt
@@ -60,6 +60,7 @@ import to.bitkit.ext.DatePattern
 import to.bitkit.ext.amountOnClose
 import to.bitkit.ext.createChannelDetails
 import to.bitkit.ext.setClipboardText
+import to.bitkit.models.MSat
 import to.bitkit.models.Toast
 import to.bitkit.ui.Routes
 import to.bitkit.ui.appViewModel
@@ -221,7 +222,7 @@ private fun ChannelDetailContent(
 
         val capacity = channel.details.channelValueSats.toLong()
         val localBalance = channel.details.amountOnClose.toLong()
-        val remoteBalance = (channel.details.inboundCapacityMsat / 1000u).toLong()
+        val remoteBalance = MSat(channel.details.inboundCapacityMsat).floor().toLong()
         val reserveBalance = (channel.details.unspendablePunishmentReserve ?: 0u).toLong()
 
         PullToRefreshBox(
@@ -376,7 +377,7 @@ private fun ChannelDetailContent(
                     name = stringResource(R.string.lightning__base_fee),
                     valueContent = {
                         MoneyCaptionB(
-                            sats = (channel.details.config.forwardingFeeBaseMsat / 1000u).toLong(),
+                            sats = MSat(channel.details.config.forwardingFeeBaseMsat.toULong()).floor().toLong(),
                             symbol = true
                         )
                     }

--- a/app/src/main/java/to/bitkit/ui/settings/lightning/ChannelDetailScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/lightning/ChannelDetailScreen.kt
@@ -60,7 +60,7 @@ import to.bitkit.ext.DatePattern
 import to.bitkit.ext.amountOnClose
 import to.bitkit.ext.createChannelDetails
 import to.bitkit.ext.setClipboardText
-import to.bitkit.models.MSat
+import to.bitkit.models.msatFloorOf
 import to.bitkit.models.Toast
 import to.bitkit.ui.Routes
 import to.bitkit.ui.appViewModel
@@ -222,7 +222,7 @@ private fun ChannelDetailContent(
 
         val capacity = channel.details.channelValueSats.toLong()
         val localBalance = channel.details.amountOnClose.toLong()
-        val remoteBalance = MSat(channel.details.inboundCapacityMsat).floor().toLong()
+        val remoteBalance = msatFloorOf(channel.details.inboundCapacityMsat).toLong()
         val reserveBalance = (channel.details.unspendablePunishmentReserve ?: 0u).toLong()
 
         PullToRefreshBox(
@@ -377,7 +377,7 @@ private fun ChannelDetailContent(
                     name = stringResource(R.string.lightning__base_fee),
                     valueContent = {
                         MoneyCaptionB(
-                            sats = MSat(channel.details.config.forwardingFeeBaseMsat.toULong()).floor().toLong(),
+                            sats = msatFloorOf(channel.details.config.forwardingFeeBaseMsat.toULong()).toLong(),
                             symbol = true
                         )
                     }

--- a/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsScreen.kt
@@ -47,6 +47,7 @@ import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.ext.amountOnClose
 import to.bitkit.ext.createChannelDetails
+import to.bitkit.models.MSat
 import to.bitkit.models.formatToModernDisplay
 import to.bitkit.ui.Routes
 import to.bitkit.ui.components.BodyM
@@ -374,7 +375,7 @@ private fun ChannelItem(
         LightningChannel(
             capacity = channelUi.details.channelValueSats.toLong(),
             localBalance = channelUi.details.amountOnClose.toLong(),
-            remoteBalance = (channelUi.details.inboundCapacityMsat / 1000u).toLong(),
+            remoteBalance = MSat(channelUi.details.inboundCapacityMsat).floor().toLong(),
             status = status,
         )
         VerticalSpacer(16.dp)

--- a/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/lightning/LightningConnectionsScreen.kt
@@ -47,7 +47,7 @@ import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.ext.amountOnClose
 import to.bitkit.ext.createChannelDetails
-import to.bitkit.models.MSat
+import to.bitkit.models.msatFloorOf
 import to.bitkit.models.formatToModernDisplay
 import to.bitkit.ui.Routes
 import to.bitkit.ui.components.BodyM
@@ -375,7 +375,7 @@ private fun ChannelItem(
         LightningChannel(
             capacity = channelUi.details.channelValueSats.toLong(),
             localBalance = channelUi.details.amountOnClose.toLong(),
-            remoteBalance = MSat(channelUi.details.inboundCapacityMsat).floor().toLong(),
+            remoteBalance = msatFloorOf(channelUi.details.inboundCapacityMsat).toLong(),
             status = status,
         )
         VerticalSpacer(16.dp)

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -91,7 +91,7 @@ import to.bitkit.ext.toUserMessage
 import to.bitkit.ext.totalValue
 import to.bitkit.ext.watchUntil
 import to.bitkit.models.FeeRate
-import to.bitkit.models.MSat
+import to.bitkit.models.msatFloorOf
 import to.bitkit.models.NewTransactionSheetDetails
 import to.bitkit.models.NewTransactionSheetDirection
 import to.bitkit.models.NewTransactionSheetType
@@ -1895,7 +1895,7 @@ class AppViewModel @Inject constructor(
                 )
             } else {
                 val withdrawAmountSats = _sendUiState.value.amount.coerceAtLeast(
-                    MSat(lnurl.data.minWithdrawable ?: 0u).floor()
+                    msatFloorOf(lnurl.data.minWithdrawable ?: 0u)
                 )
                 _sendUiState.update { it.copy(amount = withdrawAmountSats) }
                 lightningRepo.createInvoice(

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -91,6 +91,7 @@ import to.bitkit.ext.toUserMessage
 import to.bitkit.ext.totalValue
 import to.bitkit.ext.watchUntil
 import to.bitkit.models.FeeRate
+import to.bitkit.models.MSat
 import to.bitkit.models.NewTransactionSheetDetails
 import to.bitkit.models.NewTransactionSheetDirection
 import to.bitkit.models.NewTransactionSheetType
@@ -1894,7 +1895,7 @@ class AppViewModel @Inject constructor(
                 )
             } else {
                 val withdrawAmountSats = _sendUiState.value.amount.coerceAtLeast(
-                    (lnurl.data.minWithdrawable ?: 0u) / 1000u
+                    MSat(lnurl.data.minWithdrawable ?: 0u).floor()
                 )
                 _sendUiState.update { it.copy(amount = withdrawAmountSats) }
                 lightningRepo.createInvoice(

--- a/app/src/test/java/to/bitkit/models/MSatTest.kt
+++ b/app/src/test/java/to/bitkit/models/MSatTest.kt
@@ -1,0 +1,78 @@
+package to.bitkit.models
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class MSatTest {
+
+    // region ceil
+    @Test
+    fun `ceil returns exact sat for multiple of 1000`() {
+        assertEquals(1uL, MSat(1000uL).ceil())
+    }
+
+    @Test
+    fun `ceil rounds up for non-multiple`() {
+        assertEquals(2uL, MSat(1001uL).ceil())
+    }
+
+    @Test
+    fun `ceil rounds up for 1 msat`() {
+        assertEquals(1uL, MSat(1uL).ceil())
+    }
+
+    @Test
+    fun `ceil rounds up for 999 msat`() {
+        assertEquals(1uL, MSat(999uL).ceil())
+    }
+
+    @Test
+    fun `ceil returns zero for zero`() {
+        assertEquals(0uL, MSat(0uL).ceil())
+    }
+
+    @Test
+    fun `ceil handles realistic payment amount`() {
+        assertEquals(223uL, MSat(222_222uL).ceil())
+    }
+    // endregion
+
+    // region floor
+    @Test
+    fun `floor returns exact sat for multiple of 1000`() {
+        assertEquals(2uL, MSat(2000uL).floor())
+    }
+
+    @Test
+    fun `floor truncates for non-multiple`() {
+        assertEquals(1uL, MSat(1999uL).floor())
+    }
+
+    @Test
+    fun `floor returns zero for sub-sat value`() {
+        assertEquals(0uL, MSat(999uL).floor())
+    }
+
+    @Test
+    fun `floor returns zero for zero`() {
+        assertEquals(0uL, MSat(0uL).floor())
+    }
+
+    @Test
+    fun `floor handles realistic fee amount`() {
+        assertEquals(222uL, MSat(222_222uL).floor())
+    }
+    // endregion
+
+    // region sugar functions
+    @Test
+    fun `msatCeilOf matches MSat ceil`() {
+        assertEquals(MSat(1500uL).ceil(), msatCeilOf(1500uL))
+    }
+
+    @Test
+    fun `msatFloorOf matches MSat floor`() {
+        assertEquals(MSat(1500uL).floor(), msatFloorOf(1500uL))
+    }
+    // endregion
+}


### PR DESCRIPTION
This PR introduces an `MSat` inline value class that replaces all scattered `(x + 999u) / 1000u` ceiling and `x / 1000u` floor patterns with self-documenting conversions.

### Description

The msat-to-sat conversions were spread across 13 files with no domain type to explain what's happening. After PR #879 added more ceiling conversions, it became harder to understand the intent behind `(x + 999u) / 1000u` without reading the PR context. The new `MSat` value class (zero runtime overhead) makes the rounding intent self-documenting.

- Adds `MSat` inline value class in `models/` with `ceil()` and `floor()` functions
- Adds `msatCeilOf()` and `msatFloorOf()` top-level sugar functions for concise call sites
- Replaces all ceiling patterns (`(x + 999u) / 1000u`, `msatsToSatsCeil`) with `msatCeilOf(x)`
- Replaces all floor patterns (`x / 1000u`, `x / MSATS_PER_SAT`) with `msatFloorOf(x)`
- Removes `msatsToSatsCeil()` function and `MSATS_PER_SAT` constant from `Lnurl.kt`
- Adds `MSat.PER_SAT` constant for the sat→msat direction
- Adds `MSatTest.kt` with 10 test cases

### Preview

N/A — no UI changes, pure refactor.

### QA Notes
All tests listed and checked below were verified manually, this is a refactoring PR which shouldn't require extensive retesting by reviewer.

### Tests
All tests should use msat values:
- [x] LNURL-Pay (QuickPay ON & OFF) using synonymdev/bitkit-docker#5
- [x] LNURL-Withdraw (QuickPay ON & OFF) using synonymdev/bitkit-docker#5
- [x] Bolt11 (QuickPay ON & OFF) using synonymdev/bitkit-docker#6
- [x] regression: Bolt11 zero-amount invoice