### PR TITLE
fix: OS widget cleanup crash and ordering

### DIFF
--- a/app/src/main/java/to/bitkit/appwidget/config/AppWidgetConfigActivity.kt
+++ b/app/src/main/java/to/bitkit/appwidget/config/AppWidgetConfigActivity.kt
@@ -85,8 +85,8 @@ class AppWidgetConfigActivity : ComponentActivity() {
         val providerClass = AppWidgetManager.getInstance(this)
             .getAppWidgetInfo(appWidgetId)?.provider?.className
         return when (providerClass) {
-            HeadlinesGlanceReceiver::class.java.name -> AppWidgetType.HEADLINES
             PriceGlanceReceiver::class.java.name -> AppWidgetType.PRICE
+            HeadlinesGlanceReceiver::class.java.name -> AppWidgetType.HEADLINES
             BlocksGlanceReceiver::class.java.name -> AppWidgetType.BLOCKS
             WeatherGlanceReceiver::class.java.name -> AppWidgetType.WEATHER
             else -> {

--- a/app/src/main/java/to/bitkit/appwidget/config/BlocksConfigContent.kt
+++ b/app/src/main/java/to/bitkit/appwidget/config/BlocksConfigContent.kt
@@ -198,7 +198,7 @@ private fun BlockToggleRow(
                 Icon(
                     painter = painterResource(R.drawable.ic_checkmark),
                     contentDescription = null,
-                    tint = if (isEnabled) Colors.Brand else Colors.White50,
+                    tint = if (isEnabled) Colors.Brand else Colors.Gray3,
                     modifier = Modifier.size(32.dp)
                 )
             }

--- a/app/src/main/java/to/bitkit/appwidget/config/HeadlinesConfigContent.kt
+++ b/app/src/main/java/to/bitkit/appwidget/config/HeadlinesConfigContent.kt
@@ -154,7 +154,7 @@ private fun ToggleRow(
             Icon(
                 painter = painterResource(R.drawable.ic_checkmark),
                 contentDescription = null,
-                tint = if (isEnabled) Colors.Brand else Colors.White50,
+                tint = if (isEnabled) Colors.Brand else Colors.Gray3,
                 modifier = Modifier.size(32.dp)
             )
         }

--- a/app/src/main/java/to/bitkit/appwidget/config/PriceConfigContent.kt
+++ b/app/src/main/java/to/bitkit/appwidget/config/PriceConfigContent.kt
@@ -136,14 +136,12 @@ private fun SelectableRow(
                 color = if (isSelected) Colors.White else Colors.White64,
                 modifier = Modifier.weight(1f)
             )
-            if (isSelected) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_checkmark),
-                    contentDescription = null,
-                    tint = Colors.Brand,
-                    modifier = Modifier.size(32.dp)
-                )
-            }
+            Icon(
+                painter = painterResource(R.drawable.ic_checkmark),
+                contentDescription = null,
+                tint = if (isSelected) Colors.Brand else Colors.Gray3,
+                modifier = Modifier.size(32.dp)
+            )
         }
         HorizontalDivider()
     }

--- a/app/src/main/java/to/bitkit/appwidget/config/WeatherConfigContent.kt
+++ b/app/src/main/java/to/bitkit/appwidget/config/WeatherConfigContent.kt
@@ -147,7 +147,7 @@ private fun WeatherOptionRow(
             Icon(
                 painter = painterResource(R.drawable.ic_checkmark),
                 contentDescription = null,
-                tint = if (isSelected) Colors.Brand else Colors.White50,
+                tint = if (isSelected) Colors.Brand else Colors.Gray3,
                 modifier = Modifier.size(32.dp)
             )
         }

--- a/app/src/main/java/to/bitkit/appwidget/ui/blocks/BlocksGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/blocks/BlocksGlanceReceiver.kt
@@ -3,11 +3,6 @@ package to.bitkit.appwidget.ui.blocks
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import dagger.hilt.android.EntryPointAccessors
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import to.bitkit.appwidget.AppWidgetEntryPoint
 import to.bitkit.appwidget.AppWidgetRefreshWorker
 
 class BlocksGlanceReceiver : GlanceAppWidgetReceiver() {
@@ -16,21 +11,6 @@ class BlocksGlanceReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
-        super.onDeleted(context, appWidgetIds)
-        val pendingResult = goAsync()
-        val store = EntryPointAccessors
-            .fromApplication(context, AppWidgetEntryPoint::class.java)
-            .appWidgetPreferencesStore()
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                appWidgetIds.forEach { store.unregisterWidget(it) }
-            } finally {
-                pendingResult.finish()
-            }
-        }
     }
 
     override fun onDisabled(context: Context) {

--- a/app/src/main/java/to/bitkit/appwidget/ui/blocks/BlocksGlanceWidget.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/blocks/BlocksGlanceWidget.kt
@@ -37,4 +37,12 @@ class BlocksGlanceWidget : GlanceAppWidget() {
             )
         }
     }
