### PR TITLE
fix: pinned tabs with viewpager and drop shadow

### DIFF
--- a/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
+++ b/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
@@ -22,13 +22,15 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import to.bitkit.ui.theme.Colors
-import to.bitkit.ui.theme.TopBarGradient
 
 private val PinnedTabsShadowHeight = 32.dp
+private val PinnedTabsBlurRadius = 24.dp
 
 @Composable
 fun PinnedTabsScaffold(
@@ -41,6 +43,13 @@ fun PinnedTabsScaffold(
     var headerHeight by remember { mutableStateOf(0.dp) }
     val shadowBrush = remember {
         Brush.verticalGradient(colors = listOf(Colors.Black, Color.Transparent))
+    }
+    val hazeStyle = remember {
+        HazeStyle(
+            backgroundColor = Colors.Black,
+            tint = HazeTint(Colors.Black50),
+            blurRadius = PinnedTabsBlurRadius,
+        )
     }
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -66,8 +75,7 @@ fun PinnedTabsScaffold(
                 .align(Alignment.TopStart)
                 .fillMaxWidth()
                 .zIndex(2f)
-                .hazeEffect(state = hazeState)
-                .background(TopBarGradient)
+                .hazeEffect(state = hazeState, style = hazeStyle)
                 .onSizeChanged { headerHeight = with(density) { it.height.toDp() } }
         ) {
             header()

--- a/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
+++ b/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
@@ -22,7 +22,11 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.TopBarGradient
 
 private val PinnedTabsShadowHeight = 32.dp
 
@@ -32,6 +36,7 @@ fun PinnedTabsScaffold(
     modifier: Modifier = Modifier,
     content: @Composable (topPadding: Dp) -> Unit,
 ) {
+    val hazeState = rememberHazeState()
     val density = LocalDensity.current
     var headerHeight by remember { mutableStateOf(0.dp) }
     val shadowBrush = remember {
@@ -39,7 +44,13 @@ fun PinnedTabsScaffold(
     }
 
     Box(modifier = modifier.fillMaxSize()) {
-        content(headerHeight)
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .hazeSource(hazeState)
+        ) {
+            content(headerHeight)
+        }
 
         Box(
             modifier = Modifier
@@ -54,8 +65,9 @@ fun PinnedTabsScaffold(
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .fillMaxWidth()
-                .background(Colors.Black)
                 .zIndex(2f)
+                .hazeEffect(state = hazeState)
+                .background(TopBarGradient)
                 .onSizeChanged { headerHeight = with(density) { it.height.toDp() } }
         ) {
             header()

--- a/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
+++ b/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
@@ -7,21 +7,14 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeEffect
@@ -32,6 +25,8 @@ import to.bitkit.ui.theme.Colors
 private val PinnedTabsShadowHeight = 32.dp
 private val PinnedTabsBlurRadius = 24.dp
 
+private enum class PinnedTabsSlot { Header, Content, Shadow }
+
 @Composable
 fun PinnedTabsScaffold(
     header: @Composable ColumnScope.() -> Unit,
@@ -39,8 +34,6 @@ fun PinnedTabsScaffold(
     content: @Composable (topPadding: Dp) -> Unit,
 ) {
     val hazeState = rememberHazeState()
-    val density = LocalDensity.current
-    var headerHeight by remember { mutableStateOf(0.dp) }
     val shadowBrush = remember {
         Brush.verticalGradient(colors = listOf(Colors.Black, Color.Transparent))
     }
@@ -52,33 +45,44 @@ fun PinnedTabsScaffold(
         )
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .hazeSource(hazeState)
-        ) {
-            content(headerHeight)
-        }
+    SubcomposeLayout(modifier = modifier.fillMaxSize()) { constraints ->
+        val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .offset(y = headerHeight)
-                .height(PinnedTabsShadowHeight)
-                .background(shadowBrush)
-                .zIndex(1f)
-        )
+        val headerPlaceables = subcompose(PinnedTabsSlot.Header) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .hazeEffect(state = hazeState, style = hazeStyle),
+                content = { header() },
+            )
+        }.map { it.measure(looseConstraints) }
 
-        Column(
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .fillMaxWidth()
-                .zIndex(2f)
-                .hazeEffect(state = hazeState, style = hazeStyle)
-                .onSizeChanged { headerHeight = with(density) { it.height.toDp() } }
-        ) {
-            header()
+        val headerHeightPx = headerPlaceables.maxOfOrNull { it.height } ?: 0
+        val headerHeightDp = headerHeightPx.toDp()
+
+        val contentPlaceables = subcompose(PinnedTabsSlot.Content) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .hazeSource(hazeState)
+            ) {
+                content(headerHeightDp)
+            }
+        }.map { it.measure(constraints) }
+
+        val shadowPlaceables = subcompose(PinnedTabsSlot.Shadow) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(PinnedTabsShadowHeight)
+                    .background(shadowBrush)
+            )
+        }.map { it.measure(looseConstraints) }
+
+        layout(constraints.maxWidth, constraints.maxHeight) {
+            contentPlaceables.forEach { it.placeRelative(0, 0) }
+            shadowPlaceables.forEach { it.placeRelative(0, headerHeightPx) }
+            headerPlaceables.forEach { it.placeRelative(0, 0) }
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
+++ b/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
@@ -1,0 +1,64 @@
+package to.bitkit.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import to.bitkit.ui.theme.Colors
+
+private val PinnedTabsShadowHeight = 32.dp
+
+@Composable
+fun PinnedTabsScaffold(
+    header: @Composable ColumnScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (topPadding: Dp) -> Unit,
+) {
+    val density = LocalDensity.current
+    var headerHeight by remember { mutableStateOf(0.dp) }
+    val shadowBrush = remember {
+        Brush.verticalGradient(colors = listOf(Colors.Black, Color.Transparent))
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        content(headerHeight)
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .offset(y = headerHeight)
+                .height(PinnedTabsShadowHeight)
+                .background(shadowBrush)
+                .zIndex(1f)
+        )
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .fillMaxWidth()
+                .background(Colors.Black)
+                .zIndex(2f)
+                .onSizeChanged { headerHeight = with(density) { it.height.toDp() } }
+        ) {
+            header()
+        }
+    }
+}

--- a/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
+++ b/app/src/main/java/to/bitkit/ui/components/PinnedTabsScaffold.kt
@@ -47,7 +47,7 @@ fun PinnedTabsScaffold(
     val hazeStyle = remember {
         HazeStyle(
             backgroundColor = Colors.Black,
-            tint = HazeTint(Colors.Black50),
+            tint = HazeTint(Colors.Black70),
             blurRadius = PinnedTabsBlurRadius,
         )
     }

--- a/app/src/main/java/to/bitkit/ui/scaffold/PinnedTabsScaffold.kt
+++ b/app/src/main/java/to/bitkit/ui/scaffold/PinnedTabsScaffold.kt
@@ -1,4 +1,4 @@
-package to.bitkit.ui.components
+package to.bitkit.ui.scaffold
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
@@ -76,7 +76,7 @@ fun ShopDiscoverScreen(
     ScreenColumn(modifier = modifier) {
         PinnedTabsScaffold(
             header = {
-                Column(modifier = modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.fillMaxWidth()) {
                     AppTopBar(
                         titleText = stringResource(R.string.other__shop__discover__nav_title),
                         onBackClick = onBack,

--- a/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
@@ -74,21 +74,23 @@ fun ShopDiscoverScreen(
     val scope = rememberCoroutineScope()
 
     ScreenColumn(modifier = modifier) {
-        AppTopBar(
-            titleText = stringResource(R.string.other__shop__discover__nav_title),
-            onBackClick = onBack,
-            actions = { DrawerNavIcon() },
-        )
-
         PinnedTabsScaffold(
             header = {
-                CustomTabRowWithSpacing(
-                    tabs = tabs,
-                    currentTabIndex = pagerState.currentPage,
-                    selectedColor = Colors.White,
-                    onTabChange = { scope.launch { pagerState.animateScrollToPage(tabs.indexOf(it)) } },
-                    modifier = Modifier.padding(horizontal = 16.dp)
-                )
+                Column(modifier = modifier.fillMaxWidth()) {
+                    AppTopBar(
+                        titleText = stringResource(R.string.other__shop__discover__nav_title),
+                        onBackClick = onBack,
+                        actions = { DrawerNavIcon() },
+                    )
+
+                    CustomTabRowWithSpacing(
+                        tabs = tabs,
+                        currentTabIndex = pagerState.currentPage,
+                        selectedColor = Colors.White,
+                        onTabChange = { scope.launch { pagerState.animateScrollToPage(tabs.indexOf(it)) } },
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
             }
         ) { topPadding ->
             HorizontalPager(

--- a/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -23,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +36,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 import to.bitkit.R
 import to.bitkit.env.Env
 import to.bitkit.ext.configureForBasicWebContent
@@ -66,7 +70,8 @@ fun ShopDiscoverScreen(
     modifier: Modifier = Modifier,
 ) {
     val tabs = remember { ShopDiscoverTab.entries.toImmutableList() }
-    var selectedTab by remember { mutableStateOf(ShopDiscoverTab.Shop) }
+    val pagerState = rememberPagerState(pageCount = { tabs.size })
+    val scope = rememberCoroutineScope()
 
     ScreenColumn(modifier = modifier) {
         AppTopBar(
@@ -79,20 +84,25 @@ fun ShopDiscoverScreen(
             header = {
                 CustomTabRowWithSpacing(
                     tabs = tabs,
-                    currentTabIndex = tabs.indexOf(selectedTab),
+                    currentTabIndex = pagerState.currentPage,
                     selectedColor = Colors.White,
-                    onTabChange = { selectedTab = it },
+                    onTabChange = { scope.launch { pagerState.animateScrollToPage(tabs.indexOf(it)) } },
                     modifier = Modifier.padding(horizontal = 16.dp)
                 )
             }
         ) { topPadding ->
-            when (selectedTab) {
-                ShopDiscoverTab.Shop -> ShopTabContent(
-                    navigateWebView = navigateWebView,
-                    contentPadding = PaddingValues(top = topPadding, bottom = 42.dp),
-                )
+            HorizontalPager(
+                state = pagerState,
+                userScrollEnabled = tabs[pagerState.settledPage] != ShopDiscoverTab.Map,
+            ) { page ->
+                when (tabs[page]) {
+                    ShopDiscoverTab.Shop -> ShopTabContent(
+                        navigateWebView = navigateWebView,
+                        contentPadding = PaddingValues(top = topPadding, bottom = 42.dp),
+                    )
 
-                ShopDiscoverTab.Map -> MapTabContent(modifier = Modifier.padding(top = topPadding))
+                    ShopDiscoverTab.Map -> MapTabContent(modifier = Modifier.padding(top = topPadding))
+                }
             }
         }
     }

--- a/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
@@ -1,6 +1,7 @@
 package to.bitkit.ui.screens.shop.shopDiscover
 
 import android.annotation.SuppressLint
+import android.view.MotionEvent
 import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.annotation.StringRes
@@ -33,6 +34,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.collections.immutable.toImmutableList
@@ -93,17 +95,14 @@ fun ShopDiscoverScreen(
                 }
             }
         ) { topPadding ->
-            HorizontalPager(
-                state = pagerState,
-                userScrollEnabled = tabs[pagerState.settledPage] != ShopDiscoverTab.Map,
-            ) { page ->
+            HorizontalPager(state = pagerState) { page ->
                 when (tabs[page]) {
                     ShopDiscoverTab.Shop -> ShopTabContent(
                         navigateWebView = navigateWebView,
                         contentPadding = PaddingValues(top = topPadding, bottom = 42.dp),
                     )
 
-                    ShopDiscoverTab.Map -> MapTabContent(modifier = Modifier.padding(top = topPadding))
+                    ShopDiscoverTab.Map -> MapTabContent(topPadding = topPadding)
                 }
             }
         }
@@ -237,10 +236,11 @@ private fun ShopTabContent(
     }
 }
 
-@SuppressLint("SetJavaScriptEnabled")
+@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
 @Composable
 private fun MapTabContent(
     modifier: Modifier = Modifier,
+    topPadding: Dp = 0.dp,
 ) {
     var isLoading by remember { mutableStateOf(true) }
 
@@ -253,7 +253,7 @@ private fun MapTabContent(
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .padding(start = 16.dp, end = 16.dp, top = 16.dp)
+            .padding(start = 16.dp, end = 16.dp, top = topPadding + 16.dp)
             .clip(Shapes.medium)
     ) {
         AndroidView(
@@ -266,6 +266,20 @@ private fun MapTabContent(
 
                     this.webViewClient = webViewClient
                     configureForBasicWebContent()
+                    // Keep the parent HorizontalPager from intercepting horizontal pans while the user is
+                    // interacting with the map. Outside the WebView bounds the pager still swipes normally.
+                    setOnTouchListener { view, event ->
+                        when (event.actionMasked) {
+                            MotionEvent.ACTION_DOWN,
+                            MotionEvent.ACTION_MOVE,
+                            -> view.parent?.requestDisallowInterceptTouchEvent(true)
+
+                            MotionEvent.ACTION_UP,
+                            MotionEvent.ACTION_CANCEL,
+                            -> view.parent?.requestDisallowInterceptTouchEvent(false)
+                        }
+                        false
+                    }
                     loadUrl(Env.BTC_MAP_URL)
                 }
             },

--- a/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -37,6 +38,7 @@ import to.bitkit.env.Env
 import to.bitkit.ext.configureForBasicWebContent
 import to.bitkit.models.BitrefillCategory
 import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.PinnedTabsScaffold
 import to.bitkit.ui.components.SuggestionCard
 import to.bitkit.ui.components.Text13Up
 import to.bitkit.ui.components.VerticalSpacer
@@ -73,17 +75,25 @@ fun ShopDiscoverScreen(
             actions = { DrawerNavIcon() },
         )
 
-        CustomTabRowWithSpacing(
-            tabs = tabs,
-            currentTabIndex = tabs.indexOf(selectedTab),
-            selectedColor = Colors.White,
-            onTabChange = { selectedTab = it },
-            modifier = Modifier.padding(horizontal = 16.dp)
-        )
+        PinnedTabsScaffold(
+            header = {
+                CustomTabRowWithSpacing(
+                    tabs = tabs,
+                    currentTabIndex = tabs.indexOf(selectedTab),
+                    selectedColor = Colors.White,
+                    onTabChange = { selectedTab = it },
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+        ) { topPadding ->
+            when (selectedTab) {
+                ShopDiscoverTab.Shop -> ShopTabContent(
+                    navigateWebView = navigateWebView,
+                    contentPadding = PaddingValues(top = topPadding, bottom = 42.dp),
+                )
 
-        when (selectedTab) {
-            ShopDiscoverTab.Shop -> ShopTabContent(navigateWebView = navigateWebView)
-            ShopDiscoverTab.Map -> MapTabContent()
+                ShopDiscoverTab.Map -> MapTabContent(modifier = Modifier.padding(top = topPadding))
+            }
         }
     }
 }
@@ -92,13 +102,13 @@ fun ShopDiscoverScreen(
 private fun ShopTabContent(
     navigateWebView: (String, String) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     LazyColumn(
+        contentPadding = contentPadding,
         modifier = modifier.padding(horizontal = 16.dp)
     ) {
         item {
-            VerticalSpacer(16.dp)
-
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
@@ -229,7 +239,7 @@ private fun MapTabContent(
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .padding(top = 16.dp, start = 16.dp, end = 16.dp)
+            .padding(start = 16.dp, end = 16.dp)
             .clip(Shapes.medium)
     ) {
         AndroidView(

--- a/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
@@ -119,6 +119,8 @@ private fun ShopTabContent(
         modifier = modifier.padding(horizontal = 16.dp)
     ) {
         item {
+            VerticalSpacer(16.dp)
+
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
@@ -249,7 +251,7 @@ private fun MapTabContent(
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .padding(start = 16.dp, end = 16.dp)
+            .padding(start = 16.dp, end = 16.dp, top = 16.dp)
             .clip(Shapes.medium)
     ) {
         AndroidView(

--- a/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/shop/shopDiscover/ShopDiscoverScreen.kt
@@ -42,12 +42,12 @@ import to.bitkit.env.Env
 import to.bitkit.ext.configureForBasicWebContent
 import to.bitkit.models.BitrefillCategory
 import to.bitkit.ui.components.BodyM
-import to.bitkit.ui.components.PinnedTabsScaffold
 import to.bitkit.ui.components.SuggestionCard
 import to.bitkit.ui.components.Text13Up
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
+import to.bitkit.ui.scaffold.PinnedTabsScaffold
 import to.bitkit.ui.scaffold.ScreenColumn
 import to.bitkit.ui.screens.wallets.activity.components.CustomTabRowWithSpacing
 import to.bitkit.ui.screens.wallets.activity.components.TabItem

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -793,6 +793,13 @@ private fun WidgetsPage(
                 text = stringResource(R.string.widgets__add),
                 onClick = onClickAddWidget,
                 enabled = !isCalculatorInputActive,
+                icon = {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_plus),
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                },
                 modifier = Modifier
                     .alpha(footerAlpha)
                     .testTag("WidgetsAdd")

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -3,14 +3,9 @@ package to.bitkit.ui.screens.wallets.activity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -23,7 +18,6 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.launch
 import to.bitkit.R
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.PinnedTabsScaffold
@@ -34,6 +28,7 @@ import to.bitkit.ui.screens.wallets.activity.components.ActivityListFilter
 import to.bitkit.ui.screens.wallets.activity.components.ActivityListGrouped
 import to.bitkit.ui.screens.wallets.activity.components.ActivityTab
 import to.bitkit.ui.screens.wallets.activity.utils.previewActivityItems
+import to.bitkit.ui.shared.modifiers.swipeToChangeTab
 import to.bitkit.ui.shared.util.screen
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.viewmodels.ActivityListViewModel
@@ -93,23 +88,6 @@ private fun AllActivityScreenContent(
     onActivityItemClick: (String) -> Unit,
     onEmptyActivityRowClick: () -> Unit,
 ) {
-    val pagerState = rememberPagerState(
-        initialPage = currentTabIndex,
-        pageCount = { tabs.size },
-    )
-    val scope = rememberCoroutineScope()
-
-    LaunchedEffect(pagerState.currentPage) {
-        if (pagerState.currentPage != currentTabIndex) {
-            onTabChange(pagerState.currentPage)
-        }
-    }
-    LaunchedEffect(currentTabIndex) {
-        if (currentTabIndex != pagerState.currentPage) {
-            pagerState.animateScrollToPage(currentTabIndex)
-        }
-    }
-
     Column(
         modifier = Modifier.screen()
     ) {
@@ -133,25 +111,26 @@ private fun AllActivityScreenContent(
                     onRemoveTag = onRemoveTag,
                     onDateRangeClick = onDateRangeClick,
                     tabs = tabs,
-                    currentTabIndex = pagerState.currentPage,
-                    onTabChange = { tab -> scope.launch { pagerState.animateScrollToPage(tabs.indexOf(tab)) } },
+                    currentTabIndex = currentTabIndex,
+                    onTabChange = { onTabChange(tabs.indexOf(it)) },
                     modifier = Modifier.padding(horizontal = 16.dp)
                 )
             }
         ) { topPadding ->
-            HorizontalPager(state = pagerState) { _ ->
-                key(currentTabIndex) {
-                    ActivityListGrouped(
-                        items = filteredActivities,
-                        onActivityItemClick = onActivityItemClick,
-                        onEmptyActivityRowClick = onEmptyActivityRowClick,
-                        contentPadding = PaddingValues(top = topPadding + 16.dp),
-                        modifier = Modifier
-                            .padding(horizontal = 16.dp)
-                            .testTag("ActivityList")
+            ActivityListGrouped(
+                items = filteredActivities,
+                onActivityItemClick = onActivityItemClick,
+                onEmptyActivityRowClick = onEmptyActivityRowClick,
+                contentPadding = PaddingValues(top = topPadding + 16.dp),
+                modifier = Modifier
+                    .swipeToChangeTab(
+                        currentTabIndex = currentTabIndex,
+                        tabCount = tabs.size,
+                        onTabChange = onTabChange,
                     )
-                }
-            }
+                    .padding(horizontal = 16.dp)
+                    .testTag("ActivityList")
+            )
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -117,20 +118,22 @@ private fun AllActivityScreenContent(
                 )
             }
         ) { topPadding ->
-            ActivityListGrouped(
-                items = filteredActivities,
-                onActivityItemClick = onActivityItemClick,
-                onEmptyActivityRowClick = onEmptyActivityRowClick,
-                contentPadding = PaddingValues(top = topPadding + 16.dp),
-                modifier = Modifier
-                    .swipeToChangeTab(
-                        currentTabIndex = currentTabIndex,
-                        tabCount = tabs.size,
-                        onTabChange = onTabChange,
-                    )
-                    .padding(horizontal = 16.dp)
-                    .testTag("ActivityList")
-            )
+            key(currentTabIndex) {
+                ActivityListGrouped(
+                    items = filteredActivities,
+                    onActivityItemClick = onActivityItemClick,
+                    onEmptyActivityRowClick = onEmptyActivityRowClick,
+                    contentPadding = PaddingValues(top = topPadding + 16.dp),
+                    modifier = Modifier
+                        .swipeToChangeTab(
+                            currentTabIndex = currentTabIndex,
+                            tabCount = tabs.size,
+                            onTabChange = onTabChange,
+                        )
+                        .padding(horizontal = 16.dp)
+                        .testTag("ActivityList")
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -3,9 +3,14 @@ package to.bitkit.ui.screens.wallets.activity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -18,6 +23,7 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 import to.bitkit.R
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.PinnedTabsScaffold
@@ -28,7 +34,6 @@ import to.bitkit.ui.screens.wallets.activity.components.ActivityListFilter
 import to.bitkit.ui.screens.wallets.activity.components.ActivityListGrouped
 import to.bitkit.ui.screens.wallets.activity.components.ActivityTab
 import to.bitkit.ui.screens.wallets.activity.utils.previewActivityItems
-import to.bitkit.ui.shared.modifiers.swipeToChangeTab
 import to.bitkit.ui.shared.util.screen
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.viewmodels.ActivityListViewModel
@@ -88,6 +93,23 @@ private fun AllActivityScreenContent(
     onActivityItemClick: (String) -> Unit,
     onEmptyActivityRowClick: () -> Unit,
 ) {
+    val pagerState = rememberPagerState(
+        initialPage = currentTabIndex,
+        pageCount = { tabs.size },
+    )
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(pagerState.currentPage) {
+        if (pagerState.currentPage != currentTabIndex) {
+            onTabChange(pagerState.currentPage)
+        }
+    }
+    LaunchedEffect(currentTabIndex) {
+        if (currentTabIndex != pagerState.currentPage) {
+            pagerState.animateScrollToPage(currentTabIndex)
+        }
+    }
+
     Column(
         modifier = Modifier.screen()
     ) {
@@ -111,26 +133,25 @@ private fun AllActivityScreenContent(
                     onRemoveTag = onRemoveTag,
                     onDateRangeClick = onDateRangeClick,
                     tabs = tabs,
-                    currentTabIndex = currentTabIndex,
-                    onTabChange = { onTabChange(tabs.indexOf(it)) },
+                    currentTabIndex = pagerState.currentPage,
+                    onTabChange = { tab -> scope.launch { pagerState.animateScrollToPage(tabs.indexOf(tab)) } },
                     modifier = Modifier.padding(horizontal = 16.dp)
                 )
             }
         ) { topPadding ->
-            ActivityListGrouped(
-                items = filteredActivities,
-                onActivityItemClick = onActivityItemClick,
-                onEmptyActivityRowClick = onEmptyActivityRowClick,
-                contentPadding = PaddingValues(top = topPadding),
-                modifier = Modifier
-                    .swipeToChangeTab(
-                        currentTabIndex = currentTabIndex,
-                        tabCount = tabs.size,
-                        onTabChange = onTabChange,
+            HorizontalPager(state = pagerState) { _ ->
+                key(currentTabIndex) {
+                    ActivityListGrouped(
+                        items = filteredActivities,
+                        onActivityItemClick = onActivityItemClick,
+                        onEmptyActivityRowClick = onEmptyActivityRowClick,
+                        contentPadding = PaddingValues(top = topPadding + 16.dp),
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .testTag("ActivityList")
                     )
-                    .padding(horizontal = 16.dp)
-                    .testTag("ActivityList")
-            )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -3,10 +3,11 @@ package to.bitkit.ui.screens.wallets.activity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -89,6 +90,12 @@ private fun AllActivityScreenContent(
     onActivityItemClick: (String) -> Unit,
     onEmptyActivityRowClick: () -> Unit,
 ) {
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(currentTabIndex) {
+        listState.scrollToItem(0)
+    }
+
     Column(
         modifier = Modifier.screen()
     ) {
@@ -118,22 +125,21 @@ private fun AllActivityScreenContent(
                 )
             }
         ) { topPadding ->
-            key(currentTabIndex) {
-                ActivityListGrouped(
-                    items = filteredActivities,
-                    onActivityItemClick = onActivityItemClick,
-                    onEmptyActivityRowClick = onEmptyActivityRowClick,
-                    contentPadding = PaddingValues(top = topPadding + 16.dp),
-                    modifier = Modifier
-                        .swipeToChangeTab(
-                            currentTabIndex = currentTabIndex,
-                            tabCount = tabs.size,
-                            onTabChange = onTabChange,
-                        )
-                        .padding(horizontal = 16.dp)
-                        .testTag("ActivityList")
-                )
-            }
+            ActivityListGrouped(
+                items = filteredActivities,
+                onActivityItemClick = onActivityItemClick,
+                onEmptyActivityRowClick = onEmptyActivityRowClick,
+                listState = listState,
+                contentPadding = PaddingValues(top = topPadding + 16.dp),
+                modifier = Modifier
+                    .swipeToChangeTab(
+                        currentTabIndex = currentTabIndex,
+                        tabCount = tabs.size,
+                        onTabChange = onTabChange,
+                    )
+                    .padding(horizontal = 16.dp)
+                    .testTag("ActivityList")
+            )
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -22,10 +22,10 @@ import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.ui.appViewModel
-import to.bitkit.ui.components.PinnedTabsScaffold
 import to.bitkit.ui.components.Sheet
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
+import to.bitkit.ui.scaffold.PinnedTabsScaffold
 import to.bitkit.ui.screens.wallets.activity.components.ActivityListFilter
 import to.bitkit.ui.screens.wallets.activity.components.ActivityListGrouped
 import to.bitkit.ui.screens.wallets.activity.components.ActivityTab

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/AllActivityScreen.kt
@@ -1,11 +1,7 @@
 package to.bitkit.ui.screens.wallets.activity
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
@@ -17,7 +13,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.synonym.bitkitcore.Activity
-import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
@@ -25,6 +20,7 @@ import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
 import to.bitkit.R
 import to.bitkit.ui.appViewModel
+import to.bitkit.ui.components.PinnedTabsScaffold
 import to.bitkit.ui.components.Sheet
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
@@ -75,7 +71,6 @@ fun AllActivityScreen(
 }
 
 @Composable
-@OptIn(ExperimentalHazeMaterialsApi::class)
 private fun AllActivityScreenContent(
     filteredActivities: ImmutableList<Activity>?,
     searchText: String,
@@ -104,33 +99,29 @@ private fun AllActivityScreenContent(
             },
         )
 
-        ActivityListFilter(
-            searchText = searchText,
-            onSearchTextChange = onSearchTextChange,
-            hasTagFilter = hasTagFilter,
-            hasDateRangeFilter = hasDateRangeFilter,
-            onTagClick = onTagClick,
-            selectedTags = selectedTags,
-            onRemoveTag = onRemoveTag,
-            onDateRangeClick = onDateRangeClick,
-            tabs = tabs,
-            currentTabIndex = currentTabIndex,
-            onTabChange = { onTabChange(tabs.indexOf(it)) },
-            modifier = Modifier.padding(horizontal = 16.dp)
-
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // List
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-        ) {
+        PinnedTabsScaffold(
+            header = {
+                ActivityListFilter(
+                    searchText = searchText,
+                    onSearchTextChange = onSearchTextChange,
+                    hasTagFilter = hasTagFilter,
+                    hasDateRangeFilter = hasDateRangeFilter,
+                    onTagClick = onTagClick,
+                    selectedTags = selectedTags,
+                    onRemoveTag = onRemoveTag,
+                    onDateRangeClick = onDateRangeClick,
+                    tabs = tabs,
+                    currentTabIndex = currentTabIndex,
+                    onTabChange = { onTabChange(tabs.indexOf(it)) },
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+        ) { topPadding ->
             ActivityListGrouped(
                 items = filteredActivities,
                 onActivityItemClick = onActivityItemClick,
                 onEmptyActivityRowClick = onEmptyActivityRowClick,
-                contentPadding = PaddingValues(top = 0.dp),
+                contentPadding = PaddingValues(top = topPadding),
                 modifier = Modifier
                     .swipeToChangeTab(
                         currentTabIndex = currentTabIndex,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,6 +48,7 @@ fun ActivityListGrouped(
     onActivityItemClick: (String) -> Unit,
     onEmptyActivityRowClick: () -> Unit,
     modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
     showFooter: Boolean = false,
     onAllActivityButtonClick: () -> Unit = {},
     contentPadding: PaddingValues = PaddingValues(top = 20.dp),
@@ -65,6 +68,7 @@ fun ActivityListGrouped(
             val groupedItems = groupActivityItems(items)
 
             LazyColumn(
+                state = listState,
                 horizontalAlignment = Alignment.CenterHorizontally,
                 contentPadding = contentPadding,
                 modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -150,6 +150,7 @@ fun ActivityListGrouped(
                     color = Colors.White64,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .padding(contentPadding)
                         .padding(16.dp)
                 )
             }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/components/ActivityListGrouped.kt
@@ -150,7 +150,7 @@ fun ActivityListGrouped(
                     color = Colors.White64,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(contentPadding)
+                        .padding(top = contentPadding.calculateTopPadding())
                         .padding(16.dp)
                 )
             }

--- a/app/src/main/java/to/bitkit/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -33,6 +34,7 @@ import to.bitkit.ui.LocalCurrencies
 import to.bitkit.ui.Routes
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.AuthCheckAction
+import to.bitkit.ui.components.PinnedTabsScaffold
 import to.bitkit.ui.components.Sheet
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SectionHeader
@@ -220,30 +222,37 @@ private fun SettingsContent(
             actions = { DrawerNavIcon() },
         )
 
-        CustomTabRowWithSpacing(
-            tabs = tabs,
-            currentTabIndex = pagerState.currentPage,
-            selectedColor = Colors.White,
-            onTabChange = { scope.launch { pagerState.animateScrollToPage(tabs.indexOf(it)) } },
-            modifier = Modifier.padding(horizontal = 16.dp)
-        )
-
-        HorizontalPager(state = pagerState) { page ->
-            when (tabs[page]) {
-                SettingsTab.General -> GeneralTabContent(
-                    state = generalState,
-                    onEvent = onEvent,
+        PinnedTabsScaffold(
+            header = {
+                CustomTabRowWithSpacing(
+                    tabs = tabs,
+                    currentTabIndex = pagerState.currentPage,
+                    selectedColor = Colors.White,
+                    onTabChange = { scope.launch { pagerState.animateScrollToPage(tabs.indexOf(it)) } },
+                    modifier = Modifier.padding(horizontal = 16.dp)
                 )
+            }
+        ) { topPadding ->
+            HorizontalPager(state = pagerState) { page ->
+                when (tabs[page]) {
+                    SettingsTab.General -> GeneralTabContent(
+                        state = generalState,
+                        onEvent = onEvent,
+                        topPadding = topPadding,
+                    )
 
-                SettingsTab.Security -> SecurityTabContent(
-                    state = securityState,
-                    onEvent = onEvent,
-                )
+                    SettingsTab.Security -> SecurityTabContent(
+                        state = securityState,
+                        onEvent = onEvent,
+                        topPadding = topPadding,
+                    )
 
-                SettingsTab.Advanced -> AdvancedTabContent(
-                    state = advancedState,
-                    onEvent = onEvent,
-                )
+                    SettingsTab.Advanced -> AdvancedTabContent(
+                        state = advancedState,
+                        onEvent = onEvent,
+                        topPadding = topPadding,
+                    )
+                }
             }
         }
     }
@@ -253,12 +262,13 @@ private fun SettingsContent(
 private fun GeneralTabContent(
     state: GeneralTabState,
     onEvent: OnSettingsEvent,
+    topPadding: Dp = 0.dp,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
             .verticalScroll(rememberScrollState())
+            .padding(top = topPadding, start = 16.dp, end = 16.dp)
     ) {
         SectionHeader(title = stringResource(R.string.settings__general__section_interface))
 
@@ -364,12 +374,13 @@ private fun GeneralTabContent(
 private fun SecurityTabContent(
     state: SecurityTabState,
     onEvent: OnSettingsEvent,
+    topPadding: Dp = 0.dp,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
             .verticalScroll(rememberScrollState())
+            .padding(top = topPadding, start = 16.dp, end = 16.dp)
     ) {
         SectionHeader(title = stringResource(R.string.settings__security__section_backup))
 
@@ -480,12 +491,13 @@ private fun SecurityTabContent(
 private fun AdvancedTabContent(
     state: AdvancedTabState,
     onEvent: OnSettingsEvent,
+    topPadding: Dp = 0.dp,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp)
             .verticalScroll(rememberScrollState())
+            .padding(top = topPadding, start = 16.dp, end = 16.dp)
             .testTag("advanced_settings_screen")
     ) {
         if (state.isDevModeEnabled) {

--- a/app/src/main/java/to/bitkit/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/SettingsScreen.kt
@@ -34,7 +34,6 @@ import to.bitkit.ui.LocalCurrencies
 import to.bitkit.ui.Routes
 import to.bitkit.ui.appViewModel
 import to.bitkit.ui.components.AuthCheckAction
-import to.bitkit.ui.components.PinnedTabsScaffold
 import to.bitkit.ui.components.Sheet
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SectionHeader
@@ -56,6 +55,7 @@ import to.bitkit.ui.navigateToTransactionSpeedSettings
 import to.bitkit.ui.navigateToWidgetsSettings
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
+import to.bitkit.ui.scaffold.PinnedTabsScaffold
 import to.bitkit.ui.scaffold.ScreenColumn
 import to.bitkit.ui.screens.wallets.activity.components.CustomTabRowWithSpacing
 import to.bitkit.ui.screens.wallets.activity.components.TabItem

--- a/app/src/main/java/to/bitkit/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/SettingsScreen.kt
@@ -262,7 +262,7 @@ private fun SettingsContent(
 private fun GeneralTabContent(
     state: GeneralTabState,
     onEvent: OnSettingsEvent,
-    topPadding: Dp = 0.dp,
+    topPadding: Dp,
 ) {
     Column(
         modifier = Modifier
@@ -374,7 +374,7 @@ private fun GeneralTabContent(
 private fun SecurityTabContent(
     state: SecurityTabState,
     onEvent: OnSettingsEvent,
-    topPadding: Dp = 0.dp,
+    topPadding: Dp,
 ) {
     Column(
         modifier = Modifier
@@ -491,7 +491,7 @@ private fun SecurityTabContent(
 private fun AdvancedTabContent(
     state: AdvancedTabState,
     onEvent: OnSettingsEvent,
-    topPadding: Dp = 0.dp,
+    topPadding: Dp,
 ) {
     Column(
         modifier = Modifier

--- a/changelog.d/next/916.changed.md
+++ b/changelog.d/next/916.changed.md
@@ -1,0 +1,1 @@
+Activity, Shop and Settings now keep their tabs pinned with a drop shadow as content scrolls behind them, the Add Widget button shows its icon, and the Shop list has more bottom spacing.


### PR DESCRIPTION
Addresses #916

This PR:
1. Pins the tab rows on All Activity, Shop and Settings so content scrolls behind a frosted (haze) header with a drop shadow
2. Adds swipe-between-tabs (HorizontalPager) on the Shop screen, matching Settings
3. Adds the missing icon to the Add Widget button
4. Adds 42dp bottom spacing to the Shop list

### Description

Design review follow-ups for Android v2.2.0, generalized to every screen with a tab row.

- A shared `PinnedTabsScaffold` keeps the tab row (and the Activity search field) pinned while content scrolls behind it. The header uses an iOS-style haze blur tinted to the black background — so it only frosts when content is actually behind it — plus a gradient drop shadow below the tabs.
- Shop switches tabs via a `HorizontalPager`; on the Map tab the pager swipe is disabled so the map can be panned. All Activity keeps its existing swipe-to-change-tab gesture.
- The Add Widget button shows a plus icon, and the Shop list gets 42dp of bottom padding.

### Preview


[home.webm](https://github.com/user-attachments/assets/627c9978-d762-457f-b6fc-0c24a42c0817)

[activities.webm](https://github.com/user-attachments/assets/343c20c5-7954-4b18-94bb-646411ede169)

[map.webm](https://github.com/user-attachments/assets/de32a4f9-93b6-4321-b28f-5d448d108c08)


### QA Notes

#### Manual Tests
- [x] **1.** All Activity → swipe / tap across tabs and scroll: content scrolls behind the frosted, pinned tabs.
- [x] **2.** `regression:` All Activity → search: list filtering still animates.
- [x] **3a.** Shop → swipe / tap between Shop and Map tabs.
  - [x] **3b.** Shop → Map tab → pan the map: no pager conflict; tap Shop tab to return.
- [x] **4.** Shop → scroll to bottom: last item has clear bottom spacing.
- [x] **5.** Home → Add Widget button shows a plus icon left of the label.

#### Automated Checks
- UI-only; no automated coverage changed. Ran `compileDevDebugKotlin`, `detekt`, `testDevDebugUnitTest` locally — all pass.
