### PR TITLE
ci: add pubky paykit e2e shard

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -305,6 +305,7 @@ jobs:
       matrix:
         shard:
           - { name: multi_address_2_regtest, grep: "@multi_address_2" }
+          - { name: pubky_paykit, grep: "@pubky" }
 
     name: e2e-tests-staging - ${{ matrix.shard.name }}
 

--- a/app/src/main/java/to/bitkit/ui/screens/contacts/ContactActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/contacts/ContactActivityScreen.kt
@@ -127,6 +127,7 @@ private fun ContactActivityList(
         onActivityItemClick = onActivityItemClick,
         onEmptyActivityRowClick = {},
         contentPadding = PaddingValues(top = 0.dp),
+        activityTestTagPrefix = "ContactActivity",
         titleProvider = { activity ->
             name?.let {
                 val titleRes = if (activity.isSent()) {

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -48,6 +48,7 @@ fun ActivityListGrouped(
     showFooter: Boolean = false,
     onAllActivityButtonClick: () -> Unit = {},
     contentPadding: PaddingValues = PaddingValues(top = 20.dp),
+    activityTestTagPrefix: String = "Activity",
     titleProvider: @Composable (Activity) -> String? = { null },
 ) {
     val contacts by activityListViewModel?.contacts?.collectAsStateWithLifecycle() ?: remember {
@@ -108,7 +109,7 @@ fun ActivityListGrouped(
                                 ActivityRow(
                                     item = item,
                                     onClick = onActivityItemClick,
-                                    testTag = "Activity-$index",
+                                    testTag = "$activityTestTagPrefix-$index",
                                     title = titleProvider(item) ?: contactActivityTitle(item, contacts),
                                 )
                                 VerticalSpacer(16.dp)


### PR DESCRIPTION
### Description

This PR wires the new Pubky/Paykit E2E coverage into Android CI.

1. Adds a dedicated `pubky_paykit` shard to the staging E2E matrix, running `--mochaOpts.grep "@pubky"` against the regtest/network build.
2. Aligns Android contact activity row test IDs with iOS by allowing the shared activity list to use a screen-specific prefix and setting contact activity rows to `ContactActivity-*`.

The E2E tests themselves were added in synonymdev/bitkit-e2e-tests#147. Keeping this as a separate staging shard isolates Pubky/Homegate/Paykit staging dependency failures from the local-regtest wallet shards.

### Preview

N/A

### QA Notes

#### Manual Tests

N/A

#### Automated Checks

- CI coverage added: Android staging E2E now runs `@pubky`, which covers Pubky profile/contact flows and public Paykit on-chain contact payment from synonymdev/bitkit-e2e-tests#147 (after merge).
- Test ID parity: contact activity rows now use `ContactActivity-*` on Android, matching iOS for cross-platform E2E assertions.
- Local check: `./gradlew :app:compileDevDebugKotlin` passed for the contact activity test-id change.
