### PR TITLE
feat: add LDK debug action to export pathfinding scores

### DIFF
--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -76,7 +76,6 @@ internal object Env {
     val ldkScorerUrl
         get() = when (network) {
             Network.BITCOIN -> "https://api.blocktank.to/scorer-prod"
-            Network.REGTEST -> "https://api.stag0.blocktank.to/scorer"
             else -> null
         }
 

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -1360,6 +1360,11 @@ class LightningRepo @Inject constructor(
         executeWhenNodeRunning("exportNetworkGraphToFile") {
             lightningService.exportNetworkGraphToFile(outputDir)
         }
+
+    suspend fun exportPathfindingScoresToFile(outputDir: String): Result<File> =
+        executeWhenNodeRunning("exportPathfindingScoresToFile") {
+            lightningService.exportPathfindingScoresToFile(outputDir)
+        }
     // endregion
 
     // region probing

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -1050,6 +1050,14 @@ class LightningService @Inject constructor(
         return loggerLdk.exportNetworkGraphToFile(node, outputDir, fileName)
     }
 
+    suspend fun exportPathfindingScoresToFile(
+        outputDir: String,
+        fileName: String = "pathfinding_scores.bin",
+    ): Result<File> {
+        val node = this.node ?: return Result.failure(ServiceError.NodeNotSetup())
+        return loggerLdk.exportPathfindingScoresToFile(node, outputDir, fileName)
+    }
+
     // endregion
 }
 

--- a/app/src/main/java/to/bitkit/ui/screens/settings/LdkDebugScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/settings/LdkDebugScreen.kt
@@ -57,6 +57,7 @@ fun LdkDebugScreen(
         onPasteAndAddPeer = viewModel::pasteAndAddPeer,
         onLogNetworkGraphInfo = viewModel::logNetworkGraphInfo,
         onExportNetworkGraph = viewModel::exportNetworkGraph,
+        onExportScorer = viewModel::exportScorer,
         onRestartNode = viewModel::restartNode,
     )
 }
@@ -70,6 +71,7 @@ private fun LdkDebugContent(
     onPasteAndAddPeer: () -> Unit,
     onLogNetworkGraphInfo: () -> Unit,
     onExportNetworkGraph: (onFileReady: (File) -> Unit) -> Unit,
+    onExportScorer: (onFileReady: (File) -> Unit) -> Unit,
     onRestartNode: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -143,6 +145,20 @@ private fun LdkDebugContent(
                 },
             )
 
+            SectionHeader("PATHFINDING SCORER")
+            SettingsTextButtonRow(
+                title = "Export Scorer",
+                iconRes = R.drawable.ic_share,
+                iconSize = 24.dp,
+                enabled = !uiState.isLoading,
+                onClick = {
+                    onExportScorer { file ->
+                        val uri = FileProvider.getUriForFile(context, Env.FILE_PROVIDER_AUTHORITY, file)
+                        context.shareFile(uri, "application/octet-stream")
+                    }
+                },
+            )
+
             SectionHeader("NODE")
             SettingsTextButtonRow(
                 title = "Restart",
@@ -171,6 +187,7 @@ private fun Preview() {
             onPasteAndAddPeer = {},
             onLogNetworkGraphInfo = {},
             onExportNetworkGraph = {},
+            onExportScorer = {},
             onRestartNode = {},
         )
     }

--- a/app/src/main/java/to/bitkit/utils/LoggerLdk.kt
+++ b/app/src/main/java/to/bitkit/utils/LoggerLdk.kt
@@ -191,6 +191,25 @@ class LoggerLdk @Inject constructor(
             Logger.error("Failed to export network graph to file", it, context = TAG)
         }
     }
+
+    suspend fun exportPathfindingScoresToFile(
+        node: Node,
+        outputDir: String,
+        fileName: String = "pathfinding_scores.bin",
+    ): Result<File> = withContext(ioDispatcher) {
+        runCatching {
+            val bytes = node.exportPathfindingScores()
+            val outputFile = File(outputDir, fileName)
+            outputFile.writeBytes(bytes)
+            Logger.info(
+                "Exported pathfinding scores '${bytes.size}' bytes to '${outputFile.absolutePath}'",
+                context = TAG,
+            )
+            outputFile
+        }.onFailure {
+            Logger.error("Failed to export pathfinding scores to file", it, context = TAG)
+        }
+    }
 }
 
 class LdkLogWriter(

--- a/app/src/main/java/to/bitkit/viewmodels/LdkDebugViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/LdkDebugViewModel.kt
@@ -155,6 +155,32 @@ class LdkDebugViewModel @Inject constructor(
         }
     }
 
