### PR TITLE
fix: hide widget size label

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/widgets/components/WidgetSizeCarousel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/components/WidgetSizeCarousel.kt
@@ -15,16 +15,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import to.bitkit.R
-import to.bitkit.ui.components.Caption13Up
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.theme.Colors
 
 private const val PAGE_WIDE = 0
-private const val PAGE_SMALL = 1
+// private const val PAGE_SMALL = 1
 
 // temporarily removed until small size widgets variants are implemented
 private const val PAGE_COUNT = 1
@@ -65,20 +61,20 @@ fun WidgetSizeCarousel(
         }
 
         VerticalSpacer(16.dp)
-
-        Caption13Up(
-            text = stringResource(
-                when (pagerState.currentPage) {
-                    PAGE_SMALL -> R.string.widgets__widget__size_small
-                    else -> R.string.widgets__widget__size_wide
-                },
-            ),
-            color = Colors.White64,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("widget_size_label")
-        )
+        // temporarily removed until small size widgets variants are implemented
+        // Caption13Up(
+        //     text = stringResource(
+        //         when (pagerState.currentPage) {
+        //             PAGE_SMALL -> R.string.widgets__widget__size_small
+        //             else -> R.string.widgets__widget__size_wide
+        //         },
+        //     ),
+        //     color = Colors.White64,
+        //     textAlign = TextAlign.Center,
+        //     modifier = Modifier
+        //         .fillMaxWidth()
+        //         .testTag("widget_size_label")
+        // )
 
         VerticalSpacer(16.dp)
 


### PR DESCRIPTION
This PR temporarily hides the widget size label in the widget size carousel.

### Description

While only the wide widget size is available, the carousel shows a single page, so the "WIDE"/"SMALL" caption below it adds no value and is now commented out alongside the existing single-page setup. The label and its string lookup will be restored once the small size widget variants are implemented.

### Preview

[Screen_recording_20260521_085359.webm](https://github.com/user-attachments/assets/ee06607a-d6f5-4e14-aa1a-7ae4c0581f60)

### QA Notes

#### Manual Tests
- [x] **1.** Home → add/edit any widget → widget size carousel: single wide preview shows with no "WIDE"/"SMALL" caption below it.

#### Automated Checks
- N/A — UI-only change commenting out the size label; no automated coverage added or changed.
