### PR TITLE
fix: port scorer params from ios

### DIFF
--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -36,6 +36,7 @@ import org.lightningdevkit.ldknode.NodeStatus
 import org.lightningdevkit.ldknode.PaymentDetails
 import org.lightningdevkit.ldknode.PaymentId
 import org.lightningdevkit.ldknode.PeerDetails
+import org.lightningdevkit.ldknode.ScoringFeeParameters
 import org.lightningdevkit.ldknode.SpendableUtxo
 import org.lightningdevkit.ldknode.Txid
 import org.lightningdevkit.ldknode.defaultConfig
@@ -158,6 +159,7 @@ class LightningService @Inject constructor(
         val builder = Builder.fromConfig(config).apply {
             setCustomLogger(LdkLogWriter())
             configureChainSource(customServerUrl)
+            configureScoringFeeParams()
             configureGossipSource(customRgsServerUrl)
             configureScorerSource()
             setAddressType(selectedType)
@@ -232,6 +234,23 @@ class LightningService @Inject constructor(
         val scorerUrl = Env.ldkScorerUrl ?: return
         Logger.info("Using pathfinding scores source: '$scorerUrl'", context = TAG)
         setPathfindingScoresSource(scorerUrl)
+    }
+
+    private fun Builder.configureScoringFeeParams() {
+        setScoringFeeParams(
+            params = ScoringFeeParameters(
+                basePenaltyMsat = 1024u * 500u,
+                basePenaltyAmountMultiplierMsat = 131_072u * 3u,
+                liquidityPenaltyMultiplierMsat = 0u,
+                liquidityPenaltyAmountMultiplierMsat = 0u,
+                historicalLiquidityPenaltyMultiplierMsat = 10_000u,
+                historicalLiquidityPenaltyAmountMultiplierMsat = 1_250u,
+                antiProbingPenaltyMsat = 250u,
+                consideredImpossiblePenaltyMsat = 1_000_000_000_000u,
+                linearSuccessProbability = false,
+                probingDiversityPenaltyMsat = 0u,
+            )
+        )
     }
 
     private suspend fun Builder.configureChainSource(customServerUrl: String? = null) {


### PR DESCRIPTION
This PR ports [bitkit-ios `fix/scorer-params`](https://github.com/synonymdev/bitkit-ios/tree/fix/scorer-params) to Android, configuring the LDK node builder with explicit scoring fee parameters so pathfinding penalties match the iOS client.

### Description

- Adds `configureScoringFeeParams()` on the `Builder` and calls it in `LightningService.build()` right after the chain source is configured, mirroring the iOS placement immediately after `setChainSourceElectrum`
- Parameters are identical to the iOS values: base penalty 1024 × 500 msat, base penalty amount multiplier 131,072 × 3, zero liquidity penalties, historical liquidity multipliers 10,000 / 1,250, anti-probing 250, considered-impossible 1,000,000,000,000, `linearSuccessProbability = false`, probing diversity penalty 0

> [!WARNING]
> The `setScoringFeeParams` / `ScoringFeeParameters` APIs live on the ldk-node `feat/scorer-params` branch and are **not present in the pinned `com.synonym:ldk-node-android:0.7.0-rc.36`**. This branch will not compile until the ldk-node dependency is bumped to a release that includes those bindings (same pending dependency gap on the iOS side, whose `Package.resolved` still points at `v0.7.0-rc.36`).

### QA Notes

1. Once ldk-node is bumped to a version containing the scoring fee bindings, update `gradle/libs.versions.toml` (`ldk-node-android` version) and rebuild
2. `./gradlew compileDevDebugKotlin` clean
3. `./gradlew testDevDebugUnitTest` clean
4. `./gradlew detekt` clean
5. Launch the app with a live Lightning node and confirm startup completes without LDK build errors
6. Send a Lightning payment across a multi-hop route and verify routing still succeeds with the new scoring penalties applied