### PR TITLE
fix: scroll wallet screens behind top bar with haze blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fix Spending and Savings screens scrolling behind top bar and add gradient fade effect #892
 - Retouch Primary, Secondary, and Tertiary buttons styling #887
 - Avoid msat truncation when paying invoices and LNURL callbacks #879
 - Fix ANR on RGS server settings screen caused by catastrophic regex backtracking #880

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix Spending and Savings screens scrolling behind top bar and add gradient fade effect #892
 
 ### Fixed
-- Fix Spending and Savings screens scrolling behind top bar and add gradient fade effect #892
 - Retouch Primary, Secondary, and Tertiary buttons styling #887
 - Avoid msat truncation when paying invoices and LNURL callbacks #879
 - Fix ANR on RGS server settings screen caused by catastrophic regex backtracking #880

--- a/app/src/main/java/to/bitkit/ui/components/SheetHost.kt
+++ b/app/src/main/java/to/bitkit/ui/components/SheetHost.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.screens.wallets.receive.ReceiveRoute
+import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.sheets.BackupRoute
 import to.bitkit.ui.sheets.PinRoute
 import to.bitkit.ui.sheets.SendRoute

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -138,6 +137,7 @@ import to.bitkit.ui.sheets.PinRoute
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.theme.Insets
+import to.bitkit.ui.theme.TopBarGradient
 import to.bitkit.ui.utils.withAccent
 import to.bitkit.viewmodels.ActivityListViewModel
 import to.bitkit.viewmodels.AppViewModel
