### PR TITLE
fix: logs spam and peer recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,7 @@ suspend fun getData(): Result<Data> = withContext(Dispatchers.IO) {
 - NEVER manually append the `Throwable`'s message or any other props to the string passed as the 1st param of `Logger.*` calls, its internals are already enriching the final log message with the details of the `Throwable` passed via the `e` arg
 - ALWAYS wrap parameter values in log messages with single quotes, e.g. `Logger.info("Received event '$eventName'", context = TAG)`
 - ALWAYS start log messages with a verb, e.g. `Logger.info("Received payment for '$hash'", context = TAG)`
+- ALWAYS keep log names, tags, labels, and references mechanically traceable to the caller. Do not rewrite them into prose or product-facing descriptions. For `measured(...)` labels, use the concrete operation or method name from the caller, e.g. `label = "doWork"` with `context = TAG` in `WakeNodeWorker`.
 - ALWAYS log errors at the final handling layer where the error is acted upon, not in intermediate layers that just propagate it
 - ALWAYS use the Result API instead of try-catch
 - NEVER wrap methods returning `Result<T>` in try-catch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ suspend fun getData(): Result<Data> = withContext(Dispatchers.IO) {
 - NEVER manually append the `Throwable`'s message or any other props to the string passed as the 1st param of `Logger.*` calls, its internals are already enriching the final log message with the details of the `Throwable` passed via the `e` arg
 - ALWAYS wrap parameter values in log messages with single quotes, e.g. `Logger.info("Received event '$eventName'", context = TAG)`
 - ALWAYS start log messages with a verb, e.g. `Logger.info("Received payment for '$hash'", context = TAG)`
-- ALWAYS keep log names, tags, labels, and references mechanically traceable to the caller. Do not rewrite them into prose or product-facing descriptions. For `measured(...)` labels, use the concrete operation or method name from the caller, e.g. `label = "doWork"` with `context = TAG` in `WakeNodeWorker`.
+- ALWAYS keep log names, tags, labels, and references mechanically traceable to the caller. Do not rewrite them into long descriptions.
 - ALWAYS log errors at the final handling layer where the error is acted upon, not in intermediate layers that just propagate it
 - ALWAYS use the Result API instead of try-catch
 - NEVER wrap methods returning `Result<T>` in try-catch

--- a/app/src/main/java/to/bitkit/async/ServiceQueue.kt
+++ b/app/src/main/java/to/bitkit/async/ServiceQueue.kt
@@ -6,9 +6,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import to.bitkit.ext.callerName
 import to.bitkit.utils.AppError
-import to.bitkit.utils.measured
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import kotlin.coroutines.CoroutineContext
@@ -20,30 +18,16 @@ enum class ServiceQueue {
 
     fun <T> blocking(
         coroutineContext: CoroutineContext = scope.coroutineContext,
-        functionName: String = Thread.currentThread().callerName,
         block: suspend CoroutineScope.() -> T,
     ): T = runBlocking(coroutineContext) {
-        runCatching {
-            measured(label = functionName, context = TAG) {
-                block()
-            }
-        }.getOrElse { throw AppError(it) }
+        runCatching { block() }.getOrElse { throw AppError(it) }
     }
 
     suspend fun <T> background(
         coroutineContext: CoroutineContext = scope.coroutineContext,
-        functionName: String = Thread.currentThread().callerName,
         block: suspend CoroutineScope.() -> T,
     ): T = withContext(coroutineContext) {
-        runCatching {
-            measured(label = functionName, context = TAG) {
-                block()
-            }
-        }.getOrElse { throw AppError(it) }
-    }
-
-    companion object {
-        private const val TAG = "ServiceQueue"
+        runCatching { block() }.getOrElse { throw AppError(it) }
     }
 }
 

--- a/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
+++ b/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
@@ -62,6 +62,7 @@ class WakeNodeWorker @AssistedInject constructor(
     private var notificationPayload: JsonObject? = null
 
     private val timeout = 2.minutes
+    private val slowWakeNodeThreshold = 10.seconds
     private val deliverSignal = CompletableDeferred<Unit>()
 
     override suspend fun doWork(): Result {
@@ -80,7 +81,7 @@ class WakeNodeWorker @AssistedInject constructor(
         }
 
         return runCatching {
-            measured(label = "doWork", context = TAG) {
+            measured(label = "Wake node worker", context = TAG, slowThreshold = slowWakeNodeThreshold) {
                 lightningRepo.start(
                     walletIndex = 0,
                     timeout = timeout,

--- a/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
+++ b/app/src/main/java/to/bitkit/fcm/WakeNodeWorker.kt
@@ -81,7 +81,7 @@ class WakeNodeWorker @AssistedInject constructor(
         }
 
         return runCatching {
-            measured(label = "Wake node worker", context = TAG, slowThreshold = slowWakeNodeThreshold) {
+            measured(label = "doWork", context = TAG, slowThreshold = slowWakeNodeThreshold) {
                 lightningRepo.start(
                     walletIndex = 0,
                     timeout = timeout,

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -351,6 +351,7 @@ class LightningRepo @Inject constructor(
 
                 // Initial state sync
                 syncState()
+                logNodeSupportSummary("node started")
                 updateGeoBlockState()
                 refreshChannelCache()
 
@@ -377,6 +378,7 @@ class LightningRepo @Inject constructor(
                 connectToTrustedPeers().onFailure {
                     Logger.error("Failed to connect to trusted peers", it, context = TAG)
                 }
+                logNodeSupportSummary("trusted peers connected")
 
                 sync().onFailure { e ->
                     Logger.warn("Initial sync failed, event-driven sync will retry", e, context = TAG)
@@ -1322,6 +1324,52 @@ class LightningRepo @Inject constructor(
                 peers = getPeers().orEmpty().toImmutableList(),
                 channels = getChannels().orEmpty().toImmutableList(),
                 balances = getBalances(),
+            )
+        }
+    }
+
+    private fun logNodeSupportSummary(reason: String) {
+        val state = _lightningState.value
+        val connectedPeers = state.peers.count { it.isConnected }
+        val persistedPeers = state.peers.count { it.isPersisted }
+        val readyChannels = state.channels.count { it.isChannelReady }
+        val usableChannels = state.channels.count { it.isUsable }
+
+        Logger.info(
+            "Collected node support summary for '$reason': " +
+                "nodeId='${state.nodeId}', " +
+                "lifecycle='${state.nodeLifecycleState}', " +
+                "peers='${state.peers.size}', " +
+                "connectedPeers='$connectedPeers', " +
+                "persistedPeers='$persistedPeers', " +
+                "channels='${state.channels.size}', " +
+                "readyChannels='$readyChannels', " +
+                "usableChannels='$usableChannels'",
+            context = TAG,
+        )
+
+        state.peers.forEach {
+            Logger.info(
+                "Collected peer support summary for '$reason': " +
+                    "nodeId='${it.nodeId}', " +
+                    "address='${it.address}', " +
+                    "connected='${it.isConnected}', " +
+                    "persisted='${it.isPersisted}'",
+                context = TAG,
+            )
+        }
+
+        state.channels.forEach {
+            Logger.info(
+                "Collected channel support summary for '$reason': " +
+                    "channelId='${it.channelId}', " +
+                    "counterparty='${it.counterpartyNodeId}', " +
+                    "ready='${it.isChannelReady}', " +
+                    "usable='${it.isUsable}', " +
+                    "announced='${it.isAnnounced}', " +
+                    "outboundMsat='${it.outboundCapacityMsat}', " +
+                    "inboundMsat='${it.inboundCapacityMsat}'",
+                context = TAG,
             )
         }
     }

--- a/app/src/main/java/to/bitkit/repositories/LogsRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LogsRepo.kt
@@ -6,14 +6,19 @@ import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import to.bitkit.data.ChatwootHttpClient
 import to.bitkit.di.BgDispatcher
 import to.bitkit.di.IoDispatcher
 import to.bitkit.env.Env
+import to.bitkit.ext.DatePattern
 import to.bitkit.ext.fromBase64
 import to.bitkit.ext.getEnumValueOf
 import to.bitkit.ext.toBase64
+import to.bitkit.ext.utcDateFormatterOf
 import to.bitkit.models.ChatwootMessage
+import to.bitkit.models.NodeLifecycleState
 import to.bitkit.utils.LogSource
 import to.bitkit.utils.Logger
 import java.io.BufferedReader
@@ -21,10 +26,12 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileReader
+import java.util.Date
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import javax.inject.Inject
 import javax.inject.Singleton
+import to.bitkit.di.json as appJson
 
 @Singleton
 class LogsRepo @Inject constructor(
@@ -32,11 +39,12 @@ class LogsRepo @Inject constructor(
     @BgDispatcher private val bgDispatcher: CoroutineDispatcher,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val chatwootHttpClient: ChatwootHttpClient,
+    private val lightningRepo: LightningRepo,
 ) {
     suspend fun postQuestion(email: String, message: String): Result<Unit> = withContext(bgDispatcher) {
         runCatching {
-            val logsBase64 = zipLogs().getOrDefault("")
-            val logsFileName = "bitkit_logs_${System.currentTimeMillis()}.zip"
+            val logsBase64 = zipLogs(maxEncodedBytes = MAX_SUPPORT_UPLOAD_BASE64_BYTES).getOrDefault("")
+            val logsFileName = createLogsArchiveFileName()
 
             chatwootHttpClient.postQuestion(
                 message = ChatwootMessage(
@@ -49,7 +57,7 @@ class LogsRepo @Inject constructor(
                 )
             )
         }.onFailure {
-            Logger.error(it.message, e = it, context = TAG)
+            Logger.error("Failed to post support question", it, context = TAG)
         }
     }
 
@@ -61,22 +69,7 @@ class LogsRepo @Inject constructor(
 
             val logFiles = logDir
                 .listFiles { file -> file.extension == "log" }
-                ?.map { file ->
-                    val fileName = file.name
-                    val components = fileName.split("_")
-
-                    val serviceName = components.firstOrNull()
-                        ?.let { c -> c.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() } }
-                        ?: LogSource.Unknown.name
-                    val timestamp = if (components.size >= 3) components[components.size - 2] else ""
-                    val displayName = "$serviceName Log: $timestamp"
-
-                    LogFile(
-                        displayName = displayName,
-                        file = file,
-                        source = getEnumValueOf<LogSource>(serviceName).getOrDefault(LogSource.Unknown),
-                    )
-                }
+                ?.map { it.toLogFile() }
                 ?.sortedByDescending { it.file.lastModified() }
                 ?: emptyList()
 
@@ -115,7 +108,7 @@ class LogsRepo @Inject constructor(
             val file = withContext(ioDispatcher) {
                 val tempDir = context.cacheDir.resolve("logs").apply { mkdirs() }
 
-                val zipFileName = "bitkit_logs_${System.currentTimeMillis()}.zip"
+                val zipFileName = createLogsArchiveFileName()
                 val tempFile = File(tempDir, zipFileName)
 
                 // Convert base64 back to bytes and write to file
@@ -128,7 +121,7 @@ class LogsRepo @Inject constructor(
 
             return@mapCatching contentUri
         }.onFailure {
-            Logger.error("Error preparing logs for sharing", it)
+            Logger.error("Failed to prepare logs for sharing", it, context = TAG)
         }
     }
 
@@ -136,6 +129,7 @@ class LogsRepo @Inject constructor(
     suspend fun zipLogs(
         limit: Int = 20,
         source: LogSource? = null,
+        maxEncodedBytes: Int? = null,
     ): Result<String> = withContext(bgDispatcher) {
         runCatching {
             val logsResult = getLogs().onFailure {
@@ -146,30 +140,38 @@ class LogsRepo @Inject constructor(
             val logsToZip = if (source != null) {
                 allLogs.filter { it.source == source }.take(limit)
             } else {
-                // Group by source and take most recent from each
-                allLogs.groupBy { it.source }
-                    .values
-                    .flatMap { logs ->
-                        val sourcesCount = LogSource.entries.filter { it != LogSource.Unknown }.size
-                        logs.take(limit / sourcesCount.coerceAtLeast(1))
-                    }
-                    .take(limit)
+                allLogs.take(limit)
             }
 
-            if (logsToZip.isEmpty()) {
-                return@withContext Result.failure(Exception("No log files found"))
-            }
-
-            return@runCatching createZipBase64(logsToZip)
+            return@runCatching createZipBase64(logsToZip, maxEncodedBytes)
         }.onFailure {
             Logger.error("Failed to zip logs", it, context = TAG)
         }
     }
 
     @Suppress("NestedBlockDepth")
-    private fun createZipBase64(logFiles: List<LogFile>): String {
-        val zipBytes = ByteArrayOutputStream().use { byteArrayOut ->
+    private fun createZipBase64(logFiles: List<LogFile>, maxEncodedBytes: Int?): String {
+        val selectedLogFiles = logFiles.toMutableList()
+
+        while (true) {
+            val encoded = createZipBytes(selectedLogFiles).toBase64()
+            if (maxEncodedBytes == null || encoded.length <= maxEncodedBytes || selectedLogFiles.isEmpty()) {
+                Logger.info("Created support logs archive with '${selectedLogFiles.size}' log file(s)", context = TAG)
+                return encoded
+            }
+
+            selectedLogFiles.removeAt(selectedLogFiles.lastIndex)
+        }
+    }
+
+    @Suppress("NestedBlockDepth")
+    private fun createZipBytes(logFiles: List<LogFile>): ByteArray {
+        return ByteArrayOutputStream().use { byteArrayOut ->
             ZipOutputStream(byteArrayOut).use { zipOut ->
+                zipOut.putNextEntry(ZipEntry(SUPPORT_SNAPSHOT_FILE_NAME))
+                zipOut.write(createSupportSnapshot().toByteArray())
+                zipOut.closeEntry()
+
                 logFiles.forEach { logFile ->
                     if (logFile.file.exists()) {
                         val zipEntry = ZipEntry("${logFile.source.name.lowercase()}/${logFile.fileName}")
@@ -184,12 +186,97 @@ class LogsRepo @Inject constructor(
             }
             byteArrayOut.toByteArray()
         }
+    }
 
-        return zipBytes.toBase64()
+    private fun File.toLogFile(): LogFile {
+        val match = LOG_FILE_NAME_REGEX.matchEntire(name)
+        val serviceName = match
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+            ?: LogSource.Unknown.name
+        val timestamp = match?.groupValues?.getOrNull(2)?.replace("_", " ")
+        val part = match?.groupValues?.getOrNull(3)?.ifBlank { null }
+        val partSuffix = part?.let { " part $it" }.orEmpty()
+        val displayName = if (timestamp != null) {
+            "$serviceName Log: $timestamp$partSuffix"
+        } else {
+            "$serviceName Log: $name"
+        }
+
+        return LogFile(
+            displayName = displayName,
+            file = this,
+            source = getEnumValueOf<LogSource>(serviceName).getOrDefault(LogSource.Unknown),
+        )
+    }
+
+    private fun createSupportSnapshot(): String {
+        val state = lightningRepo.lightningState.value
+        val snapshot = SupportSnapshot(
+            generatedAt = currentLogTimestamp(),
+            platform = Env.platform,
+            version = Env.version,
+            network = Env.network.name,
+            nodeId = state.nodeId,
+            lifecycle = state.nodeLifecycleState.supportName(),
+            isSyncingWallet = state.isSyncingWallet,
+            isGeoBlocked = state.isGeoBlocked,
+            lastSuccessfulSyncAt = state.lastSuccessfulSyncAt?.toString(),
+            lastSyncError = state.lastSyncError?.javaClass?.simpleName,
+            blockHeight = state.nodeStatus?.currentBestBlock?.height?.toString(),
+            blockHash = state.nodeStatus?.currentBestBlock?.blockHash,
+            latestRgsSnapshotTimestamp = state.nodeStatus?.latestRgsSnapshotTimestamp?.toString(),
+            peers = state.peers.map {
+                SupportPeerSnapshot(
+                    nodeId = it.nodeId,
+                    address = it.address,
+                    isConnected = it.isConnected,
+                    isPersisted = it.isPersisted,
+                )
+            },
+            channels = state.channels.map {
+                SupportChannelSnapshot(
+                    channelId = it.channelId,
+                    counterpartyNodeId = it.counterpartyNodeId,
+                    isChannelReady = it.isChannelReady,
+                    isUsable = it.isUsable,
+                    isAnnounced = it.isAnnounced,
+                    channelValueSats = it.channelValueSats.toString(),
+                    outboundCapacityMsat = it.outboundCapacityMsat.toString(),
+                    inboundCapacityMsat = it.inboundCapacityMsat.toString(),
+                )
+            },
+            balances = state.balances?.let {
+                SupportBalanceSnapshot(
+                    totalOnchainBalanceSats = it.totalOnchainBalanceSats.toString(),
+                    spendableOnchainBalanceSats = it.spendableOnchainBalanceSats.toString(),
+                    totalAnchorChannelsReserveSats = it.totalAnchorChannelsReserveSats.toString(),
+                    totalLightningBalanceSats = it.totalLightningBalanceSats.toString(),
+                    lightningBalancesCount = it.lightningBalances.size,
+                    pendingChannelClosureBalancesCount = it.pendingBalancesFromChannelClosures.size,
+                )
+            },
+        )
+
+        return appJson.encodeToString(snapshot)
+    }
+
+    private fun createLogsArchiveFileName(): String {
+        return "bitkit_logs_${currentLogTimestamp()}.zip"
+    }
+
+    private fun currentLogTimestamp(): String {
+        return utcDateFormatterOf(DatePattern.LOG_FILE).format(Date())
     }
 
     private companion object {
         const val TAG = "SupportRepo"
+        const val MAX_SUPPORT_UPLOAD_BASE64_BYTES = 900 * 1024
+        const val SUPPORT_SNAPSHOT_FILE_NAME = "support_snapshot.json"
+        val LOG_FILE_NAME_REGEX = Regex(
+            "^([A-Za-z]+)_(\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2})(?:\\.part_(\\d{3}))?\\.log$"
+        )
     }
 }
 
@@ -200,3 +287,62 @@ data class LogFile(
 ) {
     val fileName: String get() = file.name
 }
+
+private fun NodeLifecycleState.supportName(): String = when (this) {
+    is NodeLifecycleState.Stopped -> "Stopped"
+    is NodeLifecycleState.Starting -> "Starting"
+    is NodeLifecycleState.Running -> "Running"
+    is NodeLifecycleState.Stopping -> "Stopping"
+    is NodeLifecycleState.Initializing -> "Initializing"
+    is NodeLifecycleState.ErrorStarting -> "ErrorStarting"
+}
+
+@Serializable
+private data class SupportSnapshot(
+    val generatedAt: String,
+    val platform: String,
+    val version: String,
+    val network: String,
+    val nodeId: String,
+    val lifecycle: String,
+    val isSyncingWallet: Boolean,
+    val isGeoBlocked: Boolean,
+    val lastSuccessfulSyncAt: String?,
+    val lastSyncError: String?,
+    val blockHeight: String?,
+    val blockHash: String?,
+    val latestRgsSnapshotTimestamp: String?,
+    val peers: List<SupportPeerSnapshot>,
+    val channels: List<SupportChannelSnapshot>,
+    val balances: SupportBalanceSnapshot?,
+)
+
+@Serializable
+private data class SupportPeerSnapshot(
+    val nodeId: String,
+    val address: String,
+    val isConnected: Boolean,
+    val isPersisted: Boolean,
+)
+
+@Serializable
+private data class SupportChannelSnapshot(
+    val channelId: String,
+    val counterpartyNodeId: String,
+    val isChannelReady: Boolean,
+    val isUsable: Boolean,
+    val isAnnounced: Boolean,
+    val channelValueSats: String,
+    val outboundCapacityMsat: String,
+    val inboundCapacityMsat: String,
+)
+
+@Serializable
+private data class SupportBalanceSnapshot(
+    val totalOnchainBalanceSats: String,
+    val spendableOnchainBalanceSats: String,
+    val totalAnchorChannelsReserveSats: String,
+    val totalLightningBalanceSats: String,
+    val lightningBalancesCount: Int,
+    val pendingChannelClosureBalancesCount: Int,
+)

--- a/app/src/main/java/to/bitkit/repositories/LogsRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LogsRepo.kt
@@ -44,7 +44,7 @@ class LogsRepo @Inject constructor(
     suspend fun postQuestion(email: String, message: String): Result<Unit> = withContext(bgDispatcher) {
         runCatching {
             val logsBase64 = zipLogs(maxEncodedBytes = MAX_SUPPORT_UPLOAD_BASE64_BYTES).getOrDefault("")
-            val logsFileName = createLogsArchiveFileName()
+            val logsFileName = createLogsArchiveFileName(SUPPORT_LOGS_ARCHIVE_PREFIX)
 
             chatwootHttpClient.postQuestion(
                 message = ChatwootMessage(
@@ -262,8 +262,8 @@ class LogsRepo @Inject constructor(
         return appJson.encodeToString(snapshot)
     }
 
-    private fun createLogsArchiveFileName(): String {
-        return "bitkit_logs_${currentLogTimestamp()}.zip"
+    private fun createLogsArchiveFileName(prefix: String = LOGS_ARCHIVE_PREFIX): String {
+        return "${prefix}_${currentLogTimestamp()}.zip"
     }
 
     private fun currentLogTimestamp(): String {
@@ -272,7 +272,9 @@ class LogsRepo @Inject constructor(
 
     private companion object {
         const val TAG = "SupportRepo"
+        const val LOGS_ARCHIVE_PREFIX = "bitkit_logs"
         const val MAX_SUPPORT_UPLOAD_BASE64_BYTES = 900 * 1024
+        const val SUPPORT_LOGS_ARCHIVE_PREFIX = "bitkit_support_logs"
         const val SUPPORT_SNAPSHOT_FILE_NAME = "support_snapshot.json"
         val LOG_FILE_NAME_REGEX = Regex(
             "^([A-Za-z]+)_(\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2})(?:\\.part_(\\d{3}))?\\.log$"

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -43,6 +43,7 @@ import to.bitkit.utils.measured
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @Singleton
@@ -176,7 +177,7 @@ class WalletRepo @Inject constructor(
         val startHeight = lightningRepo.lightningState.value.block()?.height
         Logger.debug("Sync $sourceLabel started at block height=$startHeight", context = TAG)
 
-        val result = measured(label = "Sync $sourceLabel", context = TAG) {
+        val result = measured(label = "Sync $sourceLabel", context = TAG, slowThreshold = SLOW_SYNC_THRESHOLD) {
             syncBalances()
             lightningRepo.sync().onSuccess {
                 syncBalances()
@@ -602,6 +603,7 @@ class WalletRepo @Inject constructor(
     private companion object {
         const val TAG = "WalletRepo"
         const val EVENT_SYNC_DEBOUNCE_MS = 500L
+        val SLOW_SYNC_THRESHOLD = 5.seconds
     }
 }
 

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -632,8 +632,26 @@ class LightningService @Inject constructor(
             Logger.info("Channel close initiated (force=$force): '$channelId'", context = TAG)
         } catch (e: NodeException) {
             val error = LdkError(e)
-            Logger.error("Error initiating channel close (force=$force): '$channelId'", error, context = TAG)
+            Logger.error("Failed to initiate channel close for '$channelId' with force '$force'", error, context = TAG)
+            logCloseChannelPeerState(node, channel)
             throw LdkError(e)
+        }
+    }
+
+    private fun logCloseChannelPeerState(node: Node, channel: ChannelDetails) {
+        runCatching {
+            val peer = node.listPeers().firstOrNull { it.nodeId == channel.counterpartyNodeId }
+            Logger.info(
+                "Collected close peer state for channel '${channel.channelId}': " +
+                    "counterparty='${channel.counterpartyNodeId}', " +
+                    "peerFound='${peer != null}', " +
+                    "peerAddress='${peer?.address}', " +
+                    "peerConnected='${peer?.isConnected}', " +
+                    "peerPersisted='${peer?.isPersisted}'",
+                context = TAG,
+            )
+        }.onFailure {
+            Logger.warn("Failed to collect close peer state for channel '${channel.channelId}'", it, context = TAG)
         }
     }
     // endregion

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/external/LnurlChannelViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/external/LnurlChannelViewModel.kt
@@ -12,10 +12,12 @@ import kotlinx.coroutines.launch
 import org.lightningdevkit.ldknode.PeerDetails
 import to.bitkit.R
 import to.bitkit.ext.of
+import to.bitkit.ext.uri
 import to.bitkit.models.Toast
 import to.bitkit.repositories.LightningRepo
 import to.bitkit.ui.Routes
 import to.bitkit.ui.shared.toast.ToastEventBus
+import to.bitkit.utils.Logger
 import javax.inject.Inject
 
 @HiltViewModel
@@ -57,6 +59,15 @@ class LnurlChannelViewModel @Inject constructor(
 
             // Connect to peer if not connected
             lightningRepo.connectPeer(peer)
+                .onSuccess {
+                    Logger.info("Connected LNURL channel peer '${peer.uri}'", context = TAG)
+                }.onFailure {
+                    Logger.warn(
+                        "Failed to connect LNURL channel peer '${peer.uri}' before channel request",
+                        it,
+                        context = TAG,
+                    )
+                }
 
             lightningRepo.requestLnurlChannel(callback = params.callback, k1 = params.k1, nodeId = nodeId)
                 .onSuccess {
@@ -80,6 +91,10 @@ class LnurlChannelViewModel @Inject constructor(
             title = context.getString(R.string.other__lnurl_channel_error),
             description = error.message ?: "Unknown error",
         )
+    }
+
+    private companion object {
+        const val TAG = "LnurlChannelViewModel"
     }
 }
 

--- a/app/src/main/java/to/bitkit/usecases/WipeWalletUseCase.kt
+++ b/app/src/main/java/to/bitkit/usecases/WipeWalletUseCase.kt
@@ -6,7 +6,6 @@ import to.bitkit.data.CacheStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.data.WidgetsStore
 import to.bitkit.data.keychain.Keychain
-import to.bitkit.env.Env
 import to.bitkit.repositories.ActivityRepo
 import to.bitkit.repositories.BackupRepo
 import to.bitkit.repositories.BlocktankRepo
@@ -72,10 +71,7 @@ class WipeWalletUseCase @Inject constructor(
             migrationService.markMigrationChecked()
 
             lightningRepo.wipeStorage(walletIndex)
-                .onSuccess {
-                    onSuccess()
-                    if (Env.isDebug) Logger.reset()
-                }
+                .onSuccess { onSuccess() }
                 .getOrThrow()
         }.onFailure {
             Logger.error("Wipe wallet error", it, context = TAG)

--- a/app/src/main/java/to/bitkit/utils/Logger.kt
+++ b/app/src/main/java/to/bitkit/utils/Logger.kt
@@ -226,7 +226,7 @@ class LogSaverImpl(
 
             // Apply retention in background without wiping useful startup context.
             CoroutineScope(Dispatchers.IO).launch {
-                cleanupOldLogFiles(activeLogFile = sessionFile)
+                enforceLogRetentionLimits(activeLogFile = sessionFile)
             }
         }
     }
@@ -239,16 +239,16 @@ class LogSaverImpl(
                 val sanitized = message.replace("\n", " ")
                 val bytes = "$sanitized\n".toByteArray()
                 val file = getWritableLogFile(bytes.size)
-                val shouldApplyRetention = currentLogFilePath != file.absolutePath
+                val previousLogFilePath = currentLogFilePath
                 currentLogFilePath = file.absolutePath
 
                 FileOutputStream(file, true).use { stream ->
                     stream.write(bytes)
                 }
 
-                if (shouldApplyRetention) {
+                if (previousLogFilePath != file.absolutePath) {
                     CoroutineScope(Dispatchers.IO).launch {
-                        cleanupOldLogFiles(activeLogFile = file)
+                        enforceLogRetentionLimits(activeLogFile = file)
                     }
                 }
             }.onFailure {
@@ -304,12 +304,12 @@ class LogSaverImpl(
         save(formatted)
     }
 
-    private fun cleanupOldLogFiles(
+    private fun enforceLogRetentionLimits(
         maxTotalSizeBytes: Long = MAX_LOG_RETENTION_BYTES,
         maxAgeDays: Long = MAX_LOG_RETENTION_DAYS,
         activeLogFile: File? = null,
     ) {
-        log("Applying log retention…", LogLevel.VERBOSE, Log::v)
+        log("Enforcing log retention limits…", LogLevel.VERBOSE, Log::v)
         val logDir = runCatching { Env.logDir }.getOrNull() ?: return
 
         val logFiles = logDir
@@ -346,7 +346,7 @@ class LogSaverImpl(
                 }
             }
 
-        log("Applied log retention.", LogLevel.VERBOSE, Log::v)
+        log("Enforced log retention limits.", LogLevel.VERBOSE, Log::v)
     }
 
     private fun deleteLogFile(file: File): Boolean {

--- a/app/src/main/java/to/bitkit/utils/Logger.kt
+++ b/app/src/main/java/to/bitkit/utils/Logger.kt
@@ -21,7 +21,9 @@ import java.io.FileOutputStream
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.measureTime
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTimedValue
 
 private const val APP = "APP"
 private const val COMPACT = false
@@ -30,6 +32,7 @@ private const val MAX_LOG_FILE_BYTES = 1L * 1024L * 1024L
 private const val MAX_LOG_RETENTION_BYTES = 500L * 1024L * 1024L
 private const val MAX_LOG_RETENTION_DAYS = 60L
 private const val MILLIS_IN_DAY = 24L * 60L * 60L * 1000L
+private val DEFAULT_SLOW_OPERATION_THRESHOLD = 1.seconds
 
 enum class LogSource { Ldk, Bitkit, Unknown }
 enum class LogLevel { PERF, VERBOSE, GOSSIP, TRACE, DEBUG, INFO, WARN, ERROR }
@@ -425,12 +428,12 @@ fun errorLogOf(e: Throwable): String = "[${e::class.simpleName}='${e.message}']"
 internal inline fun <T> measured(
     label: String,
     context: String,
+    slowThreshold: Duration = DEFAULT_SLOW_OPERATION_THRESHOLD,
     block: () -> T,
 ): T {
-    var result: T
-    val elapsed = measureTime {
-        result = block()
+    val timedValue = measureTimedValue(block)
+    if (Env.isDebug && timedValue.duration >= slowThreshold) {
+        Logger.perf("Measured '$label' in '${timedValue.duration}'", context = context)
     }
-    Logger.perf("$label took $elapsed", context = context)
-    return result
+    return timedValue.value
 }

--- a/app/src/main/java/to/bitkit/utils/Logger.kt
+++ b/app/src/main/java/to/bitkit/utils/Logger.kt
@@ -202,6 +202,7 @@ internal class LoggerImpl(
     ) {
         val message = formatLog(LogLevel.PERF, msg, context, path, line)
         Log.v(tag, message)
+        saver.save(message)
     }
 }
 
@@ -432,7 +433,7 @@ internal inline fun <T> measured(
     block: () -> T,
 ): T {
     val timedValue = measureTimedValue(block)
-    if (Env.isDebug && timedValue.duration >= slowThreshold) {
+    if (timedValue.duration >= slowThreshold) {
         Logger.perf("Measured '$label' in '${timedValue.duration}'", context = context)
     }
     return timedValue.value

--- a/app/src/main/java/to/bitkit/utils/Logger.kt
+++ b/app/src/main/java/to/bitkit/utils/Logger.kt
@@ -25,6 +25,11 @@ import kotlin.time.measureTime
 
 private const val APP = "APP"
 private const val COMPACT = false
+private const val LOG_FILE_EXTENSION = "log"
+private const val MAX_LOG_FILE_BYTES = 1L * 1024L * 1024L
+private const val MAX_LOG_RETENTION_BYTES = 500L * 1024L * 1024L
+private const val MAX_LOG_RETENTION_DAYS = 60L
+private const val MILLIS_IN_DAY = 24L * 60L * 60L * 1000L
 
 enum class LogSource { Ldk, Bitkit, Unknown }
 enum class LogLevel { PERF, VERBOSE, GOSSIP, TRACE, DEBUG, INFO, WARN, ERROR }
@@ -194,7 +199,6 @@ internal class LoggerImpl(
     ) {
         val message = formatLog(LogLevel.PERF, msg, context, path, line)
         Log.v(tag, message)
-        saver.save(message)
     }
 }
 
@@ -208,14 +212,18 @@ class LogSaverImpl(
     private val queue: CoroutineScope by lazy {
         CoroutineScope(newSingleThreadDispatcher(ServiceQueue.LOG.name) + SupervisorJob())
     }
+    private var currentLogFilePath: String? = null
 
     init {
         if (sessionFilePath.isNotEmpty()) {
+            val sessionFile = File(sessionFilePath)
+            currentLogFilePath = sessionFile.absolutePath
+            sessionFile.parentFile?.mkdirs()
             log("Log session initialized with file path: '$sessionFilePath'")
 
-            // Clean all old log files in background
+            // Apply retention in background without wiping useful startup context.
             CoroutineScope(Dispatchers.IO).launch {
-                cleanupOldLogFiles()
+                cleanupOldLogFiles(activeLogFile = sessionFile)
             }
         }
     }
@@ -226,13 +234,61 @@ class LogSaverImpl(
         queue.launch {
             runCatching {
                 val sanitized = message.replace("\n", " ")
-                FileOutputStream(File(sessionFilePath), true).use { stream ->
-                    stream.write("$sanitized\n".toByteArray())
+                val bytes = "$sanitized\n".toByteArray()
+                val file = getWritableLogFile(bytes.size)
+                val shouldApplyRetention = currentLogFilePath != file.absolutePath
+                currentLogFilePath = file.absolutePath
+
+                FileOutputStream(file, true).use { stream ->
+                    stream.write(bytes)
+                }
+
+                if (shouldApplyRetention) {
+                    CoroutineScope(Dispatchers.IO).launch {
+                        cleanupOldLogFiles(activeLogFile = file)
+                    }
                 }
             }.onFailure {
                 Log.e(APP, "Error writing to log file: '$sessionFilePath'", it)
             }
         }
+    }
+
+    private fun getWritableLogFile(nextWriteBytes: Int): File {
+        val sessionFile = File(sessionFilePath)
+        val sessionDir = sessionFile.parentFile ?: Env.logDir
+        val sessionName = sessionFile.nameWithoutExtension
+
+        sessionDir.mkdirs()
+
+        val currentFile = currentLogFilePath
+            ?.let(::File)
+            ?.takeIf {
+                it.parentFile?.absolutePath == sessionDir.absolutePath &&
+                    it.nameWithoutExtension.startsWith(sessionName)
+            }
+
+        if (currentFile != null && currentFile.hasRoomFor(nextWriteBytes)) {
+            return currentFile
+        }
+
+        var file = currentFile ?: sessionFile
+        var part = file.logPartNumber(sessionFile)
+        while (file.exists() && file.length() + nextWriteBytes > MAX_LOG_FILE_BYTES) {
+            part += 1
+            file = sessionDir.resolve("$sessionName.part_${part.toString().padStart(3, '0')}.$LOG_FILE_EXTENSION")
+        }
+
+        return file
+    }
+
+    private fun File.hasRoomFor(nextWriteBytes: Int): Boolean {
+        return !exists() || length() + nextWriteBytes <= MAX_LOG_FILE_BYTES
+    }
+
+    private fun File.logPartNumber(sessionFile: File): Int {
+        if (absolutePath == sessionFile.absolutePath) return 1
+        return nameWithoutExtension.substringAfter(".part_", "1").toIntOrNull() ?: 1
     }
 
     private fun log(
@@ -245,33 +301,58 @@ class LogSaverImpl(
         save(formatted)
     }
 
-    private fun cleanupOldLogFiles(maxTotalSizeMB: Int = 20) {
-        log("Deleting old log files…", LogLevel.VERBOSE, Log::v)
+    private fun cleanupOldLogFiles(
+        maxTotalSizeBytes: Long = MAX_LOG_RETENTION_BYTES,
+        maxAgeDays: Long = MAX_LOG_RETENTION_DAYS,
+        activeLogFile: File? = null,
+    ) {
+        log("Applying log retention…", LogLevel.VERBOSE, Log::v)
         val logDir = runCatching { Env.logDir }.getOrNull() ?: return
 
         val logFiles = logDir
-            .listFiles { file -> file.extension == "log" }
+            .listFiles { file -> file.extension == LOG_FILE_EXTENSION }
             ?: return
 
-        var totalSize = logFiles.sumOf { it.length() }
-        val maxSizeBytes = maxTotalSizeMB * 1024L * 1024L
+        val activeLogFilePath = activeLogFile?.absolutePath
+        val removableFiles = logFiles.filterNot { it.absolutePath == activeLogFilePath }
+        val oldestAllowedModifiedAt = System.currentTimeMillis() - maxAgeDays * MILLIS_IN_DAY
 
-        // Sort by creation date (oldest first)
-        logFiles
+        removableFiles
             .sortedBy { it.lastModified() }
             .forEach { file ->
-                if (totalSize <= maxSizeBytes) return
-
-                runCatching {
-                    log("Deleting old log file: '${file.name}'", LogLevel.DEBUG, Log::d)
-                    if (file.delete()) {
-                        totalSize -= file.length()
-                    }
-                }.onFailure {
-                    log("Failed to delete old log file: '${file.name}'", LogLevel.WARN, Log::w)
+                if (file.lastModified() < oldestAllowedModifiedAt) {
+                    deleteLogFile(file)
                 }
             }
-        log("Deleted all old log files.", LogLevel.VERBOSE, Log::v)
+
+        var totalSize = logDir
+            .listFiles { file -> file.extension == LOG_FILE_EXTENSION }
+            ?.sumOf { it.length() }
+            ?: return
+
+        logDir
+            .listFiles { file -> file.extension == LOG_FILE_EXTENSION }
+            ?.filterNot { it.absolutePath == activeLogFilePath }
+            ?.sortedBy { it.lastModified() }
+            ?.forEach { file ->
+                if (totalSize <= maxTotalSizeBytes) return@forEach
+
+                val fileSize = file.length()
+                if (deleteLogFile(file)) {
+                    totalSize -= fileSize
+                }
+            }
+
+        log("Applied log retention.", LogLevel.VERBOSE, Log::v)
+    }
+
+    private fun deleteLogFile(file: File): Boolean {
+        return runCatching {
+            log("Deleting old log file: '${file.name}'", LogLevel.DEBUG, Log::d)
+            file.delete()
+        }.onFailure {
+            log("Failed to delete old log file: '${file.name}'", LogLevel.WARN, Log::w)
+        }.getOrDefault(false)
     }
 
     companion object {

--- a/changelog.d/next/support-logs.fixed.md
+++ b/changelog.d/next/support-logs.fixed.md
@@ -1,0 +1,1 @@
+Improved support log handling so diagnostics stay smaller and include more useful Lightning connection details.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.45" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.46" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.42" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.43" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.43" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.44" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.44" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.45" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.41" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.42" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.40" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.41" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.39" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.40" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }


### PR DESCRIPTION
<!-- Changelog: Added in changelog.d/next/support-logs.fixed.md. -->

This PR:
1. Rotates persisted logs at about 1 MB, uses timestamped `bitkit_YYYY-MM-DD_HH-MM-SS` file names, and keeps retained logs bounded by age and total size.
2. Removes persisted PERF log spam while keeping thresholded slow-operation PERF logs persisted in every build.
3. Keeps persisted logs across wallet wipe/restore instead of clearing them as a debug-only side effect.
4. Codifies that persisted log tags, names, labels, and references must stay mechanically traceable to the caller instead of being rewritten as prose.
5. Improves support archives by adding a node/support snapshot and trimming included persisted logs to fit the upload limit.
6. Adds logging for Lightning peer and channel support summaries around node startup and LNURL channel connection failures.
7. Bumps ldk-node to `0.7.0-rc.46` from synonymdev/ldk-node#82 so announced restored channel counterparties can be recovered into the peer store, peer recovery remains retryable after transient persistence failures and RGS graph updates, live recovery respects explicit disconnects and last-channel closes during the current node instance, and concurrent persistent peer updates avoid the RGS recovery lock-order inversion fixed in rc.46.

### Description

This is the Bitkit side of the support-ticket cleanup around oversized persisted logs and restored external Lightning channels.

The log changes keep persisted logs useful for support without allowing one long TRACE session to dominate the archive. They also stop wallet wipe/restore from clearing logs, matching iOS and preserving the exact history support needs after a recovery flow. The peer diagnostics make it easier to see whether channels, connected peers, and persisted peers line up when investigating a wallet that has channel state but no usable peer connection.

The ldk-node bump consumes synonymdev/ldk-node#82 and release [v0.7.0-rc.46](https://github.com/synonymdev/ldk-node/releases/tag/v0.7.0-rc.46), which restores missing announced channel peers from the network graph during node startup, keeps recovery retryable after transient peer-store persistence failures, retries recovery after RGS graph updates, uses live exclusion locking so current-session disconnects and last-channel closes are not re-persisted by RGS recovery, and avoids a lock-order inversion between RGS recovery and concurrent persistent peer updates.

### Preview

N/A - logging changes.

### QA Notes

#### Manual Tests

##### Self-checks
- [x] **1.** Pixel 10 Pro dev build (`to.bitkit.dev`) -> launched app and inspected `files/logs` through `run-as`: new persisted logs are named `bitkit_YYYY-MM-DD_HH-MM-SS.log`.
- [x] **2.** Pixel 10 Pro dev build -> inflated the active persisted log above 1 MB, triggered in-app logging, and confirmed rotation continued in `bitkit_2026-05-17_18-44-47.part_002.log`.
- [x] **3.** Pixel 10 Pro dev build -> Drawer -> Support -> Report Issue: form opens from the support screen.

##### To Check
- [ ] **4.** Submit Report Issue and confirm archive upload includes recent persisted logs plus `support_snapshot.json`.
- [ ] **5.** `regression:` Recovery Mode -> wipe wallet -> restore wallet -> Drawer -> Support -> Report Issue: persisted logs from before the wipe are still available.
- [ ] **6.** Restored wallet with announced external LN channel -> launch Bitkit -> wait for node startup: counterparty peer is restored/reconnected without manually connecting it, and the channel becomes usable when the peer is online.
- [ ] **7.** LNURL channel flow with unreachable peer: failed peer connection is surfaced and logged before the channel request proceeds.

#### Automated Checks

- [x] `./gradlew assembleDevDebug --no-daemon` passed locally with ldk-node `0.7.0-rc.46`.
- [x] `./gradlew testDevDebugUnitTest --no-daemon` passed locally with ldk-node `0.7.0-rc.46`.
- [x] `./gradlew detekt --no-daemon` passed locally with ldk-node `0.7.0-rc.46`.
- [x] `./gradlew installDevDebug --no-daemon` installed the rc.46 dev build on `Pixel_9_36` (`emulator-5554`).
- [ ] Emulator smoke check with ldk-node `0.7.0-rc.46`: launched `to.bitkit.dev/to.bitkit.ui.MainActivity`; the wallet home screen rendered and the crash buffer stayed empty, but Android repeatedly showed `Bitkit Regtest isn't responding`. Logcat recorded `ANR in to.bitkit.dev` with `Input dispatching timed out`, so this smoke check is not marked passing.
- [x] `git diff --check`
- [x] Source check: `Logger.perf(...)` persists via `saver.save(message)` and `measured(...)` no longer checks `Env.isDebug`.
- [x] Source check: `WakeNodeWorker` keeps `measured(label = "doWork", context = TAG, ...)` and `AGENTS.md` has the short mechanical log naming rule.
- [x] Source check: `WipeWalletUseCase` no longer calls `Logger.reset()`, so wallet wipe/restore no longer clears persisted logs unless the user explicitly wipes logs.
- [x] Source check: `LogsRepo` creates `bitkit_logs_YYYY-MM-DD_HH-MM-SS.zip` for sharing and `bitkit_support_logs_YYYY-MM-DD_HH-MM-SS.zip` for support uploads, includes `support_snapshot.json`, and accepts rotated `.part_###.log` files.
- [x] Upstream validation: synonymdev/ldk-node#82 rebuilt bindings, release [v0.7.0-rc.46](https://github.com/synonymdev/ldk-node/releases/tag/v0.7.0-rc.46) is published, Android and JVM package publish workflows succeeded, and Bitkit depends on it.

#### CI Notes

- `claude-review` is currently failing because Claude Code subscription is no longer available; this is unrelated to the code under test.
