### PR TITLE
fix: align TOS padding with iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Polish Terms of Use screen padding to match iOS
+- Polish Terms of Use screen padding to match iOS #903
 
 ## [2.2.0] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Polish Terms of Use screen padding to match iOS
+
 ## [2.2.0] - 2026-04-07
 
 ### Fixed

--- a/app/src/main/java/to/bitkit/ui/onboarding/TermsOfUseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/TermsOfUseScreen.kt
@@ -60,7 +60,7 @@ fun TermsOfUseScreen(
                         .verticalScroll(rememberScrollState())
                         .testTag("TOS")
                 ) {
-                    Spacer(modifier = Modifier.height(16.dp))
+                    Spacer(modifier = Modifier.height(48.dp))
                     Display(text = stringResource(R.string.onboarding__tos_header).withAccent())
                     Spacer(modifier = Modifier.height(12.dp))
                     TosContent()
@@ -82,7 +82,7 @@ fun TermsOfUseScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 24.dp)
+                    .padding(bottom = 16.dp)
             ) {
                 TermsText(
                     title = stringResource(R.string.onboarding__tos_checkbox),

--- a/app/src/main/java/to/bitkit/ui/onboarding/TermsOfUseScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/onboarding/TermsOfUseScreen.kt
@@ -3,7 +3,6 @@ package to.bitkit.ui.onboarding
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -60,11 +59,11 @@ fun TermsOfUseScreen(
                         .verticalScroll(rememberScrollState())
                         .testTag("TOS")
                 ) {
-                    Spacer(modifier = Modifier.height(48.dp))
+                    VerticalSpacer(48.dp)
                     Display(text = stringResource(R.string.onboarding__tos_header).withAccent())
-                    Spacer(modifier = Modifier.height(12.dp))
+                    VerticalSpacer(12.dp)
                     TosContent()
-                    Spacer(modifier = Modifier.height(20.dp))
+                    VerticalSpacer(20.dp)
                 }
                 Box(
                     modifier = Modifier
@@ -100,7 +99,7 @@ fun TermsOfUseScreen(
                         .testTag("Check2")
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                VerticalSpacer(24.dp)
 
                 PrimaryButton(
                     text = stringResource(R.string.common__continue),


### PR DESCRIPTION
This PR polishes the Terms of Use onboarding screen to match bitkit-ios and align with the next screen (Intro).

### Description

1. Increases the top spacer above the "Terms of use" header from 16dp to 48dp, matching iOS's `.padding(.top, 48)` so the heading has the same breathing room below the status bar
2. Reduces the footer bottom padding from 24dp to 16dp so the Continue button sits 16dp above the navigation bar inset — identical to the Get Started / Skip Intro buttons on the following Intro screen, preventing the visual jump when advancing through onboarding

The Scaffold's `contentPadding` already provides the `systemBars` inset (Android equivalent of iOS safe area), so no structural changes were needed.

### Preview

[android.webm](https://github.com/user-attachments/assets/6df7fd31-6b5b-458d-ac3d-43ed555552a3)

[android-nav-bar.webm](https://github.com/user-attachments/assets/6c53badd-5e93-40a6-bf56-42257e9a8c1d)

https://github.com/user-attachments/assets/d57aea15-5ea3-4dc7-94af-d1bbc70fd658

### QA Notes

1. Launch a fresh onboarding flow and open the Terms of Use screen
   - Verify the "Terms of use" header has visible breathing room below the status bar (larger than before)
   - Verify the scrollable TOS content starts below the header as expected
2. Scroll to the bottom of the TOS content and tap Continue
   - Verify the Continue button sits close to the navigation bar area with a 16dp gap
   - Verify there is no vertical jump when transitioning to the Intro screen — the Continue button position should match the Get Started / Skip Intro buttons
3. Test on a device with gesture navigation and a device with 3-button navigation
   - Verify the button respects the system bar inset on both (no overlap with nav bar, no excess whitespace)
4. Verify the `TermsPreview` still renders correctly in Android Studio