@@ -805,20 +805,13 @@ private fun TopBar(
     onNavigateToAppStatus: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
 ) {
-    val topbarGradient = Brush.verticalGradient(
-        colorStops = arrayOf(
-            0.5f to Colors.Black,
-            1.0f to Color.Transparent,
-        )
-    )
-
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .hazeEffect(state = hazeState) {
-                mask = topbarGradient
+                mask = TopBarGradient
             }
-            .background(topbarGradient)
+            .background(TopBarGradient)
             .zIndex(1f)
     ) {
         TopAppBar(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
@@ -3,12 +3,10 @@ package to.bitkit.ui.screens.wallets
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -47,6 +45,7 @@ import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.StatusBarSpacer
 import to.bitkit.ui.components.TabBar
 import to.bitkit.ui.components.TopBarSpacer
+import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.screens.wallets.activity.components.activityListGroupedItems
@@ -151,7 +150,7 @@ fun SavingsWalletScreen(
             }
 
             if (!showEmptyState) {
-                item { Spacer(modifier = Modifier.height(32.dp)) }
+                item { VerticalSpacer(32.dp) }
 
                 if (canTransfer) {
                     item {

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SavingsWalletScreen.kt
@@ -3,7 +3,6 @@ package to.bitkit.ui.screens.wallets
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -17,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,7 +30,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.synonym.bitkitcore.Activity
+import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.collections.immutable.ImmutableList
@@ -42,15 +44,17 @@ import to.bitkit.ui.components.BalanceHeaderView
 import to.bitkit.ui.components.EmptyStateView
 import to.bitkit.ui.components.IncomingTransfer
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.StatusBarSpacer
 import to.bitkit.ui.components.TabBar
+import to.bitkit.ui.components.TopBarSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
-import to.bitkit.ui.scaffold.ScreenColumn
-import to.bitkit.ui.screens.wallets.activity.components.ActivityListGrouped
+import to.bitkit.ui.screens.wallets.activity.components.activityListGroupedItems
 import to.bitkit.ui.screens.wallets.activity.utils.previewOnchainActivityItems
 import to.bitkit.ui.shared.util.blockPointerInputPassthrough
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.TopBarGradient
 import to.bitkit.ui.utils.withAccent
 
 @Composable
@@ -76,6 +80,7 @@ fun SavingsWalletScreen(
     }
 
     val hazeState = rememberHazeState()
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -101,18 +106,31 @@ fun SavingsWalletScreen(
                     .windowInsetsPadding(WindowInsets.statusBars.only(WindowInsetsSides.Vertical))
             )
         }
-        ScreenColumn(noBackground = true) {
-            AppTopBar(
-                titleText = stringResource(R.string.wallet__savings__title),
-                icon = R.drawable.ic_btc_circle,
-                onBackClick = onBackClick,
-                actions = {
-                    DrawerNavIcon()
+
+        AppTopBar(
+            titleText = stringResource(R.string.wallet__savings__title),
+            icon = R.drawable.ic_btc_circle,
+            onBackClick = onBackClick,
+            actions = {
+                DrawerNavIcon()
+            },
+            modifier = Modifier
+                .hazeEffect(state = hazeState) {
+                    mask = TopBarGradient
                 }
-            )
-            Column(
-                modifier = Modifier.padding(horizontal = 16.dp)
-            ) {
+                .background(TopBarGradient)
+                .zIndex(1f)
+                .windowInsetsPadding(WindowInsets.statusBars.only(WindowInsetsSides.Vertical))
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+        ) {
+            item { StatusBarSpacer() }
+            item { TopBarSpacer() }
+            item {
                 BalanceHeaderView(
                     sats = balances.totalOnchainSats.toLong(),
                     testTag = "TotalBalance",
@@ -120,19 +138,23 @@ fun SavingsWalletScreen(
                         .fillMaxWidth()
                         .testTag("TotalBalance")
                 )
+            }
 
-                if (balances.balanceInTransferToSavings > 0u) {
+            if (balances.balanceInTransferToSavings > 0u) {
+                item {
                     IncomingTransfer(
                         amount = balances.balanceInTransferToSavings,
                         remainingDuration = forceCloseRemainingDuration,
                         modifier = Modifier.padding(vertical = 8.dp)
                     )
                 }
+            }
 
-                if (!showEmptyState) {
-                    Spacer(modifier = Modifier.height(32.dp))
+            if (!showEmptyState) {
+                item { Spacer(modifier = Modifier.height(32.dp)) }
 
-                    if (canTransfer) {
+                if (canTransfer) {
+                    item {
                         SecondaryButton(
                             onClick = onTransferToSpendingClick,
                             text = stringResource(R.string.wallet__transfer_to_spending),
@@ -147,17 +169,18 @@ fun SavingsWalletScreen(
                             modifier = Modifier.testTag("TransferToSpending")
                         )
                     }
-
-                    ActivityListGrouped(
-                        items = onchainActivities,
-                        onActivityItemClick = onActivityItemClick,
-                        onEmptyActivityRowClick = onEmptyActivityRowClick,
-                        showFooter = true,
-                        onAllActivityButtonClick = onAllActivityButtonClick,
-                    )
                 }
+
+                activityListGroupedItems(
+                    items = onchainActivities,
+                    onActivityItemClick = onActivityItemClick,
+                    onEmptyActivityRowClick = onEmptyActivityRowClick,
+                    showFooter = true,
+                    onAllActivityButtonClick = onAllActivityButtonClick,
+                )
             }
         }
+
         if (showEmptyState) {
             EmptyStateView(
                 text = stringResource(R.string.wallet__savings__onboarding).withAccent(),

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/SpendingWalletScreen.kt
@@ -3,7 +3,6 @@ package to.bitkit.ui.screens.wallets
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,7 +28,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.synonym.bitkitcore.Activity
+import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.collections.immutable.ImmutableList
@@ -42,16 +44,18 @@ import to.bitkit.ui.components.BalanceHeaderView
 import to.bitkit.ui.components.EmptyStateView
 import to.bitkit.ui.components.IncomingTransfer
 import to.bitkit.ui.components.SecondaryButton
+import to.bitkit.ui.components.StatusBarSpacer
 import to.bitkit.ui.components.TabBar
+import to.bitkit.ui.components.TopBarSpacer
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
-import to.bitkit.ui.scaffold.ScreenColumn
-import to.bitkit.ui.screens.wallets.activity.components.ActivityListGrouped
+import to.bitkit.ui.screens.wallets.activity.components.activityListGroupedItems
 import to.bitkit.ui.screens.wallets.activity.utils.previewLightningActivityItems
 import to.bitkit.ui.shared.util.blockPointerInputPassthrough
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.TopBarGradient
 import to.bitkit.ui.utils.withAccent
 
 @Composable
@@ -80,6 +84,7 @@ fun SpendingWalletScreen(
         mutableStateOf(showEmptyState && balances.totalOnchainSats > 0uL)
     }
     val hazeState = rememberHazeState()
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -104,18 +109,31 @@ fun SpendingWalletScreen(
                     .windowInsetsPadding(WindowInsets.statusBars.only(WindowInsetsSides.Vertical))
             )
         }
-        ScreenColumn(noBackground = true) {
-            AppTopBar(
-                titleText = stringResource(R.string.wallet__spending__title),
-                icon = R.drawable.ic_ln_circle,
-                onBackClick = onBackClick,
-                actions = {
-                    DrawerNavIcon()
+
+        AppTopBar(
+            titleText = stringResource(R.string.wallet__spending__title),
+            icon = R.drawable.ic_ln_circle,
+            onBackClick = onBackClick,
+            actions = {
+                DrawerNavIcon()
+            },
+            modifier = Modifier
+                .hazeEffect(state = hazeState) {
+                    mask = TopBarGradient
                 }
-            )
-            Column(
-                modifier = Modifier.padding(horizontal = 16.dp)
-            ) {
+                .background(TopBarGradient)
+                .zIndex(1f)
+                .windowInsetsPadding(WindowInsets.statusBars.only(WindowInsetsSides.Vertical))
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+        ) {
+            item { StatusBarSpacer() }
+            item { TopBarSpacer() }
+            item {
                 BalanceHeaderView(
                     sats = balances.totalLightningSats.toLong(),
                     testTag = "TotalBalance",
@@ -123,17 +141,21 @@ fun SpendingWalletScreen(
                         .fillMaxWidth()
                         .testTag("TotalBalance")
                 )
+            }
 
-                if (balances.balanceInTransferToSpending > 0u) {
+            if (balances.balanceInTransferToSpending > 0u) {
+                item {
                     IncomingTransfer(
                         amount = balances.balanceInTransferToSpending,
                         modifier = Modifier.padding(vertical = 8.dp)
                     )
                 }
+            }
 
-                if (canTransferFromSavings) {
-                    VerticalSpacer(32.dp)
+            if (canTransferFromSavings) {
+                item { VerticalSpacer(32.dp) }
 
+                item {
                     SecondaryButton(
                         onClick = onTransferFromSavingsClick,
                         text = stringResource(R.string.lightning__funding__button1),
@@ -148,11 +170,13 @@ fun SpendingWalletScreen(
                         modifier = Modifier.testTag("TransferFromSavings")
                     )
                 }
+            }
 
-                if (!showEmptyState) {
-                    VerticalSpacer(32.dp)
+            if (!showEmptyState) {
+                item { VerticalSpacer(32.dp) }
 
-                    if (canTransfer) {
+                if (canTransfer) {
+                    item {
                         SecondaryButton(
                             onClick = onTransferToSavingsClick,
                             text = stringResource(R.string.wallet__transfer_to_savings),
@@ -167,17 +191,18 @@ fun SpendingWalletScreen(
                             modifier = Modifier.testTag("TransferToSavings")
                         )
                     }
-
-                    ActivityListGrouped(
-                        items = lightningActivities,
-                        onActivityItemClick = onActivityItemClick,
-                        onEmptyActivityRowClick = onEmptyActivityRowClick,
-                        showFooter = true,
-                        onAllActivityButtonClick = onAllActivityButtonClick,
-                    )
                 }
+
+                activityListGroupedItems(
+                    items = lightningActivities,
+                    onActivityItemClick = onActivityItemClick,
+                    onEmptyActivityRowClick = onEmptyActivityRowClick,
+                    showFooter = true,
+                    onAllActivityButtonClick = onAllActivityButtonClick,
+                )
             }
         }
+
         if (showEmptyState) {
             EmptyStateView(
                 text = stringResource(R.string.wallet__spending__onboarding).withAccent(accentColor = Colors.Purple),

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -143,7 +143,7 @@ fun LazyListScope.activityListGroupedItems(
     showFooter: Boolean = false,
     onAllActivityButtonClick: () -> Unit = {},
 ) {
-    if (items != null && items.isNotEmpty()) {
+    if (!items.isNullOrEmpty()) {
         val groupedItems = groupActivityItems(items)
         itemsIndexed(
             items = groupedItems,
@@ -171,7 +171,7 @@ fun LazyListScope.activityListGroupedItems(
                                 fadeInSpec = tween(durationMillis = 300),
                                 fadeOutSpec = tween(durationMillis = 300),
                                 placementSpec = tween(durationMillis = 300),
-                            ),
+                            )
                     )
                 }
 
@@ -182,7 +182,7 @@ fun LazyListScope.activityListGroupedItems(
                                 fadeInSpec = tween(durationMillis = 300),
                                 fadeOutSpec = tween(durationMillis = 300),
                                 placementSpec = tween(durationMillis = 300),
-                            ),
+                            )
                     ) {
                         ActivityRow(item, onActivityItemClick, testTag = "Activity-$index")
                         VerticalSpacer(16.dp)
@@ -197,7 +197,7 @@ fun LazyListScope.activityListGroupedItems(
                     onClick = onAllActivityButtonClick,
                     modifier = Modifier
                         .wrapContentWidth()
-                        .padding(top = 8.dp),
+                        .padding(top = 8.dp)
                 )
             }
         }
@@ -214,7 +214,7 @@ fun LazyListScope.activityListGroupedItems(
                     color = Colors.White64,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(16.dp)
                 )
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -130,6 +131,92 @@ fun ActivityListGrouped(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Suppress("LongMethod")
+fun LazyListScope.activityListGroupedItems(
+    items: ImmutableList<Activity>?,
+    onActivityItemClick: (String) -> Unit,
+    onEmptyActivityRowClick: () -> Unit,
+    showFooter: Boolean = false,
+    onAllActivityButtonClick: () -> Unit = {},
+) {
+    if (items != null && items.isNotEmpty()) {
+        val groupedItems = groupActivityItems(items)
+        itemsIndexed(
+            items = groupedItems,
+            key = { index, item ->
+                when (item) {
+                    is String -> "header_$item"
+                    is Activity -> when (item) {
+                        is Activity.Lightning -> "lightning_${item.rawId()}"
+                        is Activity.Onchain -> "onchain_${item.rawId()}"
+                    }
+
+                    else -> "item_$index"
+                }
+            },
+        ) { index, item ->
+            when (item) {
+                is String -> {
+                    Caption13Up(
+                        text = item,
+                        color = Colors.White64,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .animateItem(
+                                fadeInSpec = tween(durationMillis = 300),
+                                fadeOutSpec = tween(durationMillis = 300),
+                                placementSpec = tween(durationMillis = 300),
+                            ),
+                    )
+                }
+
+                is Activity -> {
+                    Column(
+                        modifier = Modifier
+                            .animateItem(
+                                fadeInSpec = tween(durationMillis = 300),
+                                fadeOutSpec = tween(durationMillis = 300),
+                                placementSpec = tween(durationMillis = 300),
+                            ),
+                    ) {
+                        ActivityRow(item, onActivityItemClick, testTag = "Activity-$index")
+                        VerticalSpacer(16.dp)
+                    }
+                }
+            }
+        }
+        if (showFooter) {
+            item {
+                TertiaryButton(
+                    text = stringResource(R.string.wallet__activity_show_all),
+                    onClick = onAllActivityButtonClick,
+                    modifier = Modifier
+                        .wrapContentWidth()
+                        .padding(top = 8.dp),
+                )
+            }
+        }
+        item {
+            Spacer(modifier = Modifier.height(120.dp))
+        }
+    } else {
+        if (showFooter) {
+            item { EmptyActivityRow(onClick = onEmptyActivityRowClick) }
+        } else {
+            item {
+                BodyM(
+                    text = stringResource(R.string.wallet__activity_no),
+                    color = Colors.White64,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
                 )
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -3,10 +3,8 @@ package to.bitkit.ui.screens.wallets.activity.components
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -51,7 +49,7 @@ fun ActivityListGrouped(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.fillMaxSize()
     ) {
-        if (items != null && items.isNotEmpty()) {
+        if (!items.isNullOrEmpty()) {
             val groupedItems = groupActivityItems(items)
 
             LazyColumn(
@@ -116,7 +114,7 @@ fun ActivityListGrouped(
                     }
                 }
                 item {
-                    Spacer(modifier = Modifier.height(120.dp))
+                    VerticalSpacer(120.dp)
                 }
             }
         } else {
@@ -204,7 +202,7 @@ fun LazyListScope.activityListGroupedItems(
             }
         }
         item {
-            Spacer(modifier = Modifier.height(120.dp))
+            VerticalSpacer(120.dp)
         }
     } else {
         if (showFooter) {

--- a/app/src/main/java/to/bitkit/ui/theme/Defaults.kt
+++ b/app/src/main/java/to/bitkit/ui/theme/Defaults.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.Dp
@@ -136,3 +137,10 @@ object Insets {
 
 @OptIn(ExperimentalMaterial3Api::class)
 val TopBarHeight: Dp = TopAppBarDefaults.TopAppBarExpandedHeight
+
+val TopBarGradient: Brush = Brush.verticalGradient(
+    colorStops = arrayOf(
+        0.5f to Colors.Black,
+        1.0f to Color.Transparent,
+    ),
+)


### PR DESCRIPTION
This PR:
1. Makes the Spending and Savings wallet screen content scroll behind the top bar, matching the iOS scroll behavior
2. Applies a haze blur effect with a gradient mask to the AppTopBar on both screens
3. Extracts the top bar gradient as a shared constant reused by HomeScreen, SavingsWalletScreen, and SpendingWalletScreen

### Description

The wallet screens previously used a fixed `ScreenColumn` layout where the `AppTopBar` sat above a non-scrollable `Column`. Content could not scroll behind the top bar, and the top bar had no blur effect.

This replaces the `ScreenColumn` approach with a `Box`-based layout: the `AppTopBar` floats as an overlay with `hazeEffect` + gradient mask + `zIndex(1f)`, and all content (balance, transfer buttons, activity list) is unified into a single `LazyColumn` that scrolls underneath. A new `LazyListScope.activityListGroupedItems()` extension inlines activity items directly into the parent `LazyColumn`, avoiding nested scrollable containers.

### Preview

<!-- VIDEO_1: Record scrolling the Savings wallet screen showing content scrolling behind the blurred top bar -->
<!-- VIDEO_2: Record scrolling the Spending wallet screen showing content scrolling behind the blurred top bar -->

### QA Notes

1. Open Savings wallet screen with a balance and activity
   - Scroll down and verify the activity list and balance header scroll behind the top bar
   - Verify the top bar shows a frosted glass blur effect with a gradient fade
   - Verify the back button and drawer icon remain tappable
   
[savings.webm](https://github.com/user-attachments/assets/b39bcea7-7944-4b9f-a385-b27489e29366)

2. Open Spending wallet screen with a balance and activity
   - Same scroll-behind and blur behavior as Savings
   - Verify "Transfer To Savings" button scrolls with content

[spending.webm](https://github.com/user-attachments/assets/2468da4f-0be5-403b-8f59-5d255e35d268)

3. Open Savings/Spending wallet with no balance and no activity
   - Verify the empty state onboarding view still displays correctly at the bottom

[empty-states.webm](https://github.com/user-attachments/assets/6026e1b3-9406-4a49-a6f9-ab887ef27bbf)

4. Verify HomeScreen top bar blur still works as before (shared gradient constant)

[home.webm](https://github.com/user-attachments/assets/be46877a-b61b-4d8b-8f2c-6fcf87e790d1)