+
+    override suspend fun onDelete(context: Context, glanceId: GlanceId) {
+        val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(glanceId)
+        EntryPointAccessors
+            .fromApplication(context, AppWidgetEntryPoint::class.java)
+            .appWidgetPreferencesStore()
+            .unregisterWidget(appWidgetId)
+    }
 }

--- a/app/src/main/java/to/bitkit/appwidget/ui/facts/FactsGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/facts/FactsGlanceReceiver.kt
@@ -3,11 +3,6 @@ package to.bitkit.appwidget.ui.facts
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import dagger.hilt.android.EntryPointAccessors
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import to.bitkit.appwidget.AppWidgetEntryPoint
 import to.bitkit.appwidget.AppWidgetRefreshWorker
 
 class FactsGlanceReceiver : GlanceAppWidgetReceiver() {
@@ -16,21 +11,6 @@ class FactsGlanceReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
-        super.onDeleted(context, appWidgetIds)
-        val pendingResult = goAsync()
-        val store = EntryPointAccessors
-            .fromApplication(context, AppWidgetEntryPoint::class.java)
-            .appWidgetPreferencesStore()
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                appWidgetIds.forEach { store.unregisterWidget(it) }
-            } finally {
-                pendingResult.finish()
-            }
-        }
     }
 
     override fun onDisabled(context: Context) {

--- a/app/src/main/java/to/bitkit/appwidget/ui/facts/FactsGlanceWidget.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/facts/FactsGlanceWidget.kt
@@ -48,4 +48,12 @@ class FactsGlanceWidget : GlanceAppWidget() {
             FactsGlanceContent(fact = fact)
         }
     }
+
+    override suspend fun onDelete(context: Context, glanceId: GlanceId) {
+        val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(glanceId)
+        EntryPointAccessors
+            .fromApplication(context, AppWidgetEntryPoint::class.java)
+            .appWidgetPreferencesStore()
+            .unregisterWidget(appWidgetId)
+    }
 }

--- a/app/src/main/java/to/bitkit/appwidget/ui/headlines/HeadlinesGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/headlines/HeadlinesGlanceReceiver.kt
@@ -3,11 +3,6 @@ package to.bitkit.appwidget.ui.headlines
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import dagger.hilt.android.EntryPointAccessors
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import to.bitkit.appwidget.AppWidgetEntryPoint
 import to.bitkit.appwidget.AppWidgetRefreshWorker
 
 class HeadlinesGlanceReceiver : GlanceAppWidgetReceiver() {
@@ -16,21 +11,6 @@ class HeadlinesGlanceReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
-        super.onDeleted(context, appWidgetIds)
-        val pendingResult = goAsync()
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                val store = EntryPointAccessors
-                    .fromApplication(context, AppWidgetEntryPoint::class.java)
-                    .appWidgetPreferencesStore()
-                appWidgetIds.forEach { store.unregisterWidget(it) }
-            } finally {
-                pendingResult.finish()
-            }
-        }
     }
 
     override fun onDisabled(context: Context) {

--- a/app/src/main/java/to/bitkit/appwidget/ui/headlines/HeadlinesGlanceWidget.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/headlines/HeadlinesGlanceWidget.kt
@@ -50,4 +50,12 @@ class HeadlinesGlanceWidget : GlanceAppWidget() {
             )
         }
     }
+
+    override suspend fun onDelete(context: Context, glanceId: GlanceId) {
+        val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(glanceId)
+        EntryPointAccessors
+            .fromApplication(context, AppWidgetEntryPoint::class.java)
+            .appWidgetPreferencesStore()
+            .unregisterWidget(appWidgetId)
+    }
 }

