### PR TITLE
fix: polish widget screens and previews

### DIFF
--- a/app/src/main/java/to/bitkit/appwidget/ui/weather/WeatherGlanceContent.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/weather/WeatherGlanceContent.kt
@@ -136,7 +136,7 @@ private fun FeeBlock(weather: WeatherModel, preferences: WeatherPreferences) {
 
     Column(modifier = GlanceModifier.fillMaxWidth()) {
         CaptionB(
-            text = context.getString(labelRes),
+            text = context.getString(labelRes).uppercase(),
             color = GlanceColors.textSecondary,
             maxLines = 1,
         )

--- a/app/src/main/java/to/bitkit/data/SettingsStore.kt
+++ b/app/src/main/java/to/bitkit/data/SettingsStore.kt
@@ -118,7 +118,6 @@ data class SettingsData(
     val isPinForPaymentsEnabled: Boolean = false,
     val isDevModeEnabled: Boolean = Env.isDebug,
     val showWidgets: Boolean = true,
-    val showWidgetTitles: Boolean = false,
     val lastUsedTags: List<String> = emptyList(),
     val enableSwipeToHideBalance: Boolean = true,
     val hideBalance: Boolean = false,

--- a/app/src/main/java/to/bitkit/repositories/WidgetsRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WidgetsRepo.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import to.bitkit.data.SettingsStore
 import to.bitkit.data.WidgetsData
 import to.bitkit.data.WidgetsStore
 import to.bitkit.data.dto.ArticleDTO
@@ -54,15 +53,12 @@ class WidgetsRepo @Inject constructor(
     private val weatherService: WeatherService,
     private val priceService: PriceService,
     private val widgetsStore: WidgetsStore,
-    private val settingsStore: SettingsStore,
 ) {
     private val repoScope = CoroutineScope(bgDispatcher + SupervisorJob())
     private val widgetJobs = ConcurrentHashMap<WidgetType, Job>()
 
     val widgetsDataFlow: StateFlow<WidgetsData> = widgetsStore.data
         .stateIn(repoScope, SharingStarted.Eagerly, WidgetsData())
-
-    val showWidgetTitles = settingsStore.data.map { it.showWidgetTitles }
 
     val articlesFlow: StateFlow<List<ArticleDTO>> = widgetsDataFlow
         .map { it.articles }

--- a/app/src/main/java/to/bitkit/services/MigrationService.kt
+++ b/app/src/main/java/to/bitkit/services/MigrationService.kt
@@ -914,7 +914,6 @@ class MigrationService @Inject constructor(
                 enableAutoReadClipboard = settings.enableAutoReadClipboard ?: current.enableAutoReadClipboard,
                 enableSendAmountWarning = settings.enableSendAmountWarning ?: current.enableSendAmountWarning,
                 showWidgets = settings.showWidgets ?: current.showWidgets,
-                showWidgetTitles = settings.showWidgetTitles ?: current.showWidgetTitles,
                 defaultTransactionSpeed = when (settings.transactionSpeed) {
                     "fast" -> TransactionSpeed.Fast
                     "slow" -> TransactionSpeed.Slow
@@ -2153,7 +2152,6 @@ data class RNSettings(
     val enableQuickpay: Boolean? = null,
     val quickpayAmount: Int? = null,
     val showWidgets: Boolean? = null,
-    val showWidgetTitles: Boolean? = null,
     val transactionSpeed: String? = null,
     val customFeeRate: Int? = null,
     val hideBalance: Boolean? = null,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeUiState.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeUiState.kt
@@ -21,7 +21,6 @@ data class HomeUiState(
     val suggestions: ImmutableList<Suggestion> = persistentListOf(),
     val banners: ImmutableList<BannerItem> = persistentListOf(),
     val showWidgets: Boolean = false,
-    val showWidgetTitles: Boolean = false,
     val widgetsWithPosition: ImmutableList<WidgetWithPosition> = persistentListOf(),
     val headlinePreferences: HeadlinePreferences = HeadlinePreferences(),
     val currentArticle: ArticleModel? = null,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -85,7 +85,6 @@ class HomeViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         showWidgets = settings.showWidgets,
-                        showWidgetTitles = settings.showWidgetTitles,
                         widgetsWithPosition = if (it.isEditingWidgets &&
                             it.widgetsWithPosition.size == widgetsData.widgets.size
                         ) {

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksViewModel.kt
@@ -45,13 +45,6 @@ class BlocksViewModel @Inject constructor(
             initialValue = false
         )
 
-    val showWidgetTitles: StateFlow<Boolean> = widgetsRepo.showWidgetTitles
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT),
-            initialValue = true
-        )
-
     val currentBlock: StateFlow<BlockModel?> = widgetsRepo.blocksFlow.map { block ->
         block?.toBlockModel()
     }.stateIn(

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceEditScreen.kt
@@ -130,7 +130,7 @@ fun PriceEditContent(
 
             Column {
                 AppTopBar(
-                    titleText = stringResource(R.string.widgets__widget__edit),
+                    titleText = stringResource(R.string.widgets__price__name),
                     onBackClick = onBack,
                     modifier = Modifier.background(
                         Brush.verticalGradient(

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PricePreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PricePreviewScreen.kt
@@ -121,7 +121,7 @@ fun PricePreviewContent(
             )
 
             SettingsButtonRow(
-                title = stringResource(R.string.widgets__widget__edit),
+                title = stringResource(R.string.widgets__widget__settings),
                 value = SettingsButtonValue.StringValue(
                     if (pricePreferences == PricePreferences()) {
                         stringResource(R.string.widgets__widget__edit_default)

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/suggestions/SuggestionsViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/suggestions/SuggestionsViewModel.kt
@@ -27,9 +27,6 @@ class SuggestionsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(SUBSCRIBE_TIMEOUT), false)
 
-    val showWidgetTitles: StateFlow<Boolean> = widgetsRepo.showWidgetTitles
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(SUBSCRIBE_TIMEOUT), false)
-
     fun addWidget() {
         viewModelScope.launch {
             widgetsRepo.addWidget(WidgetType.SUGGESTIONS)

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherViewModel.kt
@@ -47,13 +47,6 @@ class WeatherViewModel @Inject constructor(
             initialValue = false
         )
 
-    val showWidgetTitles: StateFlow<Boolean> = widgetsRepo.showWidgetTitles
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT),
-            initialValue = true
-        )
-
     val currentWeather: StateFlow<WeatherModel?> = combine(
         widgetsRepo.weatherFlow,
         currencyRepo.currencyState,

--- a/app/src/main/java/to/bitkit/ui/settings/general/WidgetsSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/general/WidgetsSettingsScreen.kt
@@ -37,14 +37,11 @@ fun WidgetsSettingsScreen(
     val settings = settingsViewModel ?: return
 
     val showWidgets by settings.showWidgets.collectAsStateWithLifecycle()
-    val showWidgetTitles by settings.showWidgetTitles.collectAsStateWithLifecycle()
 
     WidgetsSettingsContent(
         onBackClick = { navController.popBackStack() },
         showWidgets = showWidgets,
-        showWidgetTitles = showWidgetTitles,
         onShowWidgetsClick = { settings.setShowWidgets(!showWidgets) },
-        onShowWidgetTitlesClick = { settings.setShowWidgetTitles(!showWidgetTitles) },
         onResetWidgetsClick = {
             settings.resetWidgets()
             navController.navigateToHome()
@@ -59,10 +56,8 @@ fun WidgetsSettingsScreen(
 @Composable
 private fun WidgetsSettingsContent(
     showWidgets: Boolean,
-    showWidgetTitles: Boolean,
     onBackClick: () -> Unit = {},
     onShowWidgetsClick: () -> Unit = {},
-    onShowWidgetTitlesClick: () -> Unit = {},
     onResetWidgetsClick: () -> Unit = {},
     onResetSuggestionsClick: () -> Unit = {},
 ) {
@@ -88,12 +83,6 @@ private fun WidgetsSettingsContent(
                 isChecked = showWidgets,
                 onClick = onShowWidgetsClick,
                 modifier = Modifier.testTag("ShowWidgets"),
-            )
-            SettingsSwitchRow(
-                title = stringResource(R.string.settings__widgets__showWidgetTitles),
-                isChecked = showWidgetTitles,
-                onClick = onShowWidgetTitlesClick,
-                modifier = Modifier.testTag("ShowWidgetTitles"),
             )
 
             // Reset section
@@ -152,7 +141,6 @@ private fun Preview() {
     AppThemeSurface {
         WidgetsSettingsContent(
             showWidgets = true,
-            showWidgetTitles = false,
         )
     }
 }

--- a/app/src/main/java/to/bitkit/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/SettingsViewModel.kt
@@ -179,15 +179,6 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    val showWidgetTitles = settingsStore.data.map { it.showWidgetTitles }
-        .asStateFlow(initialValue = false)
-
-    fun setShowWidgetTitles(value: Boolean) {
-        viewModelScope.launch {
-            settingsStore.update { it.copy(showWidgetTitles = value) }
-        }
-    }
-
     fun resetDismissedSuggestions() {
         viewModelScope.launch {
             settingsStore.update { it.copy(dismissedSuggestions = emptyList()) }

--- a/app/src/main/res/drawable/appwidget_background.xml
+++ b/app/src/main/res/drawable/appwidget_background.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="16dp" />
-    <solid android:color="@color/gray5" />
+    <solid android:color="@color/gray6" />
 </shape>

--- a/app/src/main/res/layout/appwidget_preview_blocks.xml
+++ b/app/src/main/res/layout/appwidget_preview_blocks.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/gray5"
+    android:background="@color/gray6"
     android:orientation="vertical"
     android:padding="16dp"
     tools:ignore="HardcodedText">

--- a/app/src/main/res/layout/appwidget_preview_facts.xml
+++ b/app/src/main/res/layout/appwidget_preview_facts.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/gray5"
+    android:background="@color/gray6"
     android:gravity="top"
     android:orientation="horizontal"
     android:padding="16dp"

--- a/app/src/main/res/layout/appwidget_preview_headlines.xml
+++ b/app/src/main/res/layout/appwidget_preview_headlines.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/gray5"
+    android:background="@color/gray6"
     android:orientation="vertical"
     android:padding="16dp"
     tools:ignore="HardcodedText">

--- a/app/src/main/res/layout/appwidget_preview_price.xml
+++ b/app/src/main/res/layout/appwidget_preview_price.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/gray5"
+    android:background="@color/gray6"
     android:orientation="vertical"
     android:padding="16dp"
     tools:ignore="HardcodedText">

--- a/app/src/main/res/layout/appwidget_preview_weather.xml
+++ b/app/src/main/res/layout/appwidget_preview_weather.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/gray5"
+    android:background="@color/gray6"
     android:gravity="top"
     android:orientation="horizontal"
     android:padding="16dp"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Bitkit من تصميم Synonym Software, S.A. DE C.V. ©2025. جميع الحقوق محفوظة.</string>
     <string name="settings__support_title">الدعم</string>
     <string name="settings__widgets__nav_title">الأدوات</string>
-    <string name="settings__widgets__showWidgetTitles">عرض عناوين الأدوات</string>
     <string name="settings__widgets__showWidgets">الأدوات</string>
     <string name="settings__widgets__reset_suggestions">إعادة تعيين بطاقات الاقتراحات</string>
     <string name="settings__widgets__reset_widgets">إعادة تعيين الأدوات</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Bitkit fue creado por Synonym Software, S.A. DE C.V. ©2025. Todos los derechos reservados.</string>
     <string name="settings__support_title">Soporte</string>
     <string name="settings__widgets__nav_title">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Mostrar títulos de widgets</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
     <string name="settings__widgets__reset_suggestions">Restablecer tarjetas de sugerencias</string>
     <string name="settings__widgets__reset_widgets">Restablecer widgets</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Bitkit ha estat creat per Synonym Software, S.A. DE C.V. ©2025. Tots els drets reservats.</string>
     <string name="settings__support_title">Suport</string>
     <string name="settings__widgets__nav_title">Ginys</string>
-    <string name="settings__widgets__showWidgetTitles">Mostrar títols de ginys</string>
     <string name="settings__widgets__showWidgets">Ginys</string>
     <string name="settings__widgets__reset_suggestions">Restablir targetes de suggeriments</string>
     <string name="settings__widgets__reset_widgets">Restablir widgets</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Bitkit vytvořila společnost Synonym Software, S.A. DE C.V. ©2025. Všechna práva vyhrazena.</string>
     <string name="settings__support_title">Podpora</string>
     <string name="settings__widgets__nav_title">Widgety</string>
-    <string name="settings__widgets__showWidgetTitles">Zobrazit názvy widgetů</string>
     <string name="settings__widgets__showWidgets">Widgety</string>
     <string name="settings__widgets__reset_suggestions">Resetovat karty návrhů</string>
     <string name="settings__widgets__reset_widgets">Resetovat widgety</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -562,7 +562,6 @@
     <string name="settings__general__section_payments">Zahlungen</string>
     <string name="settings__widgets__nav_title">Widgets</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Titel anzeigen</string>
     <string name="settings__widgets__reset_suggestions">Vorschlagskarten zurücksetzen</string>
     <string name="settings__widgets__reset_widgets">Widgets zurücksetzen</string>
     <string name="settings__widgets__reset_widgets_dialog_description">Bist du sicher, dass du die Widgets zurücksetzen möchtest? Die Standard-Widgets mit Standardkonfigurationen werden angezeigt.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Το Bitkit δημιουργήθηκε από τη Synonym Software, S.A. DE C.V. ©2025. Με επιφύλαξη παντός δικαιώματος.</string>
     <string name="settings__support_title">Υποστήριξη</string>
     <string name="settings__widgets__nav_title">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Εμφάνιση τίτλων Widget</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
     <string name="settings__widgets__reset_suggestions">Επαναφορά καρτών προτάσεων</string>
     <string name="settings__widgets__reset_widgets">Επαναφορά widgets</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Bitkit fue creado por Synonym Software, S.A. DE C.V. ©2025. Todos los derechos reservados.</string>
     <string name="settings__support_title">Soporte</string>
     <string name="settings__widgets__nav_title">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Mostrar Títulos de Widgets</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
     <string name="settings__widgets__reset_suggestions">Restablecer tarjetas de sugerencias</string>
     <string name="settings__widgets__reset_widgets">Restablecer widgets</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -562,7 +562,6 @@
     <string name="settings__general__section_payments">Pagos</string>
     <string name="settings__widgets__nav_title">Widgets</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Mostrar Títulos de Widgets</string>
     <string name="settings__widgets__reset_suggestions">Restablecer tarjetas de sugerencias</string>
     <string name="settings__widgets__reset_widgets">Restablecer widgets</string>
     <string name="settings__widgets__reset_widgets_dialog_description">¿Estás seguro de que deseas restablecer los widgets? Se mostrará el conjunto de widgets predeterminado con las configuraciones predeterminadas.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -562,7 +562,6 @@
     <string name="settings__general__section_payments">Paiements</string>
     <string name="settings__widgets__nav_title">Widgets</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Afficher les titres des widgets</string>
     <string name="settings__widgets__reset_suggestions">Réinitialiser les cartes de suggestions</string>
     <string name="settings__widgets__reset_widgets">Réinitialiser les widgets</string>
     <string name="settings__widgets__reset_widgets_dialog_description">Êtes-vous sûr de vouloir réinitialiser les widgets ? L\'ensemble de widgets par défaut avec les configurations par défaut sera affiché.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Bitkit è stato realizzato da Synonym Software, S.A. DE C.V. ©2025. Tutti i diritti riservati.</string>
     <string name="settings__support_title">Supporto</string>
     <string name="settings__widgets__nav_title">Widget</string>
-    <string name="settings__widgets__showWidgetTitles">Mostra titoli dei widget</string>
     <string name="settings__widgets__showWidgets">Widget</string>
     <string name="settings__widgets__reset_suggestions">Reimposta schede suggerimenti</string>
     <string name="settings__widgets__reset_widgets">Reimposta widget</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Bitkit is gemaakt door Synonym Software, S.A. DE C.V. ©2025. Alle rechten voorbehouden.</string>
     <string name="settings__support_title">Ondersteuning</string>
     <string name="settings__widgets__nav_title">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Widgettitels tonen</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
     <string name="settings__widgets__reset_suggestions">Suggestiekaarten resetten</string>
     <string name="settings__widgets__reset_widgets">Widgets resetten</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -560,7 +560,6 @@
     <string name="settings__general__section_payments">Płatności</string>
     <string name="settings__widgets__nav_title">Widgety</string>
     <string name="settings__widgets__showWidgets">Widgety</string>
-    <string name="settings__widgets__showWidgetTitles">Pokazuj tytuły widgetów</string>
     <string name="settings__widgets__reset_suggestions">Resetuj karty sugestii</string>
     <string name="settings__widgets__reset_widgets">Resetuj widgety</string>
     <string name="settings__widgets__reset_widgets_dialog_description">Czy na pewno chcesz zresetować widgety? Zostanie wyświetlony domyślny zestaw widgetów z domyślnymi konfiguracjami.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -728,7 +728,6 @@
     <string name="settings__support__copyright">Bitkit foi criado pela Synonym Software, S.A. DE C.V. ©2025. Todos os direitos reservados.</string>
     <string name="settings__support_title">Suporte</string>
     <string name="settings__widgets__nav_title">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Mostrar Títulos dos Widgets</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
     <string name="settings__widgets__reset_suggestions">Redefinir cartões de sugestões</string>
     <string name="settings__widgets__reset_widgets">Redefinir widgets</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -559,7 +559,6 @@
     <string name="settings__general__section_payments">Pagamentos</string>
     <string name="settings__widgets__nav_title">Widgets</string>
     <string name="settings__widgets__showWidgets">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Mostrar Títulos dos Widgets</string>
     <string name="settings__widgets__reset_suggestions">Repor cartões de sugestões</string>
     <string name="settings__widgets__reset_widgets">Repor widgets</string>
     <string name="settings__widgets__reset_widgets_dialog_description">Tem certeza de que deseja repor os widgets? O conjunto padrão de widgets com configurações padrão será exibido.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -744,7 +744,6 @@
     <string name="settings__support__copyright">Bitkit создан компанией Synonym Software, S.A. DE C.V. ©2025. Все права защищены.</string>
     <string name="settings__support_title">Поддержка</string>
     <string name="settings__widgets__nav_title">Виджеты</string>
-    <string name="settings__widgets__showWidgetTitles">Показывать Заголовки Виджетов</string>
     <string name="settings__widgets__showWidgets">Виджеты</string>
     <string name="settings__widgets__reset_suggestions">Сбросить карточки предложений</string>
     <string name="settings__widgets__reset_widgets">Сбросить виджеты</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <color name="brand">#FF4400</color>
     <color name="gray5">#FF2A2A2A</color>
+    <color name="gray6">#FF1C1C1C</color>
     <color name="brand_200">#FFF1EE</color>
     <color name="brand_500">#EF886A</color>
     <color name="teal_200">#03DAC5</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="brand">#FF4400</color>
-    <color name="gray5">#FF2A2A2A</color>
     <color name="gray6">#FF1C1C1C</color>
     <color name="brand_200">#FFF1EE</color>
     <color name="brand_500">#EF886A</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -900,7 +900,6 @@
     <string name="settings__support__title_unsuccess">Failed To Send</string>
     <string name="settings__support_title">Support</string>
     <string name="settings__widgets__nav_title">Widgets</string>
-    <string name="settings__widgets__showWidgetTitles">Show Widget Titles</string>
     <string name="settings__widgets__reset_suggestions">Reset Suggestions Cards</string>
     <string name="settings__widgets__reset_widgets">Reset Widgets</string>
     <string name="settings__widgets__reset_widgets_dialog_description">Are you sure you want to reset the widgets? The default widget set with default configurations will be displayed.</string>


### PR DESCRIPTION
This PR:
1. Renames the Bitcoin Price widget edit and preview screen titles for clarity
2. Uppercases the weather label on the OS home-screen widget
3. Darkens the in-app widget previews and OS widget background to gray6
4. Removes the non-functional "Show Widget Titles" setting and its plumbing
5. Removes the now-unused gray5 color

### Description

A set of small follow-up fixes on top of the widgets foundation work.

The Bitcoin Price widget edit screen now titles itself "Bitcoin Price" instead of the generic "Widget Feed", and the Price preview screen header now reads "Widget Settings". The weather label on the OS home-screen widget is now uppercased to match the other widget labels.

The in-app widget previews and the OS app widget background now use gray6 (#1C1C1C) instead of gray5, and the now-unused gray5 color has been removed.

The "Show Widget Titles" setting has been removed end-to-end: the toggle in Widget Settings, its persisted value, the migration mapping, and the now-dead flows across the Home, Blocks, Suggestions, and Weather view models. The flag was never read by any renderer, so removing it has no visible effect beyond dropping the inert toggle. Existing persisted values are ignored safely on read.

### Preview


[home-widgets.webm](https://github.com/user-attachments/assets/6937d7de-94c4-4763-8c15-332fe29cc125)

[in-app-widgets.webm](https://github.com/user-attachments/assets/58ba79ae-e597-4248-a531-a44651f671c6)

[removed-widget-title.webm](https://github.com/user-attachments/assets/954d22cb-3822-431c-936a-9cd174efa20b)

### QA Notes

#### Manual Tests
- [x] **1.** Home → add/edit Bitcoin Price widget → edit: AppBar title reads "Bitcoin Price" (not "Widget Feed").
- [x] **2.** Bitcoin Price widget → preview: AppBar title reads "Widget Settings".
- [x] **3.** Home screen (OS) → add Weather widget: the label is uppercased.
- [x] **4.** in-app widget previews (Blocks, Facts, Headlines, Price, Weather) → background: darker gray6 tone.
- [x] **5.** Home screen (OS) → any widget background: darker gray6 tone.
- [x] **6a.** Settings → Widgets: no "Show Widget Titles" toggle is shown.
  - [x] **6b.** remaining Widgets toggles and reset actions still work.

#### Automated Checks
- N/A — copy, color, and dead-code removal only; no automated coverage added or changed.
- Local: `compileDevDebugKotlin`, `testDevDebugUnitTest`, and `detekt` all pass.
