### PR TITLE
test: add mainnet probe devtools

### DIFF
--- a/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
+++ b/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
@@ -15,9 +15,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import to.bitkit.async.ServiceQueue
 import to.bitkit.repositories.LightningRepo
+import to.bitkit.repositories.ProbeOutcome
 import to.bitkit.utils.Logger
+import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "DevToolsProvider"
+private val DEV_JSON = Json { encodeDefaults = true }
 
 class DevToolsProvider : ContentProvider() {
 
@@ -56,6 +59,7 @@ private sealed interface DevCommand {
     companion object {
         fun parse(method: String, arg: String?): DevCommand? = when (method) {
             CreateInvoice.METHOD -> CreateInvoice.parse(arg)
+            ProbeInvoice.METHOD -> ProbeInvoice.parse(arg)
             else -> null
         }
     }
@@ -80,6 +84,44 @@ private sealed interface DevCommand {
                 },
             )
     }
+
+    data class ProbeInvoice(val args: Args) : DevCommand {
+        companion object {
+            const val METHOD = "probeInvoice"
+            fun parse(arg: String?) = ProbeInvoice(arg.deserialize<Args>())
+        }
+
+        @Serializable
+        data class Args(
+            val targetName: String? = null,
+            val bolt11: String,
+            val amountMsat: ULong? = null,
+            val amountSats: ULong? = null,
+            val timeoutSeconds: Long = 90,
+        )
+
+        override suspend fun execute(deps: DevToolsProvider.Dependencies): DevResult {
+            val amountSats = args.amountSats ?: args.amountMsat?.div(1_000u)
+            val timeout = args.timeoutSeconds.coerceAtLeast(1).seconds
+
+            Logger.info(
+                "Sending probe for target '${args.targetName ?: "unknown"}' amountSats='${amountSats ?: "invoice"}'",
+                context = TAG,
+            )
+
+            return deps.lightningRepo().sendProbeForInvoice(args.bolt11, amountSats)
+                .fold(
+                    onSuccess = {
+                        deps.lightningRepo().waitForProbeOutcome(it.paymentIds, timeout)
+                            .fold(
+                                onSuccess = { outcome -> outcome.toDevResult(it.paymentIds) },
+                                onFailure = { error -> DevResult.ProbeFailure.from(error, it.paymentIds) },
+                            )
+                    },
+                    onFailure = { DevResult.ProbeFailure.from(it) },
+                )
+        }
+    }
 }
 
 @Serializable
@@ -91,9 +133,49 @@ private sealed interface DevResult {
 
     @Serializable data class Invoice(val bolt11: String) : DevResult
 
+    @Serializable
+    data class ProbeSuccess(
+        val success: Boolean = true,
+        val paymentId: String,
+        val paymentHash: String,
+        val paymentIds: List<String>,
+    ) : DevResult
+
+    @Serializable
+    data class ProbeFailure(
+        val success: Boolean = false,
+        val message: String? = null,
+        val paymentId: String? = null,
+        val paymentHash: String? = null,
+        val shortChannelId: ULong? = null,
+        val paymentIds: List<String> = emptyList(),
+    ) : DevResult {
+        companion object {
+            fun from(error: Throwable, paymentIds: Set<String> = emptySet()) = ProbeFailure(
+                message = error.message,
+                paymentIds = paymentIds.toList(),
+            )
+        }
+    }
+
     @Serializable data class Error(val message: String? = null) : DevResult
 
-    fun toBundle() = bundleOf(KEY_RESULT to Json.encodeToString(this))
+    fun toBundle() = bundleOf(KEY_RESULT to DEV_JSON.encodeToString(this))
+}
+
+private fun ProbeOutcome.toDevResult(paymentIds: Set<String>): DevResult = when (this) {
+    is ProbeOutcome.Success -> DevResult.ProbeSuccess(
+        paymentId = paymentId,
+        paymentHash = paymentHash,
+        paymentIds = paymentIds.toList(),
+    )
+    is ProbeOutcome.Failure -> DevResult.ProbeFailure(
+        message = "Probe failed",
+        paymentId = paymentId,
+        paymentHash = paymentHash,
+        shortChannelId = shortChannelId,
+        paymentIds = paymentIds.toList(),
+    )
 }
 
 private inline fun <reified T> String?.deserialize(): T =

--- a/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
+++ b/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
@@ -14,6 +14,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import to.bitkit.async.ServiceQueue
+import to.bitkit.models.msatCeilOf
 import to.bitkit.repositories.LightningRepo
 import to.bitkit.repositories.ProbeOutcome
 import to.bitkit.utils.Logger
@@ -101,7 +102,7 @@ private sealed interface DevCommand {
         )
 
         override suspend fun execute(deps: DevToolsProvider.Dependencies): DevResult {
-            val amountSats = args.amountSats ?: args.amountMsat?.div(1_000u)
+            val amountSats = args.amountSats ?: args.amountMsat?.let { msatCeilOf(it) }
             val timeout = args.timeoutSeconds.coerceAtLeast(1).seconds
 
             Logger.info(

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -1268,6 +1268,19 @@ class LightningRepoTest : BaseUnitTest() {
     }
 
     @Test
+    fun `sendProbeForInvoice delegates amount probes when sats are provided`() = test {
+        startNodeForTesting()
+        whenever(lightningService.sendProbesUsingAmount("lnbc1", 42_000uL))
+            .thenReturn(Result.success(setOf(probePaymentA)))
+
+        val result = sut.sendProbeForInvoice("lnbc1", amountSats = 42uL)
+
+        assertTrue(result.isSuccess)
+        assertEquals(setOf(probePaymentA), result.getOrThrow().paymentIds)
+        verifyBlocking(lightningService) { sendProbesUsingAmount("lnbc1", 42_000uL) }
+    }
+
+    @Test
     fun `sendProbeForNode delegates to keysend probe and returns payment IDs`() = test {
         startNodeForTesting()
         whenever(lightningService.sendKeysendProbe(probeNodeId, 42_000uL))

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -1277,7 +1277,7 @@ class LightningRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         assertEquals(setOf(probePaymentA), result.getOrThrow().paymentIds)
-        verifyBlocking(lightningService) { sendProbesUsingAmount("lnbc1", 42_000uL) }
+        verify(lightningService).sendProbesUsingAmount("lnbc1", 42_000uL)
     }
 
     @Test


### PR DESCRIPTION
Addresses https://github.com/synonymdev/bitkit-nightly/issues/10

Companion PRs:
- https://github.com/synonymdev/bitkit-e2e-tests/pull/155
- https://github.com/synonymdev/bitkit-nightly/pull/7

<!-- Changelog: skipped; debug-only E2E automation hook with no user-facing release note. -->

### Description

This PR:
1. Adds a debug-only devtools command for probing a resolved Lightning invoice through ADB.
2. Returns structured probe success/failure payloads for the mainnet probe E2E runner.
3. Adds unit coverage for amount-based probe delegation.

### Preview

N/A

### QA Notes

#### Manual Tests
- [ ] Run the companion `@probe_mainnet` E2E spec from synonymdev/bitkit-e2e-tests#155 against a mainnet automation APK.

#### Automated Checks
- [x] `./gradlew compileDevDebugKotlin`
- [x] `./gradlew testDevDebugUnitTest`
- [x] `./gradlew detekt`