--- a/app/src/main/java/to/bitkit/appwidget/ui/price/PriceGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/price/PriceGlanceReceiver.kt
@@ -3,11 +3,6 @@ package to.bitkit.appwidget.ui.price
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import dagger.hilt.android.EntryPointAccessors
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import to.bitkit.appwidget.AppWidgetEntryPoint
 import to.bitkit.appwidget.AppWidgetRefreshWorker
 
 class PriceGlanceReceiver : GlanceAppWidgetReceiver() {
@@ -16,21 +11,6 @@ class PriceGlanceReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
-        super.onDeleted(context, appWidgetIds)
-        val pendingResult = goAsync()
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                val store = EntryPointAccessors
-                    .fromApplication(context, AppWidgetEntryPoint::class.java)
-                    .appWidgetPreferencesStore()
-                appWidgetIds.forEach { store.unregisterWidget(it) }
-            } finally {
-                pendingResult.finish()
-            }
-        }
     }
 
     override fun onDisabled(context: Context) {

--- a/app/src/main/java/to/bitkit/appwidget/ui/price/PriceGlanceWidget.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/price/PriceGlanceWidget.kt
@@ -58,6 +58,14 @@ class PriceGlanceWidget : GlanceAppWidget() {
         }
     }
 
+    override suspend fun onDelete(context: Context, glanceId: GlanceId) {
+        val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(glanceId)
+        EntryPointAccessors
+            .fromApplication(context, AppWidgetEntryPoint::class.java)
+            .appWidgetPreferencesStore()
+            .unregisterWidget(appWidgetId)
+    }
+
     private fun resolveWidget(price: PriceDTO?, entry: AppWidgetEntry): PriceWidgetData? {
         val widgets = price?.widgets ?: return null
         val enabledPairs = entry.pricePreferences.enabledPairs

--- a/app/src/main/java/to/bitkit/appwidget/ui/weather/WeatherGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/weather/WeatherGlanceReceiver.kt
@@ -3,11 +3,6 @@ package to.bitkit.appwidget.ui.weather
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import dagger.hilt.android.EntryPointAccessors
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import to.bitkit.appwidget.AppWidgetEntryPoint
 import to.bitkit.appwidget.AppWidgetRefreshWorker
 
 class WeatherGlanceReceiver : GlanceAppWidgetReceiver() {
@@ -16,21 +11,6 @@ class WeatherGlanceReceiver : GlanceAppWidgetReceiver() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
-        super.onDeleted(context, appWidgetIds)
-        val pendingResult = goAsync()
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                val store = EntryPointAccessors
-                    .fromApplication(context, AppWidgetEntryPoint::class.java)
-                    .appWidgetPreferencesStore()
-                appWidgetIds.forEach { store.unregisterWidget(it) }
-            } finally {
-                pendingResult.finish()
-            }
-        }
     }
 
     override fun onDisabled(context: Context) {

--- a/app/src/main/java/to/bitkit/appwidget/ui/weather/WeatherGlanceWidget.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/weather/WeatherGlanceWidget.kt
@@ -40,4 +40,12 @@ class WeatherGlanceWidget : GlanceAppWidget() {
             )
         }
     }
