### PR TITLE
chore: log cause of keychain load failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Surface underlying cause class of keychain load failures in error logs #898
+
 ## [2.2.0] - 2026-04-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- Surface underlying cause class of keychain load failures in error logs #898
-
 ## [2.2.0] - 2026-04-07
 
 ### Fixed

--- a/app/src/main/java/to/bitkit/data/keychain/AndroidKeyStore.kt
+++ b/app/src/main/java/to/bitkit/data/keychain/AndroidKeyStore.kt
@@ -87,4 +87,6 @@ class AndroidKeyStore(
         }
         generateKey()
     }
+
+    fun containsAlias(): Boolean = keyStore.containsAlias(alias)
 }

--- a/app/src/main/java/to/bitkit/data/keychain/Keychain.kt
+++ b/app/src/main/java/to/bitkit/data/keychain/Keychain.kt
@@ -19,8 +19,11 @@ import to.bitkit.ext.fromBase64
 import to.bitkit.ext.toBase64
 import to.bitkit.utils.AppError
 import to.bitkit.utils.Logger
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 
 private val Context.keychainDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "keychain"
@@ -32,59 +35,76 @@ class Keychain @Inject constructor(
     @ApplicationContext private val context: Context,
     @IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : BaseCoroutineScope(dispatcher) {
+    companion object {
+        private const val TAG = "Keychain"
+        private const val CAUSE_CHAIN_DEPTH = 4
+    }
+
     private val keyStore by lazy { AndroidKeyStore(alias = "keychain") }
 
     @Suppress("MemberNameEqualsClassName")
     private val keychain = context.keychainDataStore
 
+    private val loadDiagnosticsEmitted: MutableSet<String> =
+        Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
+
     val snapshot get() = runBlocking(this.coroutineContext) { keychain.data.first() }
 
     fun loadString(key: String): String? = load(key)?.decodeToString()
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught")
     fun load(key: String): ByteArray? {
         try {
             return snapshot[key.indexed]?.fromBase64()?.let {
                 keyStore.decrypt(it)
             }
-        } catch (_: Exception) {
-            throw KeychainError.FailedToLoad(key)
+        } catch (c: CancellationException) {
+            throw c
+        } catch (t: Throwable) {
+            emitLoadDiagnosticsOnce(key, t)
+            throw KeychainError.FailedToLoad(key, cause = t)
         }
     }
 
     suspend fun saveString(key: String, value: String) = save(key, value.toByteArray())
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught", "ThrowsCount")
     suspend fun save(key: String, value: ByteArray) {
         if (exists(key)) throw KeychainError.FailedToSaveAlreadyExists(key)
 
         try {
             val encryptedValue = keyStore.encrypt(value)
             keychain.edit { it[key.indexed] = encryptedValue.toBase64() }
-        } catch (_: Exception) {
-            throw KeychainError.FailedToSave(key)
+        } catch (c: CancellationException) {
+            throw c
+        } catch (t: Throwable) {
+            throw KeychainError.FailedToSave(key, cause = t)
         }
         Logger.info("Saved to keychain: $key")
     }
 
     /** Inserts or replaces a string value associated with a given key in the keychain. */
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught")
     suspend fun upsertString(key: String, value: String) {
         try {
             val encryptedValue = keyStore.encrypt(value.toByteArray())
             keychain.edit { it[key.indexed] = encryptedValue.toBase64() }
-        } catch (_: Exception) {
-            throw KeychainError.FailedToSave(key)
+        } catch (c: CancellationException) {
+            throw c
+        } catch (t: Throwable) {
+            throw KeychainError.FailedToSave(key, cause = t)
         }
         Logger.info("Upsert in keychain: $key")
     }
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught")
     suspend fun delete(key: String) {
         try {
             keychain.edit { it.remove(key.indexed) }
-        } catch (_: Exception) {
-            throw KeychainError.FailedToDelete(key)
+        } catch (c: CancellationException) {
+            throw c
+        } catch (t: Throwable) {
+            throw KeychainError.FailedToDelete(key, cause = t)
         }
         Logger.debug("Deleted from keychain: $key")
     }
@@ -120,6 +140,27 @@ class Keychain @Inject constructor(
             .map { string -> string?.toIntOrNull() }
     }
 
+    private fun emitLoadDiagnosticsOnce(key: String, cause: Throwable) {
+        if (!loadDiagnosticsEmitted.add(key)) return
+
+        val aliasPresent = runCatching { keyStore.containsAlias() }.getOrDefault(false)
+        val entryPresent = runCatching { snapshot.contains(key.indexed) }.getOrDefault(false)
+        val walletIndex = runCatching {
+            runBlocking { db.configDao().getAll().first() }.firstOrNull()?.walletIndex ?: 0L
+        }.getOrDefault(-1L)
+        val causeChain = generateSequence<Throwable>(cause) { it.cause }
+            .take(CAUSE_CHAIN_DEPTH)
+            .map { it.javaClass.simpleName }
+            .joinToString(separator = " <- ")
+
+        Logger.warn(
+            "Decrypt failed for key='$key' walletIndex='$walletIndex' " +
+                "aliasPresent='$aliasPresent' entryPresent='$entryPresent' " +
+                "causeChain='$causeChain'",
+            context = TAG,
+        )
+    }
+
     enum class Key {
         PUSH_NOTIFICATION_TOKEN,
         PUSH_NOTIFICATION_PRIVATE_KEY,
@@ -130,10 +171,19 @@ class Keychain @Inject constructor(
     }
 }
 
-sealed class KeychainError(message: String) : AppError(message) {
-    class FailedToDelete(key: String) : KeychainError("Failed to delete $key from keychain.")
-    class FailedToLoad(key: String) : KeychainError("Failed to load $key from keychain.")
-    class FailedToSave(key: String) : KeychainError("Failed to save to $key keychain.")
+sealed class KeychainError(message: String, cause: Throwable? = null) : AppError(message, cause) {
+    class FailedToDelete(key: String, cause: Throwable? = null) :
+        KeychainError("Failed to delete $key from keychain${cause.causeSuffix()}", cause)
+
+    class FailedToLoad(val key: String, cause: Throwable? = null) :
+        KeychainError("Failed to load $key from keychain${cause.causeSuffix()}", cause)
+
+    class FailedToSave(key: String, cause: Throwable? = null) :
+        KeychainError("Failed to save to $key keychain${cause.causeSuffix()}", cause)
+
     class FailedToSaveAlreadyExists(key: String) :
         KeychainError("Key $key already exists in keychain. Explicitly delete key before attempting to update value.")
 }
+
+private fun Throwable?.causeSuffix(): String =
+    this?.let { " (cause='${it.javaClass.simpleName}')" } ?: "."

--- a/app/src/main/java/to/bitkit/data/keychain/Keychain.kt
+++ b/app/src/main/java/to/bitkit/data/keychain/Keychain.kt
@@ -143,11 +143,11 @@ class Keychain @Inject constructor(
     private fun emitLoadDiagnosticsOnce(key: String, cause: Throwable) {
         if (!loadDiagnosticsEmitted.add(key)) return
 
-        val aliasPresent = runCatching { keyStore.containsAlias() }.getOrDefault(false)
-        val entryPresent = runCatching { snapshot.contains(key.indexed) }.getOrDefault(false)
-        val walletIndex = runCatching {
+        val aliasPresent = probe { keyStore.containsAlias() }
+        val entryPresent = probe { snapshot.contains(key.indexed) }
+        val walletIndex = probe {
             runBlocking { db.configDao().getAll().first() }.firstOrNull()?.walletIndex ?: 0L
-        }.getOrDefault(-1L)
+        }
         val causeChain = generateSequence(cause) { it.cause }
             .take(CAUSE_CHAIN_DEPTH)
             .joinToString(separator = " <- ") { it.javaClass.simpleName }
@@ -159,6 +159,12 @@ class Keychain @Inject constructor(
             context = TAG,
         )
     }
+
+    private inline fun <T> probe(block: () -> T): String =
+        runCatching(block).fold(
+            onSuccess = { it.toString() },
+            onFailure = { "error:${it.javaClass.simpleName}" },
+        )
 
     enum class Key {
         PUSH_NOTIFICATION_TOKEN,

--- a/app/src/main/java/to/bitkit/data/keychain/Keychain.kt
+++ b/app/src/main/java/to/bitkit/data/keychain/Keychain.kt
@@ -148,10 +148,9 @@ class Keychain @Inject constructor(
         val walletIndex = runCatching {
             runBlocking { db.configDao().getAll().first() }.firstOrNull()?.walletIndex ?: 0L
         }.getOrDefault(-1L)
-        val causeChain = generateSequence<Throwable>(cause) { it.cause }
+        val causeChain = generateSequence(cause) { it.cause }
             .take(CAUSE_CHAIN_DEPTH)
-            .map { it.javaClass.simpleName }
-            .joinToString(separator = " <- ")
+            .joinToString(separator = " <- ") { it.javaClass.simpleName }
 
         Logger.warn(
             "Decrypt failed for key='$key' walletIndex='$walletIndex' " +

--- a/app/src/test/java/to/bitkit/data/keychain/KeychainErrorTest.kt
+++ b/app/src/test/java/to/bitkit/data/keychain/KeychainErrorTest.kt
@@ -1,0 +1,96 @@
+package to.bitkit.data.keychain
+
+import org.junit.Test
+import java.io.IOException
+import javax.crypto.AEADBadTagException
+import javax.crypto.BadPaddingException
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class KeychainErrorTest {
+
+    @Test
+    fun `FailedToLoad without cause renders key and terminating period`() {
+        val error = KeychainError.FailedToLoad(key = "BIP39_MNEMONIC")
+
+        assertEquals("Failed to load BIP39_MNEMONIC from keychain.", error.message)
+        assertNull(error.cause)
+    }
+
+    @Test
+    fun `FailedToLoad preserves cause and embeds its simple class name`() {
+        val cause = AEADBadTagException("leak-probe-9f3a")
+        val error = KeychainError.FailedToLoad(key = "BIP39_MNEMONIC", cause = cause)
+
+        assertSame(cause, error.cause)
+        assertEquals(
+            "Failed to load BIP39_MNEMONIC from keychain (cause='AEADBadTagException')",
+            error.message,
+        )
+    }
+
+    @Test
+    fun `FailedToLoad does not leak underlying cause message`() {
+        val probe = "leak-probe-9f3a"
+        val causes = listOf(
+            AEADBadTagException(probe),
+            BadPaddingException(probe),
+            ClassCastException(probe),
+            IllegalArgumentException(probe),
+            IOException(probe),
+        )
+
+        causes.forEach { cause ->
+            val error = KeychainError.FailedToLoad(key = "BIP39_MNEMONIC", cause = cause)
+            assertFalse(
+                actual = error.message.orEmpty().contains(probe),
+                message = "message leaked cause.message for ${cause.javaClass.simpleName}",
+            )
+        }
+    }
+
+    @Test
+    fun `FailedToLoad exposes the failing key`() {
+        val error = KeychainError.FailedToLoad(key = "BIP39_PASSPHRASE", cause = IOException())
+
+        assertEquals("BIP39_PASSPHRASE", error.key)
+    }
+
+    @Test
+    fun `FailedToSave preserves cause and renders simple class name`() {
+        val cause = IOException("probe")
+        val error = KeychainError.FailedToSave(key = "BIP39_MNEMONIC", cause = cause)
+
+        assertSame(cause, error.cause)
+        assertEquals(
+            "Failed to save to BIP39_MNEMONIC keychain (cause='IOException')",
+            error.message,
+        )
+    }
+
+    @Test
+    fun `FailedToDelete preserves cause and renders simple class name`() {
+        val cause = IOException("probe")
+        val error = KeychainError.FailedToDelete(key = "BIP39_MNEMONIC", cause = cause)
+
+        assertSame(cause, error.cause)
+        assertEquals(
+            "Failed to delete BIP39_MNEMONIC from keychain (cause='IOException')",
+            error.message,
+        )
+    }
+
+    @Test
+    fun `FailedToSaveAlreadyExists has no cause and static message`() {
+        val error = KeychainError.FailedToSaveAlreadyExists(key = "BIP39_MNEMONIC")
+
+        assertNull(error.cause)
+        assertEquals(
+            "Key BIP39_MNEMONIC already exists in keychain. " +
+                "Explicitly delete key before attempting to update value.",
+            error.message,
+        )
+    }
+}

--- a/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/WalletRepoTest.kt
@@ -156,6 +156,17 @@ class WalletRepoTest : BaseUnitTest() {
     }
 
     @Test
+    fun `walletExists relies on exists and does not touch load paths`() = test {
+        whenever(keychain.exists(Keychain.Key.BIP39_MNEMONIC.name)).thenReturn(true)
+
+        val result = sut.walletExists()
+
+        assertTrue(result)
+        verify(keychain, never()).loadString(Keychain.Key.BIP39_MNEMONIC.name)
+        verify(keychain, never()).load(Keychain.Key.BIP39_MNEMONIC.name)
+    }
+
+    @Test
     fun `setWalletExistsState should update walletState with current existence status`() = test {
         whenever(keychain.exists(Keychain.Key.BIP39_MNEMONIC.name)).thenReturn(true)
 


### PR DESCRIPTION
Related to #897

This PR:
1. Stops swallowing the underlying cause when `Keychain.load/save/upsertString/delete` catch a failure, so the real exception propagates through `KeychainError`
2. Embeds the cause's simple class name (no message, no payload) into the error message so it surfaces automatically at every existing caller's log line
3. Emits a single sanitized WARN from `Keychain.load` on the first decrypt failure per key per process, capturing `aliasPresent`, `entryPresent`, `walletIndex`, and the cause chain of class names. Each probe is tri-state — `'true'` / `'false'` / `'error:ClassName'` — so a failure inside the diagnostic itself (keystore subsystem error, DataStore I/O, Room error) is distinguishable from a genuine `false`
4. Passes `CancellationException` through unwrapped from all four mutating paths
5. Adds `AndroidKeyStore.containsAlias()` so the diagnostic can distinguish "alias missing" from "alias present but unusable"

### Description

The reporter on issue #897 is stuck at launch because `keychain.loadString(BIP39_MNEMONIC)` throws, and every one of the repeated `ERROR` lines in their log says the same thing: `[AppError='Failed to load BIP39_MNEMONIC from keychain.']`. That string tells us the load failed but not why. The catch block in `Keychain.load` discards the underlying `Throwable` entirely, so the log cannot distinguish:

- DataStore / Base64 / Room failures (likely transient, data-side)
- `keyStore.getKey(...)` returning null — alias gone (terminal, hardware-side)
- `Cipher.doFinal` `AEADBadTagException` — alias regenerated under the same name (terminal, hardware-side)
- `UnrecoverableKeyException` / `KeyStoreException` — alias present but unusable

Each of these has different remediation and different user messaging. For a Bitcoin wallet we should not guess between them. This PR is diagnostics only — no retries, no routing changes, no destructive changes to stored data. After this ships, the next occurrence of the bug will include the cause class in the existing `AppError=…` line and a single enriched `WARN` with the adjacent keystore/datastore state, which is enough to pick the right fix in a follow-up PR.

The new WARN is intentionally leak-safe: it only logs class names (not `cause.message`), does not pass the `Throwable` to `Logger` (which would re-introduce the message via `errorLogOf`), and is one-shot per key per process so a start-retry loop cannot flood the log.

### Preview

N/A — diagnostic logging only, no UI changes.

### QA Notes

#### 1. Happy path (no regression)
1. Launch the app with a normal, working wallet.
2. Confirm no `WARN … Decrypt failed for key=…` lines appear in the log.
3. Confirm no `(cause='…')` suffix appears on any `AppError=…` error line.


#### 5. Unit tests
- [x] `./gradlew testDevDebugUnitTest --tests to.bitkit.data.keychain.KeychainErrorTest` passes
- [x] `./gradlew testDevDebugUnitTest --tests to.bitkit.repositories.WalletRepoTest` passes
- [x] `./gradlew detekt` clean
- [x] `./gradlew compileDevDebugKotlin` clean

### Out of scope (intentionally deferred)

- Any remediation UI (auto-routing to RecoveryModeScreen, sticky `keychainCorrupted` state, seed-restore copy) — to be designed once these logs tell us what class of failure users are actually hitting.
- Retries inside `Keychain` — would risk masking the signal we're trying to capture.
- Auto-wiping or any destructive change to the stored encrypted mnemonic — the blob stays on disk regardless of decrypt outcome.
- AndroidKeyStore configuration changes.