### PR TITLE
ai: batch agent validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,9 +161,9 @@ suspend fun getData(): Result<Data> = withContext(Dispatchers.IO) {
 ### Rules
 
 - USE coding rules from `.cursor/default.rules.mdc`
-- ALWAYS run `./gradlew compileDevDebugKotlin` after code changes to verify code compiles
-- ALWAYS run `./gradlew testDevDebugUnitTest` after code changes to verify tests succeed and fix accordingly
-- ALWAYS run `./gradlew detekt` after code changes to check for new lint issues and fix accordingly
+- For multi-step changes, stacked PR surgery, and review follow-up with several small edits, batch validation instead of running the full build/check suite after every edit. Run the relevant Gradle checks once the coherent change set is ready, before committing, updating a PR, or pushing.
+- Still run `./gradlew compileDevDebugKotlin`, `./gradlew testDevDebugUnitTest`, and `./gradlew detekt` before the final PR update/push for code changes, and fix failures before pushing.
+- Use narrower checks earlier only when they answer an immediate risk, e.g. a single unit test after touching focused business logic or a Kotlin compile after a risky refactor.
 - ALWAYS ask clarifying questions to ensure an optimal plan when encountering functional or technical uncertainties in requests
 - ALWAYS when fixing lint or test failures prefer to do the minimal amount of changes to fix the issues
 - USE single-line commit messages under 50 chars; use conventional commit messages template format: `feat: add something new`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,8 +161,9 @@ suspend fun getData(): Result<Data> = withContext(Dispatchers.IO) {
 ### Rules
 
 - USE coding rules from `.cursor/default.rules.mdc`
-- For multi-step changes, stacked PR surgery, and review follow-up with several small edits, batch validation instead of running the full build/check suite after every edit. Run the relevant Gradle checks once the coherent change set is ready, before committing, updating a PR, or pushing.
+- For multi-step changes, stacked PR surgery, and review follow-up with several small edits, batch validation instead of running the full build/check suite after every edit. Run the relevant Gradle checks once the coherent change set is ready, before updating a PR or pushing.
 - Still run `./gradlew compileDevDebugKotlin`, `./gradlew testDevDebugUnitTest`, and `./gradlew detekt` before the final PR update/push for code changes, and fix failures before pushing.
+- After fixing validation failures, rerun the narrowest useful check that proves the fix. If only test files changed, prefer the targeted test task and a test-focused lint/detekt check when the project tooling supports it; otherwise use the standard detekt task before pushing.
 - Use narrower checks earlier only when they answer an immediate risk, e.g. a single unit test after touching focused business logic or a Kotlin compile after a risky refactor.
 - ALWAYS ask clarifying questions to ensure an optimal plan when encountering functional or technical uncertainties in requests
 - ALWAYS when fixing lint or test failures prefer to do the minimal amount of changes to fix the issues


### PR DESCRIPTION
This PR updates the shared agent instructions to batch Gradle validation during multi-step or stacked PR work, while still requiring compile, unit tests, and detekt before the final PR update or push for code changes.

Rationale is that with the current setup, work is slowed down too much due to having to compile after every small change and when an AI agent is requested to do many changes, this accumulates.

Risk is minimized by still requiring validation to pass before PR update/push, and by rerunning the narrowest useful check after fixing validation failures.

### Description

- Replaces per-edit Gradle checks with a batched validation cadence for multi-step changes, stacked PR surgery, and review follow-up.
- Keeps final compile, unit test, and detekt checks required before pushing code changes.
- Narrows reruns after validation fixes, especially when only test files changed.
- Allows targeted checks earlier when they answer an immediate implementation risk.

### Preview

N/A

### QA Notes

#### Manual Tests

N/A

#### Automated Checks

- `git diff --check`
- Not run: Gradle checks skipped because this is a documentation-only change to agent instructions.
