### PR TITLE
test: add calculator widget device tests

### DIFF
--- a/app/src/androidTest/java/to/bitkit/test/annotations/CalculatorWidget.kt
+++ b/app/src/androidTest/java/to/bitkit/test/annotations/CalculatorWidget.kt
@@ -1,0 +1,5 @@
+package to.bitkit.test.annotations
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class CalculatorWidget

--- a/app/src/androidTest/java/to/bitkit/test/annotations/DeviceUiIntegration.kt
+++ b/app/src/androidTest/java/to/bitkit/test/annotations/DeviceUiIntegration.kt
@@ -1,0 +1,5 @@
+package to.bitkit.test.annotations
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class DeviceUiIntegration

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
@@ -52,6 +52,7 @@ import to.bitkit.test.annotations.DeviceIntegration
 import to.bitkit.test.annotations.DeviceUiIntegration
 import to.bitkit.ui.screens.widgets.calculator.components.CalculatorCard
 import to.bitkit.ui.theme.AppThemeSurface
+import to.bitkit.viewmodels.CurrencyViewModel
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
@@ -86,7 +87,8 @@ class CalculatorCardIntegrationTest {
     lateinit var cacheStore: CacheStore
 
     private lateinit var viewModelStore: ViewModelStore
-    private lateinit var viewModel: CalculatorViewModel
+    private lateinit var calculatorViewModel: CalculatorViewModel
+    private lateinit var currencyViewModel: CurrencyViewModel
     private lateinit var previousWidgetsData: WidgetsData
     private lateinit var previousSettingsData: SettingsData
     private lateinit var previousCacheData: AppCacheData
@@ -132,7 +134,8 @@ class CalculatorCardIntegrationTest {
             }
         }
 
-        viewModel = createViewModel()
+        calculatorViewModel = createCalculatorViewModel()
+        currencyViewModel = createCurrencyViewModel()
         clearCalculatorValues()
     }
 
@@ -194,7 +197,7 @@ class CalculatorCardIntegrationTest {
         )
     }
 
-    private fun createViewModel(): CalculatorViewModel {
+    private fun createCalculatorViewModel(): CalculatorViewModel {
         viewModelStore = ViewModelStore()
         return ViewModelProvider(
             viewModelStore,
@@ -203,18 +206,31 @@ class CalculatorCardIntegrationTest {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
                     return CalculatorViewModel(
                         widgetsRepo = widgetsRepo,
-                        currencyRepo = currencyRepo,
                     ) as T
                 }
             },
         )[CalculatorViewModel::class.java]
     }
 
