### PR TITLE
chore: bump version 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-04-07
+
 ### Fixed
 - Retouch Primary, Secondary, and Tertiary buttons styling #887
 - Avoid msat truncation when paying invoices and LNURL callbacks #879
@@ -42,4 +44,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - About screen (content merged into Support) #857
 - Standalone General, Security, and Advanced settings screens (merged into tabs) #857
 
-[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.1.2...HEAD
+[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/synonymdev/bitkit-android/compare/v2.1.2...v2.2.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,8 +55,8 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 180
-        versionName = "2.1.2"
+        versionCode = 181
+        versionName = "2.2.0"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         vectorDrawables {
             useSupportLibrary = true


### PR DESCRIPTION
Bump version to 2.2.0 (build 181) for release.

### Description

- `versionCode`: 180 → 181
- `versionName`: 2.1.2 → 2.2.0

### Preview

N/A

### QA Notes

N/A

Made with [Cursor](https://cursor.com)