+
+    override suspend fun onDelete(context: Context, glanceId: GlanceId) {
+        val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(glanceId)
+        EntryPointAccessors
+            .fromApplication(context, AppWidgetEntryPoint::class.java)
+            .appWidgetPreferencesStore()
+            .unregisterWidget(appWidgetId)
+    }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksEditScreen.kt
@@ -258,7 +258,7 @@ private fun BlockEditOptionRow(
                 Icon(
                     painter = painterResource(R.drawable.ic_checkmark),
                     contentDescription = null,
-                    tint = if (isEnabled) Colors.Brand else Colors.White50,
+                    tint = if (isEnabled) Colors.Brand else Colors.Gray3,
                     modifier = Modifier
                         .size(32.dp)
                         .testTag("${testTagPrefix}_toggle_icon")

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesEditScreen.kt
@@ -157,7 +157,7 @@ fun HeadlinesEditContent(
                     Icon(
                         painter = painterResource(R.drawable.ic_checkmark),
                         contentDescription = null,
-                        tint = if (headlinePreferences.showSource) Colors.Brand else Colors.White50,
+                        tint = if (headlinePreferences.showSource) Colors.Brand else Colors.Gray3,
                         modifier = Modifier
                             .size(32.dp)
                             .testTag("source_toggle_icon")
@@ -192,7 +192,7 @@ fun HeadlinesEditContent(
                     Icon(
                         painter = painterResource(R.drawable.ic_checkmark),
                         contentDescription = null,
-                        tint = if (headlinePreferences.showTime) Colors.Brand else Colors.White50,
+                        tint = if (headlinePreferences.showTime) Colors.Brand else Colors.Gray3,
                         modifier = Modifier
                             .size(32.dp)
                             .testTag("time_toggle_icon")

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceEditScreen.kt
@@ -199,16 +199,14 @@ private fun SelectableRow(
                     .weight(1f)
                     .testTag("${testTagPrefix}_label")
             )
-            if (isSelected) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_checkmark),
-                    contentDescription = null,
-                    tint = Colors.Brand,
-                    modifier = Modifier
-                        .size(32.dp)
-                        .testTag("${testTagPrefix}_toggle_icon")
-                )
-            }
+            Icon(
+                painter = painterResource(R.drawable.ic_checkmark),
+                contentDescription = null,
+                tint = if (isSelected) Colors.Brand else Colors.Gray3,
+                modifier = Modifier
+                    .size(32.dp)
+                    .testTag("${testTagPrefix}_toggle_icon")
+            )
         }
 
         HorizontalDivider(

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherEditScreen.kt
@@ -212,7 +212,7 @@ private fun WeatherEditOptionRow(
                 Icon(
                     painter = painterResource(R.drawable.ic_checkmark),
                     contentDescription = null,
-                    tint = if (isSelected) Colors.Brand else Colors.White50,
+                    tint = if (isSelected) Colors.Brand else Colors.Gray3,
                     modifier = Modifier
                         .size(32.dp)
                         .testTag("${testTagPrefix}_toggle_icon")

--- a/changelog.d/next/935.fixed.md
+++ b/changelog.d/next/935.fixed.md
@@ -1,1 +1,1 @@
-Fix an intermittent crash that could occur when removing or cancelling a Bitcoin home screen widget.
+Fix several OS widget issues including an intermittent crash when removing or cancelling a home screen widget, ordering of widget options, and the color of disabled checkboxes in widget configuration screens.

--- a/changelog.d/next/935.fixed.md
+++ b/changelog.d/next/935.fixed.md
@@ -1,0 +1,1 @@
+Fix an intermittent crash that could occur when removing or cancelling a Bitcoin home screen widget.


### PR DESCRIPTION
This PR:
1. Fixes an intermittent NPE crash when an OS widget is removed or its configuration is cancelled.
2. Reorders the widget config activity's provider lookup so it matches the in-app `AddWidgetsScreen` ordering.

### Description

#### 1. Receiver crash on widget removal

All five Glance receivers (`Price`, `Headlines`, `Blocks`, `Facts`, `Weather`) overrode `onDeleted` to unregister the widget entry from the preferences store. The override called `super.onDeleted()` first and then `goAsync()` itself. Glance's `GlanceAppWidgetReceiver.onDeleted` already consumes the broadcast `PendingResult` via its internal `goAsync` extension, so the second call returned `null` and `pendingResult.finish()` in our `finally` block threw a `NullPointerException`. Per Glance's own KDoc:

> if you override any of the methods of this class, you must call the super implementation, and you must not call `AppWidgetProvider.goAsync`, as it will be called by the super implementation.

The unregister logic now lives on each `GlanceAppWidget.onDelete(context, glanceId)` override, which Glance invokes inside its own broadcast-scoped coroutine. The `onDeleted` overrides on every receiver are removed, so there is no longer a duplicate `goAsync` call to NPE on.

#### 2. Provider lookup ordering

`AppWidgetConfigActivity.resolveWidgetType` was listing the providers in `Headlines, Price, Blocks, Weather` order. Reordered to `Price, Headlines, Blocks, Weather` so it matches the `AppWidgetType` enum, the manifest receivers, the refresh worker, and the in-app `AddWidgetsScreen` listing. Pure code-style change with no behavior difference.

#### A note on the system widget picker order

The Android system widget picker (long-press home → Widgets) is rendered by the launcher, not by us. The Pixel launcher groups widgets within an app by their `targetCellWidth × targetCellHeight` area, in descending order, then by manifest declaration order within each size bucket. Because `appwidget_info_facts.xml` declares `targetCellHeight="1"` while every other widget declares `targetCellHeight="2"`, Facts ends up alone in the smaller bucket and appears last in the picker. That positioning is launcher-controlled and intentional given the widget's existing 1-cell-tall design — this PR does not change widget sizes.

### Preview

[Screen_recording_20260507_120327.webm](https://github.com/user-attachments/assets/fc5a2fa3-f0c1-4716-92b0-19cff5d55a46)

### QA Notes

#### Manual Tests
- [x] **1.** Add a Bitcoin Headlines OS widget with Bitkit running in the background → tap the back arrow on the configure screen → no crash, widget is removed, app stays alive. Repeat several times to cover the intermittent timing.
- [x] **2.** Repeat step 1 for Price, Blocks, Facts, and Weather OS widgets.