+    private fun createCurrencyViewModel(): CurrencyViewModel = ViewModelProvider(
+        viewModelStore,
+        object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return CurrencyViewModel(
+                    currencyRepo = currencyRepo,
+                ) as T
+            }
+        },
+    )[CurrencyViewModel::class.java]
+
     private fun setCalculatorCard() {
         composeTestRule.setContent {
             AppThemeSurface {
                 CalculatorCard(
-                    calculatorViewModel = viewModel,
+                    currencyViewModel = currencyViewModel,
+                    calculatorViewModel = calculatorViewModel,
+                    showWidgetTitle = true,
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -223,14 +239,16 @@ class CalculatorCardIntegrationTest {
     }
 
     private fun clearCalculatorValues() {
-        viewModel.onBtcInputChanged("")
+        calculatorViewModel.updateCalculatorValues(
+            fiatValue = "",
+            btcValue = "",
+        )
         composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
             val calculatorValues = widgetsRepo.widgetsDataFlow.value.calculatorValues
-            viewModel.uiState.value.btcValue.isEmpty() &&
-                viewModel.uiState.value.fiatValue.isEmpty() &&
+            calculatorViewModel.calculatorValues.value.btcValue.isEmpty() &&
+                calculatorViewModel.calculatorValues.value.fiatValue.isEmpty() &&
                 calculatorValues.btcValue.isEmpty() &&
-                calculatorValues.fiatValue.isEmpty() &&
-                calculatorValues.satsValue == 0L
+                calculatorValues.fiatValue.isEmpty()
         }
     }
 
@@ -257,14 +275,14 @@ class CalculatorCardIntegrationTest {
     ) {
         runCatching {
             composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
-                viewModel.uiState.value.btcValue == btcValue &&
-                    viewModel.uiState.value.fiatValue == fiatValue
+                calculatorViewModel.calculatorValues.value.btcValue == btcValue &&
+                    calculatorViewModel.calculatorValues.value.fiatValue == fiatValue
             }
         }.onFailure {
             throw AssertionError(
                 buildString {
-                    append("Expected uiState btcValue='$btcValue', fiatValue='$fiatValue', ")
-                    append("but was '${viewModel.uiState.value}'. Persisted values were ")
+                    append("Expected calculatorValues btcValue='$btcValue', fiatValue='$fiatValue', ")
+                    append("but was '${calculatorViewModel.calculatorValues.value}'. Persisted values were ")
                     append("'${widgetsRepo.widgetsDataFlow.value.calculatorValues}'. Semantics tree:\n")
                     append(composeTestRule.onRoot(useUnmergedTree = true).printToString())
                 },
@@ -275,8 +293,6 @@ class CalculatorCardIntegrationTest {
         val expectedValues = CalculatorValues(
             btcValue = btcValue,
             fiatValue = fiatValue,
-            satsValue = btcValue.toLong(),
-            displayUnit = BitcoinDisplayUnit.MODERN,
         )
         runCatching {
             composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
@@ -314,8 +330,6 @@ class CalculatorCardIntegrationTest {
             CalculatorValues(
                 btcValue = btcValue,
                 fiatValue = fiatValue,
-                satsValue = btcValue.toLong(),
-                displayUnit = BitcoinDisplayUnit.MODERN,
             ),
             widgetsRepo.widgetsDataFlow.value.calculatorValues,
         )

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
@@ -97,6 +97,7 @@ class CalculatorCardIntegrationTest {
         previousLocale = Locale.getDefault()
         Locale.setDefault(Locale.US)
         hiltRule.inject()
+        viewModelStore = ViewModelStore()
 
         runBlocking {
             previousWidgetsData = widgetsStore.data.first()
@@ -193,7 +194,6 @@ class CalculatorCardIntegrationTest {
     }
 
     private fun createCalculatorViewModel(): CalculatorViewModel {
-        viewModelStore = ViewModelStore()
         return ViewModelProvider(
             viewModelStore,
             object : ViewModelProvider.Factory {

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
@@ -1,0 +1,357 @@
+package to.bitkit.ui.screens.widgets.calculator
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.printToString
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import to.bitkit.data.AppCacheData
+import to.bitkit.data.CacheStore
+import to.bitkit.data.SettingsData
+import to.bitkit.data.SettingsStore
+import to.bitkit.data.WidgetsData
+import to.bitkit.data.WidgetsStore
+import to.bitkit.di.RepoModule
+import to.bitkit.models.BitcoinDisplayUnit
+import to.bitkit.models.FxRate
+import to.bitkit.models.USD
+import to.bitkit.models.WidgetType
+import to.bitkit.models.WidgetWithPosition
+import to.bitkit.models.WidgetsBackupV1
+import to.bitkit.models.widget.CalculatorValues
+import to.bitkit.repositories.AmountInputHandler
+import to.bitkit.repositories.CurrencyRepo
+import to.bitkit.repositories.WidgetsRepo
+import to.bitkit.test.annotations.DeviceIntegration
+import to.bitkit.test.annotations.DeviceUiIntegration
+import to.bitkit.ui.screens.widgets.calculator.components.CalculatorCard
+import to.bitkit.ui.theme.AppThemeSurface
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.test.assertEquals
+
+@HiltAndroidTest
+@UninstallModules(RepoModule::class)
+@RunWith(AndroidJUnit4::class)
+@DeviceIntegration
+@DeviceUiIntegration
+class CalculatorCardIntegrationTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Inject
+    lateinit var widgetsRepo: WidgetsRepo
+
+    @Inject
+    lateinit var currencyRepo: CurrencyRepo
+
+    @Inject
+    lateinit var widgetsStore: WidgetsStore
+
+    @Inject
+    lateinit var settingsStore: SettingsStore
+
+    @Inject
+    lateinit var cacheStore: CacheStore
+
+    private lateinit var viewModelStore: ViewModelStore
+    private lateinit var viewModel: CalculatorViewModel
+    private lateinit var previousWidgetsData: WidgetsData
+    private lateinit var previousSettingsData: SettingsData
+    private lateinit var previousCacheData: AppCacheData
+    private lateinit var previousLocale: Locale
+
+    @Before
+    fun setUp() {
+        previousLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+        hiltRule.inject()
+
+        runBlocking {
+            previousWidgetsData = widgetsStore.data.first()
+            previousSettingsData = settingsStore.data.first()
+            previousCacheData = cacheStore.data.first()
+
+            settingsStore.update {
+                it.copy(
+                    selectedCurrency = USD,
+                    displayUnit = BitcoinDisplayUnit.MODERN,
+                    showWidgetTitles = true,
+                )
+            }
+            cacheStore.update { it.copy(cachedRates = listOf(testUsdRate)) }
+            widgetsStore.restoreFromBackup(
+                WidgetsBackupV1(
+                    createdAt = TEST_CREATED_AT,
+                    widgets = WidgetsData(
+                        widgets = listOf(WidgetWithPosition(type = WidgetType.CALCULATOR, position = 0)),
+                        calculatorValues = CalculatorValues(),
+                    ),
+                )
+            ).getOrThrow()
+
+            currencyRepo.currencyState.first {
+                it.selectedCurrency == USD &&
+                    it.displayUnit == BitcoinDisplayUnit.MODERN &&
+                    it.rates.any { rate -> rate.quote == USD && rate.lastPrice == TEST_USD_RATE }
+            }
+            widgetsRepo.widgetsDataFlow.first {
+                it.widgets == listOf(WidgetWithPosition(type = WidgetType.CALCULATOR, position = 0)) &&
+                    it.calculatorValues == CalculatorValues()
+            }
+        }
+
+        viewModel = createViewModel()
+        clearCalculatorValues()
+    }
+
+    @After
+    fun tearDown() {
+        if (::viewModelStore.isInitialized) {
+            viewModelStore.clear()
+        }
+        runBlocking {
+            widgetsStore.restoreFromBackup(
+                WidgetsBackupV1(
+                    createdAt = TEST_CREATED_AT,
+                    widgets = previousWidgetsData,
+                )
+            ).getOrThrow()
+            settingsStore.update { previousSettingsData }
+            cacheStore.update { previousCacheData }
+        }
+        Locale.setDefault(previousLocale)
+    }
+
+    @Test
+    fun btcInputUpdatesFiatValueAndPersistsWidgetState() {
+        setCalculatorCard()
+
+        selectInput(BTC_INPUT_TAG)
+        pressKeys("1", "2", "3", "4", "0")
+
+        waitForValues(
+            btcValue = "12340",
+            fiatValue = "12.34",
+        )
+
+        assertInputText(BTC_INPUT_TAG, "12 340")
+        assertInputText(FIAT_INPUT_TAG, "12.34")
+        assertPersistedValues(
+            btcValue = "12340",
+            fiatValue = "12.34",
+        )
+    }
+
+    @Test
+    fun fiatInputUpdatesBtcValueAndPersistsWidgetState() {
+        setCalculatorCard()
+
+        selectInput(FIAT_INPUT_TAG)
+        pressKeys("1", "0", KEY_DECIMAL_TAG, "0", "0")
+
+        waitForValues(
+            btcValue = "10000",
+            fiatValue = "10.00",
+        )
+
+        assertInputText(BTC_INPUT_TAG, "10 000")
+        assertInputText(FIAT_INPUT_TAG, "10.00")
+        assertPersistedValues(
+            btcValue = "10000",
+            fiatValue = "10.00",
+        )
+    }
+
+    private fun createViewModel(): CalculatorViewModel {
+        viewModelStore = ViewModelStore()
+        return ViewModelProvider(
+            viewModelStore,
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return CalculatorViewModel(
+                        widgetsRepo = widgetsRepo,
+                        currencyRepo = currencyRepo,
+                    ) as T
+                }
+            },
+        )[CalculatorViewModel::class.java]
+    }
+
+    private fun setCalculatorCard() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                CalculatorCard(
+                    calculatorViewModel = viewModel,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun clearCalculatorValues() {
+        viewModel.onBtcInputChanged("")
+        composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
+            val calculatorValues = widgetsRepo.widgetsDataFlow.value.calculatorValues
+            viewModel.uiState.value.btcValue.isEmpty() &&
+                viewModel.uiState.value.fiatValue.isEmpty() &&
+                calculatorValues.btcValue.isEmpty() &&
+                calculatorValues.fiatValue.isEmpty() &&
+                calculatorValues.satsValue == 0L
+        }
+    }
+
+    private fun selectInput(tag: String) {
+        composeTestRule.onNodeWithTag(tag)
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
+            composeTestRule.onAllNodesWithTag(NUMBER_PAD_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun pressKeys(vararg keys: String) {
+        keys.forEach {
+            composeTestRule.onNodeWithTag("N$it")
+                .assertIsDisplayed()
+                .performClick()
+        }
+    }
+
+    private fun waitForValues(
+        btcValue: String,
+        fiatValue: String,
+    ) {
+        runCatching {
+            composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
+                viewModel.uiState.value.btcValue == btcValue &&
+                    viewModel.uiState.value.fiatValue == fiatValue
+            }
+        }.onFailure {
+            throw AssertionError(
+                buildString {
+                    append("Expected uiState btcValue='$btcValue', fiatValue='$fiatValue', ")
+                    append("but was '${viewModel.uiState.value}'. Persisted values were ")
+                    append("'${widgetsRepo.widgetsDataFlow.value.calculatorValues}'. Semantics tree:\n")
+                    append(composeTestRule.onRoot(useUnmergedTree = true).printToString())
+                },
+                it,
+            )
+        }
+
+        val expectedValues = CalculatorValues(
+            btcValue = btcValue,
+            fiatValue = fiatValue,
+            satsValue = btcValue.toLong(),
+            displayUnit = BitcoinDisplayUnit.MODERN,
+        )
+        runCatching {
+            composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
+                widgetsRepo.widgetsDataFlow.value.calculatorValues == expectedValues
+            }
+        }.onFailure {
+            throw AssertionError(
+                "Expected persisted values '$expectedValues', but was " +
+                    "'${widgetsRepo.widgetsDataFlow.value.calculatorValues}'",
+                it,
+            )
+        }
+    }
+
+    private fun assertInputText(
+        inputTag: String,
+        text: String,
+    ) {
+        composeTestRule.onNode(
+            inputTextMatcher(inputTag = inputTag, text = text),
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+    }
+
+    private fun inputTextMatcher(
+        inputTag: String,
+        text: String,
+    ): SemanticsMatcher = hasText(text, substring = true) and hasAnyAncestor(hasTestTag(inputTag))
+
+    private fun assertPersistedValues(
+        btcValue: String,
+        fiatValue: String,
+    ) {
+        assertEquals(
+            CalculatorValues(
+                btcValue = btcValue,
+                fiatValue = fiatValue,
+                satsValue = btcValue.toLong(),
+                displayUnit = BitcoinDisplayUnit.MODERN,
+            ),
+            widgetsRepo.widgetsDataFlow.value.calculatorValues,
+        )
+    }
+
+    companion object {
+        private const val BTC_INPUT_TAG = "CalculatorBtcInput"
+        private const val FIAT_INPUT_TAG = "CalculatorFiatInput"
+        private const val NUMBER_PAD_TAG = "CalculatorNumberPad"
+        private const val KEY_DECIMAL_TAG = "Decimal"
+        private const val TIMEOUT_MS = 5_000L
+        private const val TEST_CREATED_AT = 0L
+        private const val TEST_USD_RATE = "100000"
+
+        private val testUsdRate = FxRate(
+            symbol = "BTCUSD",
+            lastPrice = TEST_USD_RATE,
+            base = "BTC",
+            baseName = "Bitcoin",
+            quote = USD,
+            quoteName = "US Dollar",
+            currencySymbol = "$",
+            currencyFlag = "US",
+            lastUpdatedAt = TEST_CREATED_AT,
+        )
+    }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    object TestRepoModule {
+
+        @Provides
+        fun bindAmountInputHandler(currencyRepo: CurrencyRepo): AmountInputHandler = currencyRepo
+
+        @Provides
+        @Named("enablePolling")
+        fun provideEnablePolling(): Boolean = false
+    }
+}

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
@@ -46,6 +46,7 @@ import to.bitkit.models.widget.CalculatorValues
 import to.bitkit.repositories.AmountInputHandler
 import to.bitkit.repositories.CurrencyRepo
 import to.bitkit.repositories.WidgetsRepo
+import to.bitkit.test.annotations.CalculatorWidget
 import to.bitkit.test.annotations.DeviceIntegration
 import to.bitkit.test.annotations.DeviceUiIntegration
 import to.bitkit.ui.screens.widgets.calculator.components.CalculatorCard
@@ -59,6 +60,7 @@ import kotlin.test.assertEquals
 @HiltAndroidTest
 @UninstallModules(RepoModule::class)
 @RunWith(AndroidJUnit4::class)
+@CalculatorWidget
 @DeviceIntegration
 @DeviceUiIntegration
 class CalculatorCardIntegrationTest {

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
@@ -2,16 +2,14 @@ package to.bitkit.ui.screens.widgets.calculator
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasAnyAncestor
-import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.printToString
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -118,7 +116,7 @@ class CalculatorCardIntegrationTest {
                     createdAt = TEST_CREATED_AT,
                     widgets = WidgetsData(
                         widgets = listOf(WidgetWithPosition(type = WidgetType.CALCULATOR, position = 0)),
-                        calculatorValues = CalculatorValues(),
+                        calculatorValues = emptyCalculatorValues,
                     ),
                 )
             ).getOrThrow()
@@ -130,13 +128,12 @@ class CalculatorCardIntegrationTest {
             }
             widgetsRepo.widgetsDataFlow.first {
                 it.widgets == listOf(WidgetWithPosition(type = WidgetType.CALCULATOR, position = 0)) &&
-                    it.calculatorValues == CalculatorValues()
+                    it.calculatorValues == emptyCalculatorValues
             }
         }
 
         calculatorViewModel = createCalculatorViewModel()
         currencyViewModel = createCurrencyViewModel()
-        clearCalculatorValues()
     }
 
     @After
@@ -161,16 +158,15 @@ class CalculatorCardIntegrationTest {
     fun btcInputUpdatesFiatValueAndPersistsWidgetState() {
         setCalculatorCard()
 
-        selectInput(BTC_INPUT_TAG)
-        pressKeys("1", "2", "3", "4", "0")
+        replaceInput(BTC_INPUT_INDEX, "12340")
 
         waitForValues(
             btcValue = "12340",
             fiatValue = "12.34",
         )
 
-        assertInputText(BTC_INPUT_TAG, "12 340")
-        assertInputText(FIAT_INPUT_TAG, "12.34")
+        assertInputText(BTC_INPUT_INDEX, "12 340")
+        assertInputText(FIAT_INPUT_INDEX, "12.34")
         assertPersistedValues(
             btcValue = "12340",
             fiatValue = "12.34",
@@ -181,16 +177,15 @@ class CalculatorCardIntegrationTest {
     fun fiatInputUpdatesBtcValueAndPersistsWidgetState() {
         setCalculatorCard()
 
-        selectInput(FIAT_INPUT_TAG)
-        pressKeys("1", "0", KEY_DECIMAL_TAG, "0", "0")
+        replaceInput(FIAT_INPUT_INDEX, "10.00")
 
         waitForValues(
             btcValue = "10000",
             fiatValue = "10.00",
         )
 
-        assertInputText(BTC_INPUT_TAG, "10 000")
-        assertInputText(FIAT_INPUT_TAG, "10.00")
+        assertInputText(BTC_INPUT_INDEX, "10 000")
+        assertInputText(FIAT_INPUT_INDEX, "10.00")
         assertPersistedValues(
             btcValue = "10000",
             fiatValue = "10.00",
@@ -236,37 +231,19 @@ class CalculatorCardIntegrationTest {
             }
         }
         composeTestRule.waitForIdle()
-    }
-
-    private fun clearCalculatorValues() {
-        calculatorViewModel.updateCalculatorValues(
-            fiatValue = "",
-            btcValue = "",
-        )
         composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
-            val calculatorValues = widgetsRepo.widgetsDataFlow.value.calculatorValues
-            calculatorViewModel.calculatorValues.value.btcValue.isEmpty() &&
-                calculatorViewModel.calculatorValues.value.fiatValue.isEmpty() &&
-                calculatorValues.btcValue.isEmpty() &&
-                calculatorValues.fiatValue.isEmpty()
+            composeTestRule.onAllNodes(hasSetTextAction()).fetchSemanticsNodes().size == INPUT_COUNT
         }
     }
 
-    private fun selectInput(tag: String) {
-        composeTestRule.onNodeWithTag(tag)
-            .assertIsDisplayed()
-            .performClick()
-        composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
-            composeTestRule.onAllNodesWithTag(NUMBER_PAD_TAG).fetchSemanticsNodes().isNotEmpty()
-        }
-    }
+    private fun inputAt(index: Int) = composeTestRule.onAllNodes(hasSetTextAction())[index]
 
-    private fun pressKeys(vararg keys: String) {
-        keys.forEach {
-            composeTestRule.onNodeWithTag("N$it")
-                .assertIsDisplayed()
-                .performClick()
-        }
+    private fun replaceInput(
+        index: Int,
+        text: String,
+    ) {
+        inputAt(index).performTextClearance()
+        inputAt(index).performTextInput(text)
     }
 
     private fun waitForValues(
@@ -308,19 +285,13 @@ class CalculatorCardIntegrationTest {
     }
 
     private fun assertInputText(
-        inputTag: String,
+        inputIndex: Int,
         text: String,
     ) {
-        composeTestRule.onNode(
-            inputTextMatcher(inputTag = inputTag, text = text),
-            useUnmergedTree = true,
-        ).assertIsDisplayed()
+        inputAt(inputIndex).assertTextContains(text, substring = true)
+        composeTestRule.onNode(hasText(text, substring = true), useUnmergedTree = true)
+            .assertIsDisplayed()
     }
-
-    private fun inputTextMatcher(
-        inputTag: String,
-        text: String,
-    ): SemanticsMatcher = hasText(text, substring = true) and hasAnyAncestor(hasTestTag(inputTag))
 
     private fun assertPersistedValues(
         btcValue: String,
@@ -336,13 +307,17 @@ class CalculatorCardIntegrationTest {
     }
 
     companion object {
-        private const val BTC_INPUT_TAG = "CalculatorBtcInput"
-        private const val FIAT_INPUT_TAG = "CalculatorFiatInput"
-        private const val NUMBER_PAD_TAG = "CalculatorNumberPad"
-        private const val KEY_DECIMAL_TAG = "Decimal"
+        private const val BTC_INPUT_INDEX = 0
+        private const val FIAT_INPUT_INDEX = 1
+        private const val INPUT_COUNT = 2
         private const val TIMEOUT_MS = 5_000L
         private const val TEST_CREATED_AT = 0L
         private const val TEST_USD_RATE = "100000"
+
+        private val emptyCalculatorValues = CalculatorValues(
+            btcValue = "",
+            fiatValue = "",
+        )
 
         private val testUsdRate = FxRate(
             symbol = "BTCUSD",


### PR DESCRIPTION
Closes: #950

> [!NOTE]
> **AI Dev Tests**
> This class of tests are intended to aid in development using AI agents, they should stay free of requirements to run them during QA gating. There shouldn't be any constraint wrt. time it takes to run these tests if ran together. Personally, I would be in favour of them covering all possible user-facing functionalities of the app in time.

Stacked on #943.

### Description

- Adds calculator widget device UI coverage rebuilt on top of #942.
- Covers BTC input to fiat conversion and fiat input to BTC conversion.
- Leaves calculator unit coverage in #942, where the view model and formatting/number-pad logic tests were added.
- Verifies persisted calculator widget state using deterministic USD rate, store state, and locale setup.
- Uses the `DeviceIntegration` and `DeviceUiIntegration` lanes from #943, and adds a focused `CalculatorWidget` lane for calculator-only device UI coverage.
- Removes the stale OS-widget updater dependency now that #942 keeps the calculator OS widget out of scope.

### Preview

N/A

### QA Notes
#### Manual Tests
N/A

#### Automated Checks
- Local: `./gradlew compileDevDebugKotlin testDevDebugUnitTest compileDevDebugAndroidTestKotlin detekt`
- Local: `./gradlew compileDevDebugAndroidTestKotlin`
- Local task discovery: `./gradlew tasks --all --console=plain | rg 'connectedDevDebugCalculatorWidgetAndroidTest|CalculatorWidget'`
- Local dry run: `./gradlew connectedDevDebugDeviceUiIntegrationAndroidTest -m`
- Device run before the annotation rename: `./gradlew connectedDevDebugDeviceUiIntegrationAndroidTest` ran 2 tests on Pixel 10 Pro - 16.

### Reviewer Note

Recommended merge order (! wait a few seconds for branch of merged PRs to be deleted):
1. #942
2. #943 into master
3. This PR into master