+    fun exportScorer(onFileReady: (File) -> Unit) {
+        viewModelScope.launch(bgDispatcher) {
+            _uiState.update { it.copy(isLoading = true) }
+            val outputDir = File(context.cacheDir, DIR_EXPORTS).apply { mkdirs() }.absolutePath
+            lightningRepo.exportPathfindingScoresToFile(outputDir).onSuccess { file ->
+                Logger.info(
+                    "Pathfinding scores exported to '${file.absolutePath}' (${file.length()} bytes)",
+                    context = TAG,
+                )
+                ToastEventBus.send(
+                    type = Toast.ToastType.INFO,
+                    title = "Scorer exported (${file.length()} bytes)",
+                )
+                onFileReady(file)
+            }.onFailure { e ->
+                Logger.error("Failed to export pathfinding scores", e, context = TAG)
+                ToastEventBus.send(
+                    type = Toast.ToastType.ERROR,
+                    title = "Failed to export scorer",
+                    description = e.message,
+                )
+            }
+            _uiState.update { it.copy(isLoading = false) }
+        }
+    }
+
     fun restartNode() {
         viewModelScope.launch(bgDispatcher) {
             _uiState.update { it.copy(isLoading = true) }


### PR DESCRIPTION
This PR adds an "Export Scorer" action to the LDK Debug screen that dumps the running node's merged pathfinding scorer to a file and triggers an Android share sheet, so it can be moved off-device for inspection. It also nulls the regtest scorer URL since the staging endpoint serves a 5-byte minimal payload.

Depends on:
- https://github.com/synonymdev/rust-lightning/pull/2 — sibling work in the LDK fork (not a hard dependency for this PR; this branch uses `node.exportPathfindingScores()` which is already in `ldk-node 0.7.0-rc.36`)
- https://github.com/synonymdev/ldk-node/pull/79 — the consumer that reads the bytes this debug action exports

### Description

Mirrors the existing `exportNetworkGraph` flow exactly:

- New "Export Scorer" button under a `PATHFINDING SCORER` section in `LdkDebugScreen`.
- `LdkDebugViewModel.exportScorer()` writes to `<context.cacheDir>/exports/pathfinding_scores.bin` and surfaces the file via `FileProvider` so a share sheet pops up — same UX as Export Network Graph.
- `LightningService.exportPathfindingScoresToFile()` is a thin wrapper around `node.exportPathfindingScores()` (existing UDL binding).
- `LoggerLdk.exportPathfindingScoresToFile()` writes the raw bytes; logs the byte count.
- `Env.ldkScorerUrl` for `Network.REGTEST` is set to `null`. The staging endpoint (`https://api.stag0.blocktank.to/scorer`) serves 5 bytes — minimal/empty data — so wiring it through accomplishes nothing. Making this explicit matches "we don't use the scorer on regtest".

Dev-only screen — no localized strings (per CLAUDE.md "NEVER add string resources for strings used only in dev settings screens").

### Preview

<!-- Need to capture on a device after merge — share sheet from a Bitkit dev build with the new button tapped. -->

### QA Notes

- Build & install: `./gradlew installDevDebug` (or `installTnetDebug` / `installMainnet` per network).
- Open Settings → Dev → LDK Debug → tap "Export Scorer". A toast should show the byte count, then the system share sheet opens.
- Save the `.bin` somewhere off-device.
- (Optional) Pull via adb: `adb shell "run-as to.bitkit.dev cat files/cache/exports/pathfinding_scores.bin" > /tmp/scorer_local.bin` (adjust app id per flavor).
- The exported bytes are `ChannelLiquidities`-encoded — same wire format as the served scorer at `https://api.blocktank.to/scorer-prod`. They can be inspected with the `scorer-inspect` CLI from synonymdev/ldk-node#79 once that lands.
- Regression-check: the existing "Export Network Graph" button still works.
- Verified: `./gradlew compileDevDebugKotlin testDevDebugUnitTest detekt` — all pass; only pre-existing detekt warnings (none introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)