### PR TITLE
chore: version 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,22 +151,15 @@ APK is generated in `app/build/outputs/apk/_flavor_/release`. (`_flavor_` can be
 Example for dev: `app/build/outputs/apk/dev/release`
 
 ### Build for Release
-
-To build the mainnet flavor for release run:
-
-```sh
-./gradlew assembleMainnetRelease
-```
-
-#### Android App Bundle (AAB)
-
-For Play Store submission, build an AAB instead of APK:
+To build the mainnet binaries (AAB & APKs) for release, run:
 
 ```sh
-./gradlew bundleMainnetRelease
+./gradlew bundleMainnetRelease assembleMainnetRelease
 ```
 
 AAB is generated in `app/build/outputs/bundle/mainnetRelease/`.
+APKs are generated in `app/build/outputs/apk/mainnetRelease/`.
+
 
 ### Build for E2E Testing
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,8 +55,8 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 181
-        versionName = "2.2.0"
+        versionCode = 182
+        versionName = "2.2.1"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         vectorDrawables {
             useSupportLibrary = true


### PR DESCRIPTION
Bump version to 2.2.1 (build 182) for release.

### Description

- `versionCode`: 181 → 182
- `versionName`: 2.2.0 → 2.2.1
- Simplify mainnet release build instructions in the README to a single command producing both AAB and APKs

### Preview

N/A

### QA Notes

> [!WARNING]
> Only for internal testing.
