### PR TITLE
feat(widgets): intro and gallery sheet

### DIFF
--- a/app/src/androidTest/java/to/bitkit/ui/components/DrawerMenuWidgetsTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/components/DrawerMenuWidgetsTest.kt
@@ -1,0 +1,162 @@
+package to.bitkit.ui.components
+
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import to.bitkit.test.annotations.ComposeUi
+import to.bitkit.ui.Routes
+import to.bitkit.ui.theme.AppThemeSurface
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@ComposeUi
+class DrawerMenuWidgetsTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun testUnseenWidgetsIntroNavigatesToIntro() {
+        composeTestRule.setContent {
+            val navController = rememberNavController()
+            val drawerState = rememberDrawerState(DrawerValue.Open)
+
+            DrawerMenuTestSurface {
+                NavHost(
+                    navController = navController,
+                    startDestination = Routes.Home,
+                ) {
+                    composable<Routes.Home> {
+                        Text("Home", modifier = Modifier.testTag("HomeRoute"))
+                    }
+                    composable<Routes.WidgetsIntro> {
+                        Text("Widgets Intro", modifier = Modifier.testTag("WidgetsIntroRoute"))
+                    }
+                }
+                DrawerMenu(
+                    drawerState = drawerState,
+                    rootNavController = navController,
+                    hasSeenWidgetsIntro = false,
+                    hasSeenShopIntro = true,
+                    onBeforeNavigate = {},
+                    showWidgets = true,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("DrawerWidgets").performClick()
+
+        composeTestRule.onNodeWithTag("WidgetsIntroRoute").assertIsDisplayed()
+    }
+
+    @Test
+    fun testSeenWidgetsIntroRequestsHomeWidgetsPage() {
+        composeTestRule.setContent {
+            val navController = rememberNavController()
+            val drawerState = rememberDrawerState(DrawerValue.Open)
+            val openWidgetsHome = remember { mutableStateOf(false) }
+
+            DrawerMenuTestSurface {
+                NavHost(
+                    navController = navController,
+                    startDestination = Routes.Home,
+                ) {
+                    composable<Routes.Home> {
+                        Text("Home", modifier = Modifier.testTag("HomeRoute"))
+                    }
+                }
+                DrawerMenu(
+                    drawerState = drawerState,
+                    rootNavController = navController,
+                    hasSeenWidgetsIntro = true,
+                    hasSeenShopIntro = true,
+                    onBeforeNavigate = {},
+                    showWidgets = true,
+                    onOpenWidgetsHome = { openWidgetsHome.value = true },
+                )
+                if (openWidgetsHome.value) {
+                    Text("Widgets requested", modifier = Modifier.testTag("WidgetsHomeRequested"))
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag("DrawerWidgets").performClick()
+
+        composeTestRule.onNodeWithTag("WidgetsHomeRequested").assertIsDisplayed()
+    }
+
+    @Test
+    fun testSeenWidgetsIntroWithDisabledWidgetsOpensSheet() {
+        composeTestRule.setContent {
+            val navController = rememberNavController()
+            val drawerState = rememberDrawerState(DrawerValue.Open)
+            val openWidgetsSheet = remember { mutableStateOf(false) }
+
+            DrawerMenuTestSurface {
+                NavHost(
+                    navController = navController,
+                    startDestination = Routes.Home,
+                ) {
+                    composable<Routes.Home> {
+                        Text("Home", modifier = Modifier.testTag("HomeRoute"))
+                    }
+                }
+                DrawerMenu(
+                    drawerState = drawerState,
+                    rootNavController = navController,
+                    hasSeenWidgetsIntro = true,
+                    hasSeenShopIntro = true,
+                    onBeforeNavigate = {},
+                    showWidgets = false,
+                    onOpenWidgetsHome = { error("Should not request home widgets page") },
+                    onOpenWidgetsSheet = { openWidgetsSheet.value = true },
+                )
+                if (openWidgetsSheet.value) {
+                    Text("Widgets sheet requested", modifier = Modifier.testTag("WidgetsSheetRequested"))
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag("DrawerWidgets").performClick()
+
+        composeTestRule.onNodeWithTag("WidgetsSheetRequested").assertIsDisplayed()
+    }
+}
+
+@Composable
+private fun DrawerMenuTestSurface(content: @Composable () -> Unit) {
+    AppThemeSurface {
+        CompositionLocalProvider(LocalInspectionMode provides true) {
+            content()
+        }
+    }
+}

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/AddWidgetsSheetContentTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/AddWidgetsSheetContentTest.kt
@@ -1,0 +1,301 @@
+package to.bitkit.ui.screens.widgets
+
+import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import to.bitkit.models.WidgetType
+import to.bitkit.models.widget.ArticleModel
+import to.bitkit.models.widget.BlockModel
+import to.bitkit.test.annotations.ComposeUi
+import to.bitkit.ui.theme.AppThemeSurface
+
+@ComposeUi
+class AddWidgetsSheetContentTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testGalleryShowsFigmaOrderedVisibleCards() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = true,
+                    onWidgetSelected = {},
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("widgets_gallery_screen").assertExists()
+        composeTestRule.onNodeWithTag("WidgetListItem-price").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("WidgetListItem-weather").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-calculator"))
+        composeTestRule.onNodeWithTag("WidgetListItem-calculator").assertIsDisplayed()
+    }
+
+    @Test
+    fun testGalleryTitleScrollsWithContent() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = true,
+                    onWidgetSelected = {},
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("widgets_gallery_title").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-suggestions"))
+        composeTestRule.onNodeWithTag("widgets_gallery_title").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun testGalleryUsesWidgetPreviewComponents() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = true,
+                    onWidgetSelected = {},
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("price_card_small_chart").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("weather_card_small").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("headline_card_wide").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("block_label").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-suggestions"))
+        composeTestRule.onNodeWithTag("Suggestion-back_up").assertIsDisplayed()
+    }
+
+    @Test
+    fun testGalleryUsesProvidedWidgetData() {
+        val article = ArticleModel(
+            timeAgo = "5 min ago",
+            title = "Live preview headline",
+            publisher = "live.source",
+            link = "https://live.source",
+        )
+        val block = BlockModel(
+            height = "999,999",
+            time = "09:08:07 UTC",
+            date = "5/29/2026",
+            transactionCount = "9,876",
+            size = "1,234kb",
+            fees = "50 000",
+        )
+
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = true,
+                    onWidgetSelected = {},
+                    onEnableInSettingsClick = {},
+                    article = article,
+                    block = block,
+                    fact = "Live preview fact",
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Live preview headline").assertIsDisplayed()
+        composeTestRule.onNodeWithText("live.source").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-blocks"))
+        composeTestRule.onNodeWithText("999,999").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-facts"))
+        composeTestRule.onNodeWithText("Live preview fact").assertIsDisplayed()
+    }
+
+    @Test
+    fun testTwoColumnGalleryItemsHaveEqualHeight() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = true,
+                    onWidgetSelected = {},
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        val priceBounds = composeTestRule.onNodeWithTag("WidgetListItem-price").getUnclippedBoundsInRoot()
+        val weatherBounds = composeTestRule.onNodeWithTag("WidgetListItem-weather").getUnclippedBoundsInRoot()
+
+        assertEquals(priceBounds.bottom - priceBounds.top, weatherBounds.bottom - weatherBounds.top)
+
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-calculator"))
+
+        val factsBounds = composeTestRule.onNodeWithTag("WidgetListItem-facts-layout").getUnclippedBoundsInRoot()
+        val calculatorBounds = composeTestRule.onNodeWithTag("WidgetListItem-calculator-layout").getUnclippedBoundsInRoot()
+
+        assertEquals(factsBounds.bottom - factsBounds.top, calculatorBounds.bottom - calculatorBounds.top)
+    }
+
+    @Test
+    fun testGalleryTapSelectsWidget() {
+        var selectedWidget: WidgetType? = null
+
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = true,
+                    onWidgetSelected = { selectedWidget = it },
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("WidgetListItem-weather").performClick()
+
+        assert(selectedWidget == WidgetType.WEATHER)
+
+        selectedWidget = null
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-facts"))
+        composeTestRule.onNodeWithTag("WidgetListItem-facts").performClick()
+
+        assert(selectedWidget == WidgetType.FACTS)
+    }
+
+    @Test
+    fun testPriceChartTapSelectsWidget() {
+        var selectedWidget: WidgetType? = null
+
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = true,
+                    onWidgetSelected = { selectedWidget = it },
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("price_card_small_chart").performTouchInput {
+            down(center)
+            up()
+        }
+
+        assert(selectedWidget == WidgetType.PRICE)
+    }
+
+    @Test
+    fun testHeadlineContentTapSelectsWidget() {
+        var selectedWidget: WidgetType? = null
+
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = true,
+                    onWidgetSelected = { selectedWidget = it },
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onAllNodesWithTag("headline_text")[0].performTouchInput {
+            down(center)
+            up()
+        }
+
+        assert(selectedWidget == WidgetType.NEWS)
+    }
+
+    @Test
+    fun testDisabledGalleryShowsSettingsButton() {
+        var enableSettingsClicked = false
+
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = false,
+                    onWidgetSelected = {},
+                    onEnableInSettingsClick = { enableSettingsClicked = true },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("WidgetListItem-price").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-calculator"))
+        composeTestRule.onNodeWithTag("WidgetListItem-calculator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("widgets_gallery_scroll")
+            .performScrollToNode(hasTestTag("WidgetListItem-suggestions"))
+        composeTestRule.onNodeWithTag("WidgetListItem-suggestions").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("WidgetEnableInSettings").assertExists().performClick()
+        assert(enableSettingsClicked)
+    }
+
+    @Test
+    fun testDisabledGalleryHeadlineCardIsNotClickable() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = false,
+                    onWidgetSelected = {},
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("headline_card_wide").assertHasNoClickAction()
+    }
+
+    @Test
+    fun testSettingsButtonHasBottomPadding() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                AddWidgetsSheetContent(
+                    fiatSymbol = "$",
+                    showWidgets = false,
+                    onWidgetSelected = {},
+                    onEnableInSettingsClick = {},
+                )
+            }
+        }
+
+        val rootBottom = composeTestRule.onRoot().getUnclippedBoundsInRoot().bottom
+        val buttonBottom = composeTestRule.onNodeWithTag("WidgetEnableInSettings")
+            .getUnclippedBoundsInRoot()
+            .bottom
+
+        assert(buttonBottom < rootBottom)
+    }
+}

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/WidgetsIntroScreenTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/WidgetsIntroScreenTest.kt
@@ -1,0 +1,64 @@
+package to.bitkit.ui.screens.widgets
+
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertTrue
+import to.bitkit.test.annotations.ComposeUi
+import to.bitkit.ui.theme.AppThemeSurface
+
+@ComposeUi
+class WidgetsIntroScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testWidgetsIntroActions() {
+        var viewOrganizeClicked = false
+        var addWidgetClicked = false
+
+        composeTestRule.setContent {
+            AppThemeSurface {
+                WidgetsIntroScreen(
+                    onViewOrganize = { viewOrganizeClicked = true },
+                    onAddWidget = { addWidgetClicked = true },
+                    onBackClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("WidgetsOnboardingViewOrganize").assertExists().performClick()
+        assert(viewOrganizeClicked)
+
+        composeTestRule.onNodeWithTag("WidgetsOnboardingAddWidget").assertExists().performClick()
+        assert(addWidgetClicked)
+    }
+
+    @Test
+    fun testWidgetsIntroActionsAreHorizontal() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                WidgetsIntroScreen(
+                    onViewOrganize = {},
+                    onAddWidget = {},
+                    onBackClick = {},
+                )
+            }
+        }
+
+        val viewOrganizeBounds = composeTestRule
+            .onNodeWithTag("WidgetsOnboardingViewOrganize")
+            .getUnclippedBoundsInRoot()
+        val addWidgetBounds = composeTestRule
+            .onNodeWithTag("WidgetsOnboardingAddWidget")
+            .getUnclippedBoundsInRoot()
+
+        assertTrue(viewOrganizeBounds.right < addWidgetBounds.left)
+        assertTrue(viewOrganizeBounds.top < addWidgetBounds.bottom)
+        assertTrue(addWidgetBounds.top < viewOrganizeBounds.bottom)
+    }
+}

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/calculator/CalculatorCardIntegrationTest.kt
@@ -51,7 +51,6 @@ import to.bitkit.test.annotations.DeviceIntegration
 import to.bitkit.test.annotations.DeviceUiIntegration
 import to.bitkit.ui.screens.widgets.calculator.components.CalculatorCard
 import to.bitkit.ui.theme.AppThemeSurface
-import to.bitkit.viewmodels.CurrencyViewModel
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
@@ -88,7 +87,6 @@ class CalculatorCardIntegrationTest {
 
     private lateinit var viewModelStore: ViewModelStore
     private lateinit var calculatorViewModel: CalculatorViewModel
-    private lateinit var currencyViewModel: CurrencyViewModel
     private lateinit var previousWidgetsData: WidgetsData
     private lateinit var previousSettingsData: SettingsData
     private lateinit var previousCacheData: AppCacheData
@@ -110,7 +108,6 @@ class CalculatorCardIntegrationTest {
                 it.copy(
                     selectedCurrency = USD,
                     displayUnit = BitcoinDisplayUnit.MODERN,
-                    showWidgetTitles = true,
                 )
             }
             cacheStore.update { it.copy(cachedRates = listOf(testUsdRate)) }
@@ -136,7 +133,6 @@ class CalculatorCardIntegrationTest {
         }
 
         calculatorViewModel = createCalculatorViewModel()
-        currencyViewModel = createCurrencyViewModel()
     }
 
     @After
@@ -203,31 +199,18 @@ class CalculatorCardIntegrationTest {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
                     return CalculatorViewModel(
                         widgetsRepo = widgetsRepo,
+                        currencyRepo = currencyRepo,
                     ) as T
                 }
             },
         )[CalculatorViewModel::class.java]
     }
 
-    private fun createCurrencyViewModel(): CurrencyViewModel = ViewModelProvider(
-        viewModelStore,
-        object : ViewModelProvider.Factory {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return CurrencyViewModel(
-                    currencyRepo = currencyRepo,
-                ) as T
-            }
-        },
-    )[CurrencyViewModel::class.java]
-
     private fun setCalculatorCard() {
         composeTestRule.setContent {
             AppThemeSurface {
                 CalculatorCard(
-                    currencyViewModel = currencyViewModel,
                     calculatorViewModel = calculatorViewModel,
-                    showWidgetTitle = true,
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -254,14 +237,14 @@ class CalculatorCardIntegrationTest {
     ) {
         runCatching {
             composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
-                calculatorViewModel.calculatorValues.value.btcValue == btcValue &&
-                    calculatorViewModel.calculatorValues.value.fiatValue == fiatValue
+                calculatorViewModel.uiState.value.btcValue == btcValue &&
+                    calculatorViewModel.uiState.value.fiatValue == fiatValue
             }
         }.onFailure {
             throw AssertionError(
                 buildString {
                     append("Expected calculatorValues btcValue='$btcValue', fiatValue='$fiatValue', ")
-                    append("but was '${calculatorViewModel.calculatorValues.value}'. Persisted values were ")
+                    append("but was '${calculatorViewModel.uiState.value}'. Persisted values were ")
                     append("'${widgetsRepo.widgetsDataFlow.value.calculatorValues}'. Semantics tree:\n")
                     append(composeTestRule.onRoot(useUnmergedTree = true).printToString())
                 },
@@ -272,6 +255,8 @@ class CalculatorCardIntegrationTest {
         val expectedValues = CalculatorValues(
             btcValue = btcValue,
             fiatValue = fiatValue,
+            satsValue = btcValue.toLong(),
+            displayUnit = BitcoinDisplayUnit.MODERN,
         )
         runCatching {
             composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
@@ -303,6 +288,8 @@ class CalculatorCardIntegrationTest {
             CalculatorValues(
                 btcValue = btcValue,
                 fiatValue = fiatValue,
+                satsValue = btcValue.toLong(),
+                displayUnit = BitcoinDisplayUnit.MODERN,
             ),
             widgetsRepo.widgetsDataFlow.value.calculatorValues,
         )

--- a/app/src/androidTest/java/to/bitkit/ui/screens/widgets/suggestions/SuggestionsPreviewScreenTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/screens/widgets/suggestions/SuggestionsPreviewScreenTest.kt
@@ -1,0 +1,34 @@
+package to.bitkit.ui.screens.widgets.suggestions
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import org.junit.Rule
+import org.junit.Test
+import to.bitkit.test.annotations.ComposeUi
+import to.bitkit.ui.theme.AppThemeSurface
+
+@ComposeUi
+class SuggestionsPreviewScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testDefaultPreviewShowsFourSuggestions() {
+        composeTestRule.setContent {
+            AppThemeSurface {
+                SuggestionsPreviewGrid(
+                    onSuggestionClick = {},
+                    modifier = Modifier
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("Suggestion-back_up").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("Suggestion-secure").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("Suggestion-lightning").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("Suggestion-support").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/to/bitkit/ui/shared/modifiers/SheetHeightTest.kt
+++ b/app/src/androidTest/java/to/bitkit/ui/shared/modifiers/SheetHeightTest.kt
@@ -1,0 +1,78 @@
+package to.bitkit.ui.shared.modifiers
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import to.bitkit.test.annotations.ComposeUi
+import to.bitkit.ui.components.SheetSize
+import to.bitkit.ui.theme.AppThemeSurface
+import to.bitkit.ui.theme.Insets
+import to.bitkit.ui.theme.TopBarHeight
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@ComposeUi
+class SheetHeightTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun largeNonModalHeightIgnoresBottomInset() {
+        var expectedHeight = 0
+        var actualHeight = 0
+
+        composeTestRule.setContent {
+            AppThemeSurface {
+                val density = LocalDensity.current
+                val windowHeight = LocalWindowInfo.current.containerSize.height
+                val topInset = Insets.Top
+                val expected = with(density) {
+                    (windowHeight.toDp() - topInset - TopBarHeight + 6.dp).roundToPx()
+                }
+
+                SideEffect {
+                    expectedHeight = expected
+                }
+
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = Modifier
+                            .sheetHeight(size = SheetSize.LARGE)
+                            .fillMaxWidth()
+                            .onSizeChanged { actualHeight = it.height }
+                    )
+                }
+            }
+        }
+
+        composeTestRule.waitUntil {
+            expectedHeight > 0 && actualHeight > 0
+        }
+
+        assertEquals(expectedHeight, actualHeight)
+    }
+}

--- a/app/src/main/java/to/bitkit/data/widgets/PriceService.kt
+++ b/app/src/main/java/to/bitkit/data/widgets/PriceService.kt
@@ -41,8 +41,16 @@ class PriceService @Inject constructor(
         fetchData(period).getOrThrow()
     }
 
-    suspend fun fetchData(period: GraphPeriod): Result<PriceDTO> = runCatching {
-        val widgets = TradingPair.entries.mapNotNull { pair ->
+    suspend fun fetchData(period: GraphPeriod): Result<PriceDTO> = fetchData(
+        pairs = TradingPair.entries.toList(),
+        period = period,
+    )
+
+    suspend fun fetchData(
+        pairs: List<TradingPair>,
+        period: GraphPeriod,
+    ): Result<PriceDTO> = runCatching {
+        val widgets = pairs.mapNotNull { pair ->
             runCatching { fetchPairData(pair = pair, period = period) }
                 .onFailure { Logger.warn(e = it, msg = "Failed to fetch ${pair.ticker}", context = TAG) }
                 .getOrNull()

--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -101,6 +101,7 @@ class BackupRepo @Inject constructor(
     private var periodicCheckJob: Job? = null
 
     private val runningBackups = ConcurrentHashMap.newKeySet<BackupCategory>() // Tracks active jobs since app start
+    private val failedBackupRequired = ConcurrentHashMap<BackupCategory, Long>()
 
     private var isObserving = false
     private var lastNotificationTime = 0L
@@ -119,7 +120,11 @@ class BackupRepo @Inject constructor(
     fun setWiping(isWiping: Boolean) = _isWiping.update { isWiping }
     private fun currentTimeMillis(): Long = nowMillis(clock)
     private fun shouldSkipBackup(): Boolean = _isRestoring.value || _isWiping.value
-    private fun BackupItemStatus.shouldBackup() = this.isRequired && !this.running && !shouldSkipBackup()
+    private fun BackupItemStatus.shouldBackup(category: BackupCategory) =
+        this.isRequired &&
+            !this.running &&
+            !shouldSkipBackup() &&
+            failedBackupRequired[category] != this.required
 
     fun startObservingBackups() {
         if (isObserving) return
@@ -197,11 +202,12 @@ class BackupRepo @Inject constructor(
                 cacheStore.backupStatuses
                     .map { statuses -> statuses[category] ?: BackupItemStatus() }
                     .distinctUntilChanged { old, new ->
-                        // restart scheduling when synced or required timestamps change
-                        old.synced == new.synced && old.required == new.required
+                        old.synced == new.synced &&
+                            old.required == new.required &&
+                            old.running == new.running
                     }
                     .collect { status ->
-                        if (status.shouldBackup()) {
+                        if (status.shouldBackup(category)) {
                             scheduleBackup(category)
                         }
                     }
@@ -355,6 +361,7 @@ class BackupRepo @Inject constructor(
 
     private fun markBackupRequired(category: BackupCategory) {
         scope.launch {
+            failedBackupRequired -= category
             cacheStore.updateBackupStatus(category) {
                 it.copy(required = currentTimeMillis())
             }
@@ -441,6 +448,7 @@ class BackupRepo @Inject constructor(
         Logger.debug("Backup starting for: '$category'", context = TAG)
 
         runningBackups += category
+        failedBackupRequired -= category
         cacheStore.updateBackupStatus(category) {
             it.copy(running = true, required = currentTimeMillis())
         }
@@ -448,6 +456,7 @@ class BackupRepo @Inject constructor(
         vssBackupClient.putObject(key = category.name, data = getBackupDataBytes(category))
             .onSuccess {
                 runningBackups -= category
+                failedBackupRequired -= category
                 cacheStore.updateBackupStatus(category) {
                     it.copy(
                         running = false,
@@ -459,6 +468,7 @@ class BackupRepo @Inject constructor(
             .onFailure { e ->
                 runningBackups -= category
                 cacheStore.updateBackupStatus(category) {
+                    failedBackupRequired[category] = it.required
                     it.copy(running = false)
                 }
                 Logger.error("Backup failed for: '$category'", e, context = TAG)

--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -447,10 +447,11 @@ class BackupRepo @Inject constructor(
     suspend fun triggerBackup(category: BackupCategory) = withContext(ioDispatcher) {
         Logger.debug("Backup starting for: '$category'", context = TAG)
 
+        val backupRequired = currentTimeMillis()
         runningBackups += category
         failedBackupRequired -= category
         cacheStore.updateBackupStatus(category) {
-            it.copy(running = true, required = currentTimeMillis())
+            it.copy(running = true, required = backupRequired)
         }
 
         vssBackupClient.putObject(key = category.name, data = getBackupDataBytes(category))
@@ -468,7 +469,11 @@ class BackupRepo @Inject constructor(
             .onFailure { e ->
                 runningBackups -= category
                 cacheStore.updateBackupStatus(category) {
-                    failedBackupRequired[category] = it.required
+                    if (it.required == backupRequired) {
+                        failedBackupRequired[category] = backupRequired
+                    } else {
+                        failedBackupRequired -= category
+                    }
                     it.copy(running = false)
                 }
                 Logger.error("Backup failed for: '$category'", e, context = TAG)

--- a/app/src/main/java/to/bitkit/repositories/WidgetsRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WidgetsRepo.kt
@@ -23,7 +23,9 @@ import to.bitkit.data.WidgetsStore
 import to.bitkit.data.dto.ArticleDTO
 import to.bitkit.data.dto.BlockDTO
 import to.bitkit.data.dto.WeatherDTO
+import to.bitkit.data.dto.price.GraphPeriod
 import to.bitkit.data.dto.price.PriceDTO
+import to.bitkit.data.dto.price.TradingPair
 import to.bitkit.data.widgets.BlocksService
 import to.bitkit.data.widgets.FactsService
 import to.bitkit.data.widgets.NewsService
@@ -196,6 +198,13 @@ class WidgetsRepo @Inject constructor(
     }
 
     suspend fun fetchAllPeriods() = withContext(bgDispatcher) { priceService.fetchAllPeriods() }
+
+    suspend fun fetchPriceData(
+        pairs: List<TradingPair>,
+        period: GraphPeriod,
+    ) = withContext(bgDispatcher) {
+        priceService.fetchData(pairs = pairs, period = period)
+    }
 
     private suspend fun <T> updateWidget(
         service: WidgetService<T>,

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -47,12 +48,13 @@ import kotlinx.serialization.Serializable
 import to.bitkit.env.Env
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.Toast
-import to.bitkit.models.WidgetType
 import to.bitkit.repositories.ConnectivityState
 import to.bitkit.ui.Routes.ExternalConnection
 import to.bitkit.ui.components.AuthCheckScreen
+import to.bitkit.ui.components.DefaultSheetContainerColor
 import to.bitkit.ui.components.DrawerMenu
 import to.bitkit.ui.components.Sheet
+import to.bitkit.ui.components.SheetHandlePlacement
 import to.bitkit.ui.components.SheetHost
 import to.bitkit.ui.components.TabBar
 import to.bitkit.ui.components.TimedSheetType
@@ -133,25 +135,7 @@ import to.bitkit.ui.screens.wallets.activity.TagSelectorSheet
 import to.bitkit.ui.screens.wallets.receive.ReceiveRoute
 import to.bitkit.ui.screens.wallets.receive.ReceiveSheet
 import to.bitkit.ui.screens.wallets.suggestion.BuyIntroScreen
-import to.bitkit.ui.screens.widgets.AddWidgetsScreen
 import to.bitkit.ui.screens.widgets.WidgetsIntroScreen
-import to.bitkit.ui.screens.widgets.blocks.BlocksEditScreen
-import to.bitkit.ui.screens.widgets.blocks.BlocksPreviewScreen
-import to.bitkit.ui.screens.widgets.blocks.BlocksViewModel
-import to.bitkit.ui.screens.widgets.calculator.CalculatorPreviewScreen
-import to.bitkit.ui.screens.widgets.facts.FactsPreviewScreen
-import to.bitkit.ui.screens.widgets.facts.FactsViewModel
-import to.bitkit.ui.screens.widgets.headlines.HeadlinesEditScreen
-import to.bitkit.ui.screens.widgets.headlines.HeadlinesPreviewScreen
-import to.bitkit.ui.screens.widgets.headlines.HeadlinesViewModel
-import to.bitkit.ui.screens.widgets.price.PriceEditScreen
-import to.bitkit.ui.screens.widgets.price.PricePreviewScreen
-import to.bitkit.ui.screens.widgets.price.PriceViewModel
-import to.bitkit.ui.screens.widgets.suggestions.SuggestionsPreviewScreen
-import to.bitkit.ui.screens.widgets.suggestions.SuggestionsViewModel
-import to.bitkit.ui.screens.widgets.weather.WeatherEditScreen
-import to.bitkit.ui.screens.widgets.weather.WeatherPreviewScreen
-import to.bitkit.ui.screens.widgets.weather.WeatherViewModel
 import to.bitkit.ui.settings.BackupSettingsScreen
 import to.bitkit.ui.settings.BlocktankRegtestScreen
 import to.bitkit.ui.settings.CJitDetailScreen
@@ -204,6 +188,8 @@ import to.bitkit.ui.sheets.QuickPayIntroSheet
 import to.bitkit.ui.sheets.SendRoute
 import to.bitkit.ui.sheets.SendSheet
 import to.bitkit.ui.sheets.UpdateSheet
+import to.bitkit.ui.sheets.WidgetsSheet
+import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.utils.AutoReadClipboardHandler
 import to.bitkit.ui.utils.RequestNotificationPermissions
 import to.bitkit.ui.utils.composableWithDefaultTransitions
@@ -399,7 +385,24 @@ fun ContentView(
         val isProfileAuthenticated by settingsViewModel.isPubkyAuthenticated.collectAsStateWithLifecycle()
         val hasPubkyContacts by settingsViewModel.hasPubkyContacts.collectAsStateWithLifecycle()
         val isPaykitEnabled by settingsViewModel.isPaykitEnabled.collectAsStateWithLifecycle()
+        val showWidgets by settingsViewModel.showWidgets.collectAsStateWithLifecycle()
         val currentSheet by appViewModel.currentSheet.collectAsStateWithLifecycle()
+        var homeWalletPageRequest by remember { mutableIntStateOf(0) }
+        var homeWidgetsPageRequest by remember { mutableIntStateOf(0) }
+        val navigateToHomeWallet = {
+            homeWalletPageRequest++
+            navController.navigateToHome()
+        }
+        val navigateToHomeWidgets = {
+            homeWidgetsPageRequest++
+            navController.navigateToHome()
+        }
+        val onConsumeHomeWalletPageRequest = {
+            homeWalletPageRequest = 0
+        }
+        val onConsumeHomeWidgetsPageRequest = {
+            homeWidgetsPageRequest = 0
+        }
 
         Box(
             modifier = modifier.fillMaxSize()
@@ -407,6 +410,14 @@ fun ContentView(
             SheetHost(
                 shouldExpand = currentSheet != null,
                 onDismiss = { appViewModel.hideSheet() },
+                sheetHandlePlacement = when (currentSheet) {
+                    is Sheet.Widgets -> SheetHandlePlacement.ContentOverlay
+                    else -> SheetHandlePlacement.ScaffoldSlot
+                },
+                sheetContainerColor = when (currentSheet) {
+                    is Sheet.Widgets -> Colors.Gray7
+                    else -> DefaultSheetContainerColor
+                },
                 sheets = {
                     when (val sheet = currentSheet) {
                         null -> Unit
@@ -438,6 +449,18 @@ fun ContentView(
                         Sheet.ChangePin -> ChangePinSheet(appViewModel)
                         Sheet.DisablePin -> DisablePinSheet(appViewModel)
                         is Sheet.Backup -> BackupSheet(sheet, onDismiss = { appViewModel.hideSheet() })
+                        is Sheet.Widgets -> {
+                            WidgetsSheet(
+                                sheet = sheet,
+                                app = appViewModel,
+                                fiatSymbol = LocalCurrencies.current.currencySymbol,
+                                showWidgets = showWidgets,
+                                onNavigateHomeWidgets = navigateToHomeWidgets,
+                                onOpenWidgetsSettings = {
+                                    navController.navigateTo(Routes.WidgetsSettings)
+                                },
+                            )
+                        }
                         is Sheet.LnurlAuth -> LnurlAuthSheet(sheet, appViewModel)
                         Sheet.ForceTransfer -> ForceTransferSheet(appViewModel, transferViewModel)
                         Sheet.ConnectionClosed -> ConnectionClosedSheet(
@@ -516,6 +539,11 @@ fun ContentView(
                         settingsViewModel = settingsViewModel,
                         currencyViewModel = currencyViewModel,
                         transferViewModel = transferViewModel,
+                        homeWalletPageRequest = homeWalletPageRequest,
+                        homeWidgetsPageRequest = homeWidgetsPageRequest,
+                        onConsumeHomeWalletPageRequest = onConsumeHomeWalletPageRequest,
+                        onConsumeHomeWidgetsPageRequest = onConsumeHomeWidgetsPageRequest,
+                        onNavigateHomeWidgets = navigateToHomeWidgets,
                         onHomeCalculatorInputActiveChanged = { isHomeCalculatorInputActive = it },
                     )
 
@@ -562,6 +590,10 @@ fun ContentView(
                 hasContacts = hasPubkyContacts,
                 isProfileAuthenticated = isProfileAuthenticated,
                 isPaykitEnabled = isPaykitEnabled,
+                showWidgets = showWidgets,
+                onOpenWalletHome = navigateToHomeWallet,
+                onOpenWidgetsHome = navigateToHomeWidgets,
+                onOpenWidgetsSheet = { appViewModel.showSheet(Sheet.Widgets()) },
                 modifier = Modifier.align(Alignment.TopEnd)
             )
         }
@@ -578,6 +610,11 @@ private fun RootNavHost(
     settingsViewModel: SettingsViewModel,
     currencyViewModel: CurrencyViewModel,
     transferViewModel: TransferViewModel,
+    homeWalletPageRequest: Int,
+    homeWidgetsPageRequest: Int,
+    onConsumeHomeWalletPageRequest: () -> Unit,
+    onConsumeHomeWidgetsPageRequest: () -> Unit,
+    onNavigateHomeWidgets: () -> Unit,
     onHomeCalculatorInputActiveChanged: (Boolean) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
@@ -590,6 +627,10 @@ private fun RootNavHost(
             settingsViewModel = settingsViewModel,
             navController = navController,
             drawerState = drawerState,
+            homeWalletPageRequest = homeWalletPageRequest,
+            homeWidgetsPageRequest = homeWidgetsPageRequest,
+            onConsumeHomeWalletPageRequest = onConsumeHomeWalletPageRequest,
+            onConsumeHomeWidgetsPageRequest = onConsumeHomeWidgetsPageRequest,
             onCalculatorInputActiveChanged = onHomeCalculatorInputActiveChanged,
         )
         allActivity(
@@ -617,7 +658,12 @@ private fun RootNavHost(
         logs(navController)
         suggestions(navController)
         support(navController)
-        widgets(navController, settingsViewModel)
+        widgets(
+            navController = navController,
+            settingsViewModel = settingsViewModel,
+            appViewModel = appViewModel,
+            onNavigateHomeWidgets = onNavigateHomeWidgets,
+        )
         update()
         recoveryMode(navController, appViewModel)
 
@@ -834,6 +880,10 @@ private fun NavGraphBuilder.home(
     settingsViewModel: SettingsViewModel,
     navController: NavHostController,
     drawerState: DrawerState,
+    homeWalletPageRequest: Int,
+    homeWidgetsPageRequest: Int,
+    onConsumeHomeWalletPageRequest: () -> Unit,
+    onConsumeHomeWidgetsPageRequest: () -> Unit,
     onCalculatorInputActiveChanged: (Boolean) -> Unit,
 ) {
     composable<Routes.Home> {
@@ -861,6 +911,10 @@ private fun NavGraphBuilder.home(
                 walletViewModel = walletViewModel,
                 appViewModel = appViewModel,
                 activityListViewModel = activityListViewModel,
+                walletPageRequest = homeWalletPageRequest,
+                widgetsPageRequest = homeWidgetsPageRequest,
+                onConsumeWalletPageRequest = onConsumeHomeWalletPageRequest,
+                onConsumeWidgetsPageRequest = onConsumeHomeWidgetsPageRequest,
                 onCalculatorInputActiveChanged = onCalculatorInputActiveChanged,
             )
         }
@@ -1189,6 +1243,9 @@ private fun NavGraphBuilder.profile(
                 },
                 onNavigateToPayContacts = {
                     navController.navigateTo(Routes.PayContacts) { popUpTo(Routes.Home) }
+                },
+                onNavigateToProfile = {
+                    navController.navigateTo(Routes.Profile) { popUpTo(Routes.Home) }
                 },
                 onBackClick = { navController.popBackStack() },
             )
@@ -1582,168 +1639,30 @@ private fun NavGraphBuilder.support(
     }
 }
 
-@Suppress("LongMethod")
 private fun NavGraphBuilder.widgets(
     navController: NavHostController,
     settingsViewModel: SettingsViewModel,
+    appViewModel: AppViewModel,
+    onNavigateHomeWidgets: () -> Unit,
 ) {
     composableWithDefaultTransitions<Routes.WidgetsIntro> {
-        WidgetsIntroScreen(
-            onContinue = {
-                settingsViewModel.setHasSeenWidgetsIntro(true)
-                navController.navigateTo(Routes.AddWidget)
-            },
-            onBackClick = { navController.popBackStack() },
-        )
-    }
-    composableWithDefaultTransitions<Routes.AddWidget> {
         val showWidgets by settingsViewModel.showWidgets.collectAsStateWithLifecycle()
-        AddWidgetsScreen(
-            onWidgetSelected = { widgetType ->
-                when (widgetType) {
-                    WidgetType.BLOCK -> navController.navigateTo(Routes.BlocksPreview)
-                    WidgetType.CALCULATOR -> navController.navigateTo(Routes.CalculatorPreview)
-                    WidgetType.FACTS -> navController.navigateTo(Routes.FactsPreview)
-                    WidgetType.NEWS -> navController.navigateTo(Routes.HeadlinesPreview)
-                    WidgetType.PRICE -> navController.navigateTo(Routes.PricePreview)
-                    WidgetType.WEATHER -> navController.navigateTo(Routes.WeatherPreview)
-                    WidgetType.SUGGESTIONS -> navController.navigateTo(Routes.SuggestionsPreview)
+
+        WidgetsIntroScreen(
+            onViewOrganize = {
+                settingsViewModel.setHasSeenWidgetsIntro(true)
+                if (showWidgets) {
+                    onNavigateHomeWidgets()
+                } else {
+                    appViewModel.showSheet(Sheet.Widgets())
                 }
             },
-            fiatSymbol = LocalCurrencies.current.currencySymbol,
+            onAddWidget = {
+                settingsViewModel.setHasSeenWidgetsIntro(true)
+                appViewModel.showSheet(Sheet.Widgets())
+            },
             onBackClick = { navController.popBackStack() },
-            showWidgets = showWidgets,
-            onEnableInSettingsClick = { navController.navigateTo(Routes.WidgetsSettings) },
         )
-    }
-    composableWithDefaultTransitions<Routes.SuggestionsPreview> {
-        val viewModel = hiltViewModel<SuggestionsViewModel>()
-        SuggestionsPreviewScreen(
-            suggestionsViewModel = viewModel,
-            onClose = { navController.navigateToHome() },
-            onBack = { navController.popBackStack() },
-        )
-    }
-    composableWithDefaultTransitions<Routes.CalculatorPreview> {
-        CalculatorPreviewScreen(
-            onClose = { navController.navigateToHome() },
-            onBack = { navController.popBackStack() },
-        )
-    }
-    navigationWithDefaultTransitions<Routes.Headlines>(
-        startDestination = Routes.HeadlinesPreview
-    ) {
-        composableWithDefaultTransitions<Routes.HeadlinesPreview> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Headlines) }
-            val viewModel = hiltViewModel<HeadlinesViewModel>(parentEntry)
-
-            HeadlinesPreviewScreen(
-                headlinesViewModel = viewModel,
-                onClose = { navController.navigateToHome() },
-                onBack = { navController.popBackStack() },
-                navigateEditWidget = { navController.navigateTo(Routes.HeadlinesEdit) },
-            )
-        }
-        composableWithDefaultTransitions<Routes.HeadlinesEdit> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Headlines) }
-            val viewModel = hiltViewModel<HeadlinesViewModel>(parentEntry)
-
-            HeadlinesEditScreen(
-                headlinesViewModel = viewModel,
-                onBack = { navController.popBackStack() },
-                navigatePreview = {
-                    navController.navigateTo(Routes.HeadlinesPreview)
-                }
-            )
-        }
-    }
-    navigationWithDefaultTransitions<Routes.Facts>(
-        startDestination = Routes.FactsPreview
-    ) {
-        composableWithDefaultTransitions<Routes.FactsPreview> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Facts) }
-            val viewModel = hiltViewModel<FactsViewModel>(parentEntry)
-
-            FactsPreviewScreen(
-                factsViewModel = viewModel,
-                onClose = { navController.navigateToHome() },
-                onBack = { navController.popBackStack() },
-            )
-        }
-    }
-    navigationWithDefaultTransitions<Routes.Blocks>(
-        startDestination = Routes.BlocksPreview
-    ) {
-        composableWithDefaultTransitions<Routes.BlocksPreview> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Blocks) }
-            val viewModel = hiltViewModel<BlocksViewModel>(parentEntry)
-
-            BlocksPreviewScreen(
-                blocksViewModel = viewModel,
-                onClose = { navController.navigateToHome() },
-                onBack = { navController.popBackStack() },
-                navigateEditWidget = { navController.navigateTo(Routes.BlocksEdit) },
-            )
-        }
-        composableWithDefaultTransitions<Routes.BlocksEdit> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Blocks) }
-            val viewModel = hiltViewModel<BlocksViewModel>(parentEntry)
-
-            BlocksEditScreen(
-                blocksViewModel = viewModel,
-                onBack = { navController.popBackStack() },
-                navigatePreview = { navController.navigateTo(Routes.BlocksPreview) }
-            )
-        }
-    }
-    navigationWithDefaultTransitions<Routes.Weather>(
-        startDestination = Routes.WeatherPreview
-    ) {
-        composableWithDefaultTransitions<Routes.WeatherPreview> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Weather) }
-            val viewModel = hiltViewModel<WeatherViewModel>(parentEntry)
-
-            WeatherPreviewScreen(
-                weatherViewModel = viewModel,
-                onClose = { navController.navigateToHome() },
-                onBack = { navController.popBackStack() },
-                navigateEditWidget = { navController.navigateTo(Routes.WeatherEdit) },
-            )
-        }
-        composableWithDefaultTransitions<Routes.WeatherEdit> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Weather) }
-            val viewModel = hiltViewModel<WeatherViewModel>(parentEntry)
-
-            WeatherEditScreen(
-                weatherViewModel = viewModel,
-                onBack = { navController.popBackStack() },
-                navigatePreview = { navController.navigateTo(Routes.WeatherPreview) }
-            )
-        }
-    }
-    navigationWithDefaultTransitions<Routes.Price>(
-        startDestination = Routes.PricePreview
-    ) {
-        composableWithDefaultTransitions<Routes.PricePreview> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Price) }
-            val viewModel = hiltViewModel<PriceViewModel>(parentEntry)
-
-            PricePreviewScreen(
-                priceViewModel = viewModel,
-                onClose = { navController.navigateToHome() },
-                onBack = { navController.popBackStack() },
-                navigateEditWidget = { navController.navigateTo(Routes.PriceEdit) },
-            )
-        }
-        composableWithDefaultTransitions<Routes.PriceEdit> {
-            val parentEntry = remember(it) { navController.getBackStackEntry(Routes.Price) }
-            val viewModel = hiltViewModel<PriceViewModel>(parentEntry)
-            PriceEditScreen(
-                viewModel = viewModel,
-                onBack = { navController.popBackStack() },
-                navigatePreview = { navController.navigateTo(Routes.PricePreview) }
-            )
-        }
     }
 }
 
@@ -2119,57 +2038,6 @@ sealed interface Routes {
 
     @Serializable
     data object WidgetsIntro : Routes
-
-    @Serializable
-    data object AddWidget : Routes
-
-    @Serializable
-    data object SuggestionsPreview : Routes
-
-    @Serializable
-    data object Headlines : Routes
-
-    @Serializable
-    data object HeadlinesPreview : Routes
-
-    @Serializable
-    data object HeadlinesEdit : Routes
-
-    @Serializable
-    data object Facts : Routes
-
-    @Serializable
-    data object FactsPreview : Routes
-
-    @Serializable
-    data object Blocks : Routes
-
-    @Serializable
-    data object BlocksPreview : Routes
-
-    @Serializable
-    data object BlocksEdit : Routes
-
-    @Serializable
-    data object Weather : Routes
-
-    @Serializable
-    data object WeatherPreview : Routes
-
-    @Serializable
-    data object WeatherEdit : Routes
-
-    @Serializable
-    data object Price : Routes
-
-    @Serializable
-    data object PricePreview : Routes
-
-    @Serializable
-    data object PriceEdit : Routes
-
-    @Serializable
-    data object CalculatorPreview : Routes
 
     @Serializable
     data object AppStatus : Routes

--- a/app/src/main/java/to/bitkit/ui/components/DrawerMenu.kt
+++ b/app/src/main/java/to/bitkit/ui/components/DrawerMenu.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.launch
 import to.bitkit.R
 import to.bitkit.ui.Routes
 import to.bitkit.ui.navigateTo
-import to.bitkit.ui.navigateToHome
 import to.bitkit.ui.navigateToProfile
 import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.shared.util.blockPointerInputPassthrough
@@ -70,7 +69,11 @@ fun DrawerMenu(
     hasSeenWidgetsIntro: Boolean,
     hasSeenShopIntro: Boolean,
     onBeforeNavigate: (Routes?) -> Unit,
+    showWidgets: Boolean,
     modifier: Modifier = Modifier,
+    onOpenWalletHome: () -> Unit = {},
+    onOpenWidgetsHome: () -> Unit = {},
+    onOpenWidgetsSheet: () -> Unit = {},
     hasSeenProfileIntro: Boolean = false,
     hasSeenContactsIntro: Boolean = false,
     hasContacts: Boolean = false,
@@ -114,8 +117,13 @@ fun DrawerMenu(
                     onBeforeNavigate(Routes.WidgetsIntro)
                     rootNavController.navigateIfNotCurrent(Routes.WidgetsIntro)
                 } else {
-                    onBeforeNavigate(Routes.AddWidget)
-                    rootNavController.navigateIfNotCurrent(Routes.AddWidget)
+                    if (showWidgets) {
+                        onBeforeNavigate(Routes.Home)
+                        onOpenWidgetsHome()
+                    } else {
+                        onBeforeNavigate(null)
+                        onOpenWidgetsSheet()
+                    }
                 }
             },
             onClickShop = {
@@ -173,6 +181,10 @@ fun DrawerMenu(
                     )
                 }
             },
+            onClickWallet = {
+                onBeforeNavigate(Routes.Home)
+                onOpenWalletHome()
+            },
             onBeforeNavigate = onBeforeNavigate,
         )
     }
@@ -186,6 +198,7 @@ private fun Menu(
     onClickShop: () -> Unit,
     onClickContacts: () -> Unit,
     onClickProfile: () -> Unit,
+    onClickWallet: () -> Unit,
     onBeforeNavigate: (Routes?) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
@@ -203,9 +216,7 @@ private fun Menu(
             label = stringResource(R.string.wallet__drawer__wallet),
             iconRes = R.drawable.ic_coins,
             onClick = {
-                val isInHome = rootNavController.currentBackStackEntry?.destination?.hasRoute<Routes.Home>() ?: false
-                onBeforeNavigate(null)
-                if (!isInHome) rootNavController.navigateToHome()
+                onClickWallet()
                 scope.launch { drawerState.close() }
             },
             modifier = Modifier.testTag("DrawerWallet")
@@ -383,6 +394,7 @@ private fun Preview() {
                 hasSeenWidgetsIntro = false,
                 hasSeenShopIntro = false,
                 onBeforeNavigate = {},
+                showWidgets = true,
                 modifier = Modifier.align(Alignment.TopEnd)
             )
         }

--- a/app/src/main/java/to/bitkit/ui/components/SheetHost.kt
+++ b/app/src/main/java/to/bitkit/ui/components/SheetHost.kt
@@ -5,8 +5,10 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -18,10 +20,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import kotlinx.coroutines.launch
 import to.bitkit.models.SamRockSetupRequest
 import to.bitkit.ui.screens.wallets.receive.ReceiveRoute
@@ -29,12 +36,18 @@ import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.sheets.BackupRoute
 import to.bitkit.ui.sheets.PinRoute
 import to.bitkit.ui.sheets.SendRoute
+import to.bitkit.ui.sheets.WidgetsRoute
 import to.bitkit.ui.theme.AppShapes
 import to.bitkit.ui.theme.Colors
 
 enum class SheetSize { LARGE, MEDIUM, SMALL, CALENDAR; }
 
-private val sheetContainerColor = Color(0xFF141414) // Equivalent to White08 on a Black background
+val DefaultSheetContainerColor = Color(0xFF141414) // Equivalent to White08 on a Black background
+
+enum class SheetHandlePlacement {
+    ScaffoldSlot,
+    ContentOverlay,
+}
 
 @Stable
 sealed interface Sheet {
@@ -44,6 +57,7 @@ sealed interface Sheet {
     data object ChangePin : Sheet
     data object DisablePin : Sheet
     data class Backup(val route: BackupRoute = BackupRoute.ShowMnemonic) : Sheet
+    data class Widgets(val route: WidgetsRoute = WidgetsRoute.Gallery) : Sheet
     data object ActivityDateRangeSelector : Sheet
     data object ActivityTagSelector : Sheet
     data class LnurlAuth(val domain: String, val lnurl: String, val k1: String) : Sheet
@@ -75,6 +89,8 @@ enum class TimedSheetType(val priority: Int) {
 fun SheetHost(
     shouldExpand: Boolean,
     onDismiss: () -> Unit = {},
+    sheetHandlePlacement: SheetHandlePlacement = SheetHandlePlacement.ScaffoldSlot,
+    sheetContainerColor: Color = DefaultSheetContainerColor,
     sheets: @Composable ColumnScope.() -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -82,6 +98,7 @@ fun SheetHost(
     val scaffoldState = rememberBottomSheetScaffoldState(
         bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     )
+    var wasSheetVisible by remember { mutableStateOf(false) }
 
     // Automatically expand or hide the bottom sheet based on bool flag
     LaunchedEffect(shouldExpand) {
@@ -92,10 +109,11 @@ fun SheetHost(
         }
     }
 
-    // Observe the state of the bottom sheet to invoke onDismiss callback
-    // TODO prevent onDismiss call during first render
     LaunchedEffect(scaffoldState.bottomSheetState.isVisible) {
-        if (!scaffoldState.bottomSheetState.isVisible) {
+        if (scaffoldState.bottomSheetState.isVisible) {
+            wasSheetVisible = true
+        } else if (wasSheetVisible) {
+            wasSheetVisible = false
             onDismiss()
         }
     }
@@ -105,8 +123,18 @@ fun SheetHost(
             scaffoldState = scaffoldState,
             sheetPeekHeight = 0.dp,
             sheetShape = AppShapes.sheet,
-            sheetContent = sheets,
-            sheetDragHandle = { SheetDragHandle() },
+            sheetContent = {
+                when (sheetHandlePlacement) {
+                    SheetHandlePlacement.ScaffoldSlot -> sheets()
+                    SheetHandlePlacement.ContentOverlay -> OverlayHandleSheetContent(sheets)
+                }
+            },
+            sheetDragHandle = when (sheetHandlePlacement) {
+                SheetHandlePlacement.ScaffoldSlot -> {
+                    { SheetDragHandle() }
+                }
+                SheetHandlePlacement.ContentOverlay -> null
+            },
             sheetContainerColor = sheetContainerColor,
             sheetContentColor = MaterialTheme.colorScheme.onSurface,
         ) {
@@ -127,6 +155,23 @@ fun SheetHost(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun OverlayHandleSheetContent(
+    sheets: @Composable ColumnScope.() -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            sheets()
+        }
+
+        SheetDragHandle(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .zIndex(1f)
+        )
     }
 }
 

--- a/app/src/main/java/to/bitkit/ui/screens/profile/PubkyChoiceScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/profile/PubkyChoiceScreen.kt
@@ -65,6 +65,7 @@ fun PubkyChoiceScreen(
     onNavigateToCreateProfile: () -> Unit,
     onNavigateToContactImportOverview: () -> Unit,
     onNavigateToPayContacts: () -> Unit,
+    onNavigateToProfile: () -> Unit,
     onBackClick: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -83,6 +84,13 @@ fun PubkyChoiceScreen(
                 PubkyChoiceEffect.NavigateToPayContacts -> onNavigateToPayContacts()
             }
         }
+    }
+
+    LaunchedEffect(uiState.navigateToProfile) {
+        if (!uiState.navigateToProfile) return@LaunchedEffect
+
+        viewModel.clearProfileNavigation()
+        onNavigateToProfile()
     }
 
     Content(

--- a/app/src/main/java/to/bitkit/ui/screens/profile/PubkyChoiceViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/profile/PubkyChoiceViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import to.bitkit.R
@@ -48,6 +49,13 @@ class PubkyChoiceViewModel @Inject constructor(
                 approvalJob?.cancel()
                 approvalJob = null
                 _uiState.update { it.copy(isWaitingForRing = false, isLoadingAfterAuth = false) }
+            }
+        }
+        viewModelScope.launch {
+            pubkyRepo.isAuthenticated.collectLatest {
+                if (it && approvalJob?.isActive != true && !_uiState.value.isLoadingAfterAuth) {
+                    _uiState.update { state -> state.copy(navigateToProfile = true) }
+                }
             }
         }
     }
@@ -159,6 +167,10 @@ class PubkyChoiceViewModel @Inject constructor(
         _uiState.update { it.copy(showRingNotInstalledDialog = false) }
     }
 
+    fun clearProfileNavigation() {
+        _uiState.update { it.copy(navigateToProfile = false) }
+    }
+
     @VisibleForTesting
     internal fun createRingAuthIntent(authUrl: String): Intent = Intent(Intent.ACTION_VIEW, Uri.parse(authUrl)).apply {
         setPackage(PUBKY_RING_PACKAGE)
@@ -196,6 +208,7 @@ data class PubkyChoiceUiState(
     val isWaitingForRing: Boolean = false,
     val isLoadingAfterAuth: Boolean = false,
     val showRingNotInstalledDialog: Boolean = false,
+    val navigateToProfile: Boolean = false,
 )
 
 sealed interface PubkyChoiceEffect {

--- a/app/src/main/java/to/bitkit/ui/screens/settings/DevSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/settings/DevSettingsScreen.kt
@@ -183,6 +183,13 @@ fun DevSettingsScreen(
             SectionHeader("DEBUG")
 
             SettingsTextButtonRow(
+                title = "Reset Widgets Intro Flag",
+                onClick = {
+                    settings.setHasSeenWidgetsIntro(false)
+                    app.toast(type = Toast.ToastType.SUCCESS, title = "Widgets intro flag reset")
+                }
+            )
+            SettingsTextButtonRow(
                 title = "Generate Test Activities",
                 onClick = {
                     val count = 100

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeScreen.kt
@@ -158,6 +158,7 @@ import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.shared.util.shareText
 import to.bitkit.ui.sheets.BackupRoute
 import to.bitkit.ui.sheets.PinRoute
+import to.bitkit.ui.sheets.toWidgetsPreviewRoute
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.theme.Insets
@@ -185,6 +186,10 @@ fun HomeScreen(
     walletViewModel: WalletViewModel,
     appViewModel: AppViewModel,
     activityListViewModel: ActivityListViewModel,
+    walletPageRequest: Int = 0,
+    widgetsPageRequest: Int = 0,
+    onConsumeWalletPageRequest: () -> Unit = {},
+    onConsumeWidgetsPageRequest: () -> Unit = {},
     onCalculatorInputActiveChanged: (Boolean) -> Unit = {},
     homeViewModel: HomeViewModel = hiltViewModel(),
 ) {
@@ -315,21 +320,13 @@ fun HomeScreen(
             if (!hasSeenWidgetsIntro) {
                 rootNavController.navigateTo(Routes.WidgetsIntro)
             } else {
-                rootNavController.navigateTo(Routes.AddWidget)
+                appViewModel.showSheet(Sheet.Widgets())
             }
         },
         onClickEditWidgetList = homeViewModel::onClickEditWidgetList,
         onClickEditWidget = { widgetType ->
             homeViewModel.disableEditMode()
-            when (widgetType) {
-                WidgetType.BLOCK -> rootNavController.navigateTo(Routes.BlocksPreview)
-                WidgetType.CALCULATOR -> rootNavController.navigateTo(Routes.CalculatorPreview)
-                WidgetType.FACTS -> rootNavController.navigateTo(Routes.FactsPreview)
-                WidgetType.NEWS -> rootNavController.navigateTo(Routes.HeadlinesPreview)
-                WidgetType.PRICE -> rootNavController.navigateTo(Routes.PricePreview)
-                WidgetType.WEATHER -> rootNavController.navigateTo(Routes.WeatherPreview)
-                WidgetType.SUGGESTIONS -> rootNavController.navigateTo(Routes.SuggestionsPreview)
-            }
+            appViewModel.showSheet(Sheet.Widgets(widgetType.toWidgetsPreviewRoute()))
         },
         onClickDeleteWidget = { widgetType ->
             homeViewModel.displayAlertDeleteWidget(widgetType)
@@ -337,6 +334,10 @@ fun HomeScreen(
         onMoveWidget = { fromIndex, toIndex ->
             homeViewModel.moveWidget(fromIndex, toIndex)
         },
+        walletPageRequest = walletPageRequest,
+        widgetsPageRequest = widgetsPageRequest,
+        onConsumeWalletPageRequest = onConsumeWalletPageRequest,
+        onConsumeWidgetsPageRequest = onConsumeWidgetsPageRequest,
         onPageChanged = homeViewModel::onPageChanged,
         onDismissWidgetsOnboardingHint = homeViewModel::dismissWidgetsOnboardingHint,
         onNavigateToAppStatus = { rootNavController.navigate(Routes.AppStatus) },
@@ -349,7 +350,7 @@ fun HomeScreen(
     )
 }
 
-@Suppress("MagicNumber")
+@Suppress("CyclomaticComplexMethod", "MagicNumber")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
 @Composable
 private fun Content(
@@ -369,6 +370,10 @@ private fun Content(
     onClickEditWidget: (WidgetType) -> Unit = {},
     onClickDeleteWidget: (WidgetType) -> Unit = {},
     onMoveWidget: (Int, Int) -> Unit = { _, _ -> },
+    walletPageRequest: Int = 0,
+    widgetsPageRequest: Int = 0,
+    onConsumeWalletPageRequest: () -> Unit = {},
+    onConsumeWidgetsPageRequest: () -> Unit = {},
     onPageChanged: (Int) -> Unit = {},
     onDismissWidgetsOnboardingHint: () -> Unit = {},
     onNavigateToAppStatus: () -> Unit = {},
@@ -407,6 +412,24 @@ private fun Content(
         if (pagerState.currentPage == 1 && !latestActivities.isNullOrEmpty()) {
             onDismissWidgetsOnboardingHint()
         }
+    }
+
+    LaunchedEffect(walletPageRequest) {
+        if (walletPageRequest == 0) return@LaunchedEffect
+
+        pagerState.animateScrollToPage(0)
+        onPageChanged(0)
+        onConsumeWalletPageRequest()
+    }
+
+    LaunchedEffect(widgetsPageRequest, pageCount) {
+        if (widgetsPageRequest == 0) return@LaunchedEffect
+
+        if (pageCount > 1) {
+            pagerState.animateScrollToPage(1)
+            onPageChanged(1)
+        }
+        onConsumeWidgetsPageRequest()
     }
 
     LaunchedEffect(pagerState.currentPage, isCalculatorInputActive) {
@@ -764,9 +787,9 @@ private fun WidgetsPage(
                         title = stringResource(widgetWithPosition.type.title),
                         onClickSettings = { onClickEditWidget(widgetWithPosition.type) },
                         onClickDelete = { onClickDeleteWidget(widgetWithPosition.type) },
-                        modifier = Modifier
-                            .fillMaxWidth(),
                         dragModifier = dragModifier,
+                        modifier = Modifier
+                            .fillMaxWidth()
                     )
                 }
             } else {

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendAmountScreen.kt
@@ -106,7 +106,7 @@ fun SendAmountScreen(
             onBack()
         }.takeIf { canGoBack },
         onClickMax = { maxSats ->
-            if (uiState.lnurl == null) {
+            if (uiState.lnurl == null && uiState.payMethod == SendMethod.LIGHTNING) {
                 app?.toast(
                     type = Toast.ToastType.INFO,
                     title = context.getString(R.string.wallet__send_max_spending__title),

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/AddWidgetsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/AddWidgetsScreen.kt
@@ -1,142 +1,523 @@
 package to.bitkit.ui.screens.widgets
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.persistentListOf
 import to.bitkit.R
+import to.bitkit.data.dto.FeeCondition
+import to.bitkit.data.dto.price.Change
+import to.bitkit.data.dto.price.GraphPeriod
+import to.bitkit.data.dto.price.PriceDTO
+import to.bitkit.data.dto.price.PriceWidgetData
+import to.bitkit.data.dto.price.TradingPair
+import to.bitkit.models.BitcoinDisplayUnit
+import to.bitkit.models.Suggestion
+import to.bitkit.models.USD_SYMBOL
 import to.bitkit.models.WidgetType
-import to.bitkit.ui.components.FillHeight
+import to.bitkit.models.widget.ArticleModel
+import to.bitkit.models.widget.BlockModel
+import to.bitkit.models.widget.BlocksPreferences
+import to.bitkit.models.widget.PricePreferences
+import to.bitkit.models.widget.WeatherDataOption
+import to.bitkit.models.widget.WeatherPreferences
+import to.bitkit.ui.components.BodyS
+import to.bitkit.ui.components.BottomSheetPreview
 import to.bitkit.ui.components.PrimaryButton
-import to.bitkit.ui.components.settings.SettingsButtonRow
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.DrawerNavIcon
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.screens.widgets.blocks.BlockCard
+import to.bitkit.ui.screens.widgets.blocks.WeatherModel
+import to.bitkit.ui.screens.widgets.calculator.components.CalculatorCardSmall
+import to.bitkit.ui.screens.widgets.components.WidgetCardDimens
+import to.bitkit.ui.screens.widgets.components.WidgetSheetTitle
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
+import to.bitkit.ui.screens.widgets.facts.FactsCardSmall
+import to.bitkit.ui.screens.widgets.headlines.HeadlineCard
+import to.bitkit.ui.screens.widgets.price.PriceCardSmall
+import to.bitkit.ui.screens.widgets.suggestions.SuggestionsPreviewGrid
+import to.bitkit.ui.screens.widgets.weather.WeatherCardSmall
+import to.bitkit.ui.shared.modifiers.clickableAlpha
+import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.theme.AppThemeSurface
+import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
-fun AddWidgetsScreen(
-    fiatSymbol: String,
-    showWidgets: Boolean = true,
-    onWidgetSelected: (WidgetType) -> Unit,
-    onBackClick: () -> Unit,
+fun AddWidgetsSheetContent(
+    showWidgets: Boolean,
+    modifier: Modifier = Modifier,
+    fiatSymbol: String = USD_SYMBOL,
+    onWidgetSelected: (WidgetType) -> Unit = {},
     onEnableInSettingsClick: () -> Unit = {},
+    galleryScrollState: ScrollState = rememberScrollState(),
+    weatherModel: WeatherModel? = null,
+    article: ArticleModel? = null,
+    block: BlockModel? = null,
+    fact: String? = null,
+    price: PriceDTO? = PreviewPrice,
 ) {
-    ScreenColumn {
-        AppTopBar(
-            titleText = stringResource(R.string.widgets__add),
-            onBackClick = onBackClick,
-            actions = { DrawerNavIcon() },
-        )
-
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("widgets_gallery_screen")
+    ) {
         Column(
             modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState())
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(galleryScrollState)
+                .testTag("widgets_gallery_scroll")
         ) {
-            SettingsButtonRow(
-                title = stringResource(R.string.widgets__price__name),
-                subtitle = stringResource(R.string.widgets__price__description),
-                iconRes = R.drawable.widget_chart_line,
-                iconSize = 48.dp,
-                maxLinesSubtitle = 1,
-                enabled = showWidgets,
-                onClick = { onWidgetSelected(WidgetType.PRICE) },
-                modifier = Modifier.testTag("WidgetListItem-price"),
+            WidgetSheetTitle(
+                title = stringResource(R.string.widgets__add),
+                modifier = Modifier.testTag("widgets_gallery_title")
             )
-            SettingsButtonRow(
-                title = stringResource(R.string.widgets__news__name),
-                subtitle = stringResource(R.string.widgets__news__description),
-                iconRes = R.drawable.widget_newspaper,
-                iconSize = 48.dp,
-                maxLinesSubtitle = 1,
-                enabled = showWidgets,
-                onClick = { onWidgetSelected(WidgetType.NEWS) },
-                modifier = Modifier.testTag("WidgetListItem-news"),
-            )
-            SettingsButtonRow(
-                title = stringResource(R.string.widgets__blocks__name),
-                subtitle = stringResource(R.string.widgets__blocks__description),
-                iconRes = R.drawable.widget_cube,
-                iconSize = 48.dp,
-                maxLinesSubtitle = 1,
-                enabled = showWidgets,
-                onClick = { onWidgetSelected(WidgetType.BLOCK) },
-                modifier = Modifier.testTag("WidgetListItem-blocks"),
-            )
-            SettingsButtonRow(
-                title = stringResource(R.string.widgets__facts__name),
-                subtitle = stringResource(R.string.widgets__facts__description),
-                iconRes = R.drawable.widget_lightbulb,
-                iconSize = 48.dp,
-                maxLinesSubtitle = 1,
-                enabled = showWidgets,
-                onClick = { onWidgetSelected(WidgetType.FACTS) },
-                modifier = Modifier.testTag("WidgetListItem-facts"),
-            )
-            SettingsButtonRow(
-                title = stringResource(R.string.widgets__weather__name),
-                subtitle = stringResource(R.string.widgets__weather__description),
-                iconRes = R.drawable.widget_cloud,
-                iconSize = 48.dp,
-                maxLinesSubtitle = 1,
-                enabled = showWidgets,
-                onClick = { onWidgetSelected(WidgetType.WEATHER) },
-                modifier = Modifier.testTag("WidgetListItem-weather"),
-            )
-            SettingsButtonRow(
-                title = stringResource(R.string.widgets__calculator__name),
-                subtitle = stringResource(R.string.widgets__calculator__description).replace(
-                    "{fiatSymbol}",
-                    fiatSymbol
-                ),
-                iconRes = R.drawable.widget_math_operation,
-                iconSize = 48.dp,
-                maxLinesSubtitle = 1,
-                enabled = showWidgets,
-                onClick = { onWidgetSelected(WidgetType.CALCULATOR) },
-                modifier = Modifier.testTag("WidgetListItem-calculator"),
-            )
-            SettingsButtonRow(
-                title = stringResource(R.string.widgets__suggestions__name),
-                subtitle = stringResource(R.string.widgets__suggestions__description),
-                iconRes = R.drawable.widget_suggestions,
-                iconSize = 48.dp,
-                maxLinesSubtitle = 1,
-                enabled = showWidgets,
-                onClick = { onWidgetSelected(WidgetType.SUGGESTIONS) },
-                modifier = Modifier.testTag("WidgetListItem-suggestions"),
+
+            WidgetsGalleryList(
+                fiatSymbol = fiatSymbol,
+                showWidgets = showWidgets,
+                onWidgetSelected = onWidgetSelected,
+                weatherModel = weatherModel,
+                article = article,
+                block = block,
+                fact = fact,
+                price = price,
+                modifier = Modifier.fillMaxWidth()
             )
         }
-        FillHeight()
-        if (!showWidgets) {
-            PrimaryButton(
-                text = stringResource(R.string.widgets__enable_in_settings),
-                onClick = onEnableInSettingsClick,
+
+        EnableWidgetsButton(
+            showWidgets = showWidgets,
+            onEnableInSettingsClick = onEnableInSettingsClick,
+        )
+    }
+}
+
+@Composable
+private fun WidgetsGalleryList(
+    fiatSymbol: String,
+    showWidgets: Boolean,
+    onWidgetSelected: (WidgetType) -> Unit,
+    modifier: Modifier = Modifier,
+    weatherModel: WeatherModel? = null,
+    article: ArticleModel? = null,
+    block: BlockModel? = null,
+    fact: String? = null,
+    price: PriceDTO? = PreviewPrice,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .padding(horizontal = 16.dp)
+            .padding(top = 16.dp)
+            .padding(bottom = Insets.Bottom + 24.dp)
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            WidgetPreviewItem(
+                title = stringResource(R.string.widgets__price__name),
+                showWidgets = showWidgets,
+                onClick = { onWidgetSelected(WidgetType.PRICE) },
+                testTag = "WidgetListItem-price",
+                modifier = Modifier.weight(1f)
+            ) {
+                if (price == null) {
+                    PriceLoadingCard(modifier = Modifier.smallPreviewCard())
+                } else {
+                    PriceCardSmall(
+                        pricePreferences = PreviewPricePreferences,
+                        priceDTO = price,
+                        backgroundColor = Colors.Gray6,
+                        modifier = Modifier.smallPreviewCard()
+                    )
+                }
+            }
+
+            WidgetPreviewItem(
+                title = stringResource(R.string.widgets__weather__name),
+                showWidgets = showWidgets,
+                onClick = { onWidgetSelected(WidgetType.WEATHER) },
+                testTag = "WidgetListItem-weather",
+                modifier = Modifier.weight(1f)
+            ) {
+                WeatherCardSmall(
+                    weatherModel = weatherModel ?: PreviewWeather,
+                    preferences = PreviewWeatherPreferences,
+                    modifier = Modifier.smallPreviewCard()
+                )
+            }
+        }
+
+        WidgetPreviewItem(
+            title = stringResource(R.string.widgets__news__name),
+            showWidgets = showWidgets,
+            onClick = { onWidgetSelected(WidgetType.NEWS) },
+            testTag = "WidgetListItem-news",
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            val previewArticle = article ?: PreviewArticle
+            HeadlineCard(
+                time = previewArticle.timeAgo,
+                headline = previewArticle.title,
+                source = previewArticle.publisher,
+                link = previewArticle.link,
+                enabled = showWidgets,
+                backgroundColor = Colors.Gray6,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .testTag("headline_card_wide")
+            )
+        }
+
+        WidgetPreviewItem(
+            title = stringResource(R.string.widgets__blocks__name),
+            showWidgets = showWidgets,
+            onClick = { onWidgetSelected(WidgetType.BLOCK) },
+            testTag = "WidgetListItem-blocks",
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            BlockCard(
+                preferences = PreviewBlocksPreferences,
+                block = block ?: PreviewBlock,
+                backgroundColor = Colors.Gray6,
+            )
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            WidgetPreviewItem(
+                title = stringResource(R.string.widgets__facts__name),
+                showWidgets = showWidgets,
+                onClick = { onWidgetSelected(WidgetType.FACTS) },
+                testTag = "WidgetListItem-facts",
+                testTagPlacement = WidgetPreviewTestTagPlacement.Title,
+                layoutTestTag = "WidgetListItem-facts-layout",
+                modifier = Modifier.weight(1f)
+            ) {
+                FactsCardSmall(
+                    headline = fact ?: PREVIEW_FACT,
+                    backgroundColor = Colors.Gray6,
+                    modifier = Modifier.smallPreviewCard()
+                )
+            }
+
+            WidgetPreviewItem(
+                title = stringResource(R.string.widgets__calculator__name),
+                showWidgets = showWidgets,
+                onClick = { onWidgetSelected(WidgetType.CALCULATOR) },
+                testTag = "WidgetListItem-calculator",
+                testTagPlacement = WidgetPreviewTestTagPlacement.Title,
+                layoutTestTag = "WidgetListItem-calculator-layout",
+                modifier = Modifier.weight(1f)
+            ) {
+                CalculatorCardSmall(
+                    btcPrimaryDisplayUnit = BitcoinDisplayUnit.MODERN,
+                    btcValue = PREVIEW_CALCULATOR_BTC_VALUE,
+                    fiatSymbol = fiatSymbol,
+                    fiatValue = PREVIEW_CALCULATOR_FIAT_VALUE,
+                    modifier = Modifier.smallPreviewCard()
+                )
+            }
+        }
+
+        WidgetPreviewItem(
+            title = stringResource(R.string.widgets__suggestions__name),
+            showWidgets = showWidgets,
+            onClick = { onWidgetSelected(WidgetType.SUGGESTIONS) },
+            testTag = "WidgetListItem-suggestions",
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            SuggestionsPreviewGrid(
+                suggestions = PREVIEW_SUGGESTIONS,
+                onSuggestionClick = {
+                    if (showWidgets) {
+                        onWidgetSelected(WidgetType.SUGGESTIONS)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }
 }
 
+@Composable
+private fun PriceLoadingCard(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .clip(MaterialTheme.shapes.medium)
+            .background(Colors.Gray6)
+    ) {
+        CircularProgressIndicator(color = Colors.White64)
+    }
+}
+
+@Composable
+private fun WidgetPreviewItem(
+    title: String,
+    showWidgets: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    testTag: String? = null,
+    testTagPlacement: WidgetPreviewTestTagPlacement = WidgetPreviewTestTagPlacement.Item,
+    layoutTestTag: String? = null,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .optionalTestTag(layoutTestTag)
+            .widgetPreviewTestTag(
+                tag = testTag,
+                tagPlacement = testTagPlacement,
+                targetPlacement = WidgetPreviewTestTagPlacement.Item,
+            )
+            .alpha(if (showWidgets) 1f else DISABLED_CARD_ALPHA)
+            .then(
+                if (showWidgets) {
+                    Modifier.semantics {
+                        role = Role.Button
+                        onClick {
+                            onClick()
+                            true
+                        }
+                    }
+                } else {
+                    Modifier
+                }
+            )
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            WidgetPreviewTitle(
+                title = title,
+                testTag = testTag,
+                testTagPlacement = testTagPlacement,
+                showWidgets = showWidgets,
+                onClick = onClick,
+            )
+            content()
+        }
+
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .clickableAlpha(
+                    pressedAlpha = 1f,
+                    enabled = showWidgets,
+                    onClick = onClick,
+                )
+        )
+    }
+}
+
+@Composable
+private fun WidgetPreviewTitle(
+    title: String,
+    testTag: String?,
+    testTagPlacement: WidgetPreviewTestTagPlacement,
+    showWidgets: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (testTag == null || testTagPlacement != WidgetPreviewTestTagPlacement.Title) {
+        BodyS(
+            text = title,
+            color = Colors.White64,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = modifier
+        )
+        return
+    }
+
+    val titleModifier = if (showWidgets) {
+        modifier
+            .fillMaxWidth()
+            .testTag(testTag)
+            .clickableAlpha(
+                pressedAlpha = 1f,
+                onClick = onClick,
+            )
+    } else {
+        modifier
+            .fillMaxWidth()
+            .testTag(testTag)
+    }
+
+    Box(modifier = titleModifier) {
+        BodyS(
+            text = title,
+            color = Colors.White64,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+private enum class WidgetPreviewTestTagPlacement {
+    Item,
+    Title,
+}
+
+private fun Modifier.optionalTestTag(tag: String?): Modifier {
+    if (tag == null) return this
+
+    return testTag(tag)
+}
+
+private fun Modifier.widgetPreviewTestTag(
+    tag: String?,
+    tagPlacement: WidgetPreviewTestTagPlacement,
+    targetPlacement: WidgetPreviewTestTagPlacement,
+): Modifier {
+    if (tag == null || tagPlacement != targetPlacement) return this
+
+    return testTag(tag)
+}
+
+@Composable
+private fun EnableWidgetsButton(
+    showWidgets: Boolean,
+    onEnableInSettingsClick: () -> Unit,
+) {
+    if (showWidgets) return
+
+    PrimaryButton(
+        text = stringResource(R.string.widgets__enable_in_settings),
+        onClick = onEnableInSettingsClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                start = 16.dp,
+                end = 16.dp,
+                top = 8.dp,
+                bottom = Insets.Bottom + 16.dp,
+            )
+            .testTag("WidgetEnableInSettings")
+    )
+}
+
+private fun Modifier.smallPreviewCard(): Modifier =
+    fillMaxWidth().height(WidgetCardDimens.COMPACT_CARD_SIZE.height)
+
+private val PreviewPricePreferences = PricePreferences(
+    enabledPairs = listOf(TradingPair.BTC_USD),
+    period = GraphPeriod.ONE_DAY,
+)
+
+private val PreviewPrice = PriceDTO(
+    widgets = listOf(
+        PriceWidgetData(
+            pair = TradingPair.BTC_USD,
+            period = GraphPeriod.ONE_DAY,
+            change = Change(isPositive = true, formatted = "+1.24%"),
+            price = "75,326",
+            pastValues = listOf(
+                1.0,
+                2.3,
+                1.4,
+                1.8,
+                4.9,
+                2.7,
+                3.2,
+                2.5,
+                6.3,
+                5.8,
+                3.9,
+                7.0,
+            ),
+        ),
+    ),
+)
+
+private val PreviewWeather = WeatherModel(
+    condition = FeeCondition.GOOD,
+    title = R.string.widgets__weather__condition__good__title,
+    shortTitle = R.string.widgets__weather__condition__good__short_title,
+    description = R.string.widgets__weather__condition__good__description,
+    currentFee = "$ 0.52",
+    currentFeeSats = 52,
+    currentFeeSatsFormatted = "52 sats/vByte",
+    nextBlockFee = "2 sats/vByte",
+    icon = FeeCondition.GOOD.icon,
+)
+
+private val PreviewWeatherPreferences = WeatherPreferences(
+    selectedOption = WeatherDataOption.CURRENT_FEE_FIAT,
+)
+
+private val PreviewBlock = BlockModel(
+    height = "761,405",
+    time = "01:31:42 UTC",
+    date = "11/2/2022",
+    transactionCount = "2,175",
+    size = "1,606kb",
+    fees = "25 059 357",
+)
+
+private val PreviewBlocksPreferences = BlocksPreferences(
+    showBlock = true,
+    showTime = true,
+    showDate = true,
+    showTransactions = true,
+    showSize = false,
+    showFees = false,
+)
+
+private const val PREVIEW_CALCULATOR_BTC_VALUE = "10000"
+private const val PREVIEW_CALCULATOR_FIAT_VALUE = "4.55"
+private const val PREVIEW_FACT = "Bitcoin doesn’t need your personal information"
+private val PreviewArticle = ArticleModel(
+    timeAgo = "21 min ago",
+    title = "How Bitcoin Changed El Salvador In More Ways...",
+    publisher = "bitcoinmagazine.com",
+    link = "https://bitcoinmagazine.com",
+)
+private val PREVIEW_SUGGESTIONS = persistentListOf(
+    Suggestion.BACK_UP,
+    Suggestion.SECURE,
+    Suggestion.LIGHTNING,
+    Suggestion.SUPPORT,
+)
+private const val DISABLED_CARD_ALPHA = 0.42f
+
 @Preview(showSystemUi = true)
 @Composable
-private fun Preview() {
+private fun PreviewSheet() {
     AppThemeSurface {
-        AddWidgetsScreen(
-            onWidgetSelected = {},
-            fiatSymbol = "$",
-            onBackClick = {},
-        )
+        BottomSheetPreview {
+            Column(
+                modifier = Modifier.sheetHeight(),
+            ) {
+                AddWidgetsSheetContent(
+                    showWidgets = true,
+                )
+            }
+        }
     }
 }
 
@@ -144,11 +525,14 @@ private fun Preview() {
 @Composable
 private fun PreviewDisabled() {
     AppThemeSurface {
-        AddWidgetsScreen(
-            onWidgetSelected = {},
-            fiatSymbol = "$",
-            onBackClick = {},
-            showWidgets = false,
-        )
+        BottomSheetPreview {
+            Column(
+                modifier = Modifier.sheetHeight(),
+            ) {
+                AddWidgetsSheetContent(
+                    showWidgets = false,
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/WidgetsGalleryViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/WidgetsGalleryViewModel.kt
@@ -1,0 +1,115 @@
+package to.bitkit.ui.screens.widgets
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import to.bitkit.data.dto.price.GraphPeriod
+import to.bitkit.data.dto.price.PriceDTO
+import to.bitkit.data.dto.price.TradingPair
+import to.bitkit.models.WidgetType
+import to.bitkit.models.widget.ArticleModel
+import to.bitkit.models.widget.BlockModel
+import to.bitkit.models.widget.toArticleModel
+import to.bitkit.models.widget.toBlockModel
+import to.bitkit.repositories.CurrencyRepo
+import to.bitkit.repositories.WidgetsRepo
+import to.bitkit.ui.screens.widgets.blocks.WeatherModel
+import to.bitkit.ui.screens.widgets.blocks.toWeatherModel
+import javax.inject.Inject
+
+@HiltViewModel
+class WidgetsGalleryViewModel @Inject constructor(
+    private val widgetsRepo: WidgetsRepo,
+    private val currencyRepo: CurrencyRepo,
+) : ViewModel() {
+    private val _currentPrice = MutableStateFlow<PriceDTO?>(null)
+    val currentPrice: StateFlow<PriceDTO?> = _currentPrice.asStateFlow()
+
+    val currentWeather: StateFlow<WeatherModel?> = combine(
+        widgetsRepo.weatherFlow,
+        currencyRepo.currencyState,
+    ) { weather, _ ->
+        weather?.toWeatherModel(
+            currentFee = currencyRepo.formatSatsAsFiatWithSymbol(weather.avgFeeSats, withSpace = true)
+                ?: weather.currentFee,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT),
+        initialValue = null,
+    )
+
+    val currentBlock: StateFlow<BlockModel?> = widgetsRepo.blocksFlow
+        .map { it?.toBlockModel() }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT),
+            initialValue = null,
+        )
+
+    val currentArticle: StateFlow<ArticleModel?> = widgetsRepo.articlesFlow
+        .map { articles -> articles.map { it.toArticleModel() }.randomOrNull() }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT),
+            initialValue = null,
+        )
+
+    val currentFact: StateFlow<String?> = widgetsRepo.factsFlow
+        .map { it.randomOrNull() }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT),
+            initialValue = null,
+        )
+
+    fun refreshOnDisplay() {
+        viewModelScope.launch {
+            coroutineScope {
+                launch { refreshPriceOnDisplay() }
+                launch { widgetsRepo.refreshWidget(WidgetType.WEATHER) }
+                launch { widgetsRepo.refreshWidget(WidgetType.BLOCK) }
+                launch { widgetsRepo.refreshWidget(WidgetType.NEWS) }
+                launch { widgetsRepo.refreshWidget(WidgetType.FACTS) }
+            }
+        }
+    }
+
+    private suspend fun refreshPriceOnDisplay() {
+        setCachedPriceIfAvailable()
+
+        widgetsRepo.fetchPriceData(
+            pairs = listOf(DEFAULT_PAIR),
+            period = DEFAULT_PERIOD,
+        ).onSuccess { price ->
+            _currentPrice.update { price }
+        }
+    }
+
+    private fun setCachedPriceIfAvailable() {
+        val cachedPrice = widgetsRepo.priceFlow.value
+            ?.takeIf { it.hasDefaultGalleryPrice() }
+
+        _currentPrice.update { it ?: cachedPrice }
+    }
+
+    private fun PriceDTO.hasDefaultGalleryPrice() = widgets.any {
+        it.pair == DEFAULT_PAIR && it.period == DEFAULT_PERIOD
+    }
+
+    companion object {
+        private const val SUBSCRIPTION_TIMEOUT = 5000L
+        private val DEFAULT_PAIR = TradingPair.BTC_USD
+        private val DEFAULT_PERIOD = GraphPeriod.ONE_DAY
+    }
+}

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/WidgetsIntroScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/WidgetsIntroScreen.kt
@@ -1,7 +1,9 @@
 package to.bitkit.ui.screens.widgets
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -17,6 +19,7 @@ import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.Display
 import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
@@ -26,18 +29,21 @@ import to.bitkit.ui.utils.withAccent
 
 @Composable
 fun WidgetsIntroScreen(
-    onContinue: () -> Unit,
+    onViewOrganize: () -> Unit,
+    onAddWidget: () -> Unit,
     onBackClick: () -> Unit,
 ) {
     ScreenColumn {
         AppTopBar(
-            titleText = "",
+            titleText = stringResource(R.string.widgets__widgets),
             onBackClick = onBackClick,
             actions = { DrawerNavIcon() },
         )
 
         Column(
-            modifier = Modifier.padding(horizontal = 32.dp)
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 32.dp)
         ) {
             Image(
                 painter = painterResource(R.drawable.puzzle),
@@ -54,13 +60,33 @@ fun WidgetsIntroScreen(
             Spacer(Modifier.height(8.dp))
             BodyM(text = stringResource(R.string.widgets__onboarding__description), color = Colors.White64)
             Spacer(Modifier.height(32.dp))
-            PrimaryButton(
-                text = stringResource(R.string.common__continue),
-                onClick = onContinue,
-                modifier = Modifier.testTag("WidgetsOnboarding-button")
-            )
-            Spacer(Modifier.height(16.dp))
         }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            SecondaryButton(
+                text = stringResource(R.string.widgets__onboarding__view_organize),
+                onClick = onViewOrganize,
+                fullWidth = false,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("WidgetsOnboarding-view-organize")
+            )
+            PrimaryButton(
+                text = stringResource(R.string.widgets__add),
+                onClick = onAddWidget,
+                fullWidth = false,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("WidgetsOnboardingAddWidget")
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
     }
 }
 
@@ -69,7 +95,8 @@ fun WidgetsIntroScreen(
 private fun Preview() {
     AppThemeSurface {
         WidgetsIntroScreen(
-            onContinue = {},
+            onViewOrganize = {},
+            onAddWidget = {},
             onBackClick = {}
         )
     }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlockCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlockCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -35,6 +36,7 @@ import to.bitkit.ui.theme.Colors
 @Composable
 fun BlockCard(
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Colors.White10,
     preferences: BlocksPreferences,
     block: BlockModel,
 ) {
@@ -45,7 +47,7 @@ fun BlockCard(
     Box(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.medium)
-            .background(Colors.White10)
+            .background(backgroundColor)
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -68,6 +70,7 @@ fun BlockCard(
 @Composable
 fun BlockCardSmall(
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Colors.White10,
     preferences: BlocksPreferences,
     block: BlockModel,
 ) {
@@ -79,7 +82,7 @@ fun BlockCardSmall(
         modifier = modifier
             .size(WidgetCardDimens.COMPACT_CARD_SIZE)
             .clip(shape = MaterialTheme.shapes.medium)
-            .background(Colors.White10)
+            .background(backgroundColor)
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksEditScreen.kt
@@ -31,10 +31,11 @@ import to.bitkit.ui.components.FillHeight
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun BlocksEditScreen(
@@ -76,12 +77,14 @@ private fun Content(
     block: BlockModel,
     modifier: Modifier = Modifier,
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("blocks_edit_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("blocks_edit_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__blocks__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -115,7 +118,10 @@ private fun Content(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier
-                    .padding(vertical = 21.dp)
+                    .padding(
+                        top = 21.dp,
+                        bottom = Insets.Bottom + 21.dp,
+                    )
                     .fillMaxWidth()
                     .testTag("buttons_row")
             ) {

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksPreviewScreen.kt
@@ -24,11 +24,12 @@ import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.widgets.components.WidgetSizeCarousel
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun BlocksPreviewScreen(
@@ -53,12 +54,10 @@ fun BlocksPreviewScreen(
         block = currentBlock,
         onClickEdit = navigateEditWidget,
         onClickDelete = {
-            blocksViewModel.removeWidget()
-            onClose()
+            blocksViewModel.removeWidget(onComplete = onClose)
         },
         onClickSave = {
-            blocksViewModel.savePreferences()
-            onClose()
+            blocksViewModel.savePreferences(onComplete = onClose)
         },
         modifier = modifier
     )
@@ -75,12 +74,14 @@ private fun Content(
     block: BlockModel?,
     modifier: Modifier = Modifier,
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("blocks_preview_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("blocks_preview_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__blocks__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -146,7 +147,7 @@ private fun Content(
                 .padding(
                     start = 16.dp,
                     end = 16.dp,
-                    bottom = 16.dp,
+                    bottom = Insets.Bottom + 16.dp,
                     top = 22.dp,
                 )
                 .fillMaxWidth()

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/blocks/BlocksViewModel.kt
@@ -74,16 +74,18 @@ class BlocksViewModel @Inject constructor(
         _customPreferences.value = BlocksPreferences()
     }
 
-    fun savePreferences() {
+    fun savePreferences(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.updateBlocksPreferences(_customPreferences.value)
             widgetsRepo.addWidget(WidgetType.BLOCK)
+            onComplete()
         }
     }
 
-    fun removeWidget() {
+    fun removeWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.deleteWidget(WidgetType.BLOCK)
+            onComplete()
         }
     }
 

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/calculator/CalculatorPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/calculator/CalculatorPreviewScreen.kt
@@ -22,13 +22,14 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.widgets.calculator.components.CalculatorCardEditor
 import to.bitkit.ui.screens.widgets.calculator.components.CalculatorCardSmall
 import to.bitkit.ui.screens.widgets.components.WidgetSizeCarousel
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun CalculatorPreviewScreen(
@@ -49,12 +50,10 @@ fun CalculatorPreviewScreen(
         onInputSelected = viewModel::onInputSelected,
         onInputDismissed = viewModel::onInputDismissed,
         onClickDelete = {
-            viewModel.removeWidget()
-            onClose()
+            viewModel.removeWidget(onComplete = onClose)
         },
         onClickSave = {
-            viewModel.saveWidget()
-            onClose()
+            viewModel.saveWidget(onComplete = onClose)
         },
         modifier = modifier
     )
@@ -73,12 +72,14 @@ fun CalculatorPreviewContent(
     onInputSelected: (MoneyType) -> Unit = {},
     onInputDismissed: () -> Unit = {},
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("calculator_preview_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("calculator_preview_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__calculator__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -141,7 +142,7 @@ fun CalculatorPreviewContent(
                 .padding(
                     start = 16.dp,
                     end = 16.dp,
-                    bottom = 16.dp,
+                    bottom = Insets.Bottom + 16.dp,
                     top = 22.dp,
                 )
                 .fillMaxWidth()

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/calculator/CalculatorViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/calculator/CalculatorViewModel.kt
@@ -63,15 +63,17 @@ class CalculatorViewModel @Inject constructor(
         observeCalculatorState()
     }
 
-    fun removeWidget() {
+    fun removeWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.deleteWidget(WidgetType.CALCULATOR)
+            onComplete()
         }
     }
 
-    fun saveWidget() {
+    fun saveWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.addWidget(WidgetType.CALCULATOR)
+            onComplete()
         }
     }
 

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/components/WidgetSheetPage.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/components/WidgetSheetPage.kt
@@ -1,0 +1,53 @@
+package to.bitkit.ui.screens.widgets.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import to.bitkit.ui.components.Subtitle
+import to.bitkit.ui.theme.Colors
+
+private val WidgetSheetTitleTopPadding = 32.dp
+private val WidgetSheetTitleHeight = 32.dp
+private val WidgetSheetTopBarTitleInset = 16.dp
+
+val WidgetSheetTopPadding = WidgetSheetTitleTopPadding - WidgetSheetTopBarTitleInset
+
+fun Modifier.widgetSheetPage(): Modifier = this
+    .padding(top = WidgetSheetTopPadding)
+
+fun Modifier.widgetSheetContent(): Modifier = this
+    .fillMaxSize()
+    .widgetSheetSurface()
+
+fun Modifier.widgetSheetSurface(): Modifier = this
+    .background(Colors.Gray7)
+
+@Composable
+fun WidgetSheetTitle(
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.TopCenter,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(top = WidgetSheetTitleTopPadding)
+            .height(WidgetSheetTitleHeight)
+    ) {
+        Subtitle(
+            text = title,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsCard.kt
@@ -33,11 +33,12 @@ import to.bitkit.ui.theme.Colors
 fun FactsCard(
     headline: String,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Colors.White10,
 ) {
     Box(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.medium)
-            .background(Colors.White10)
+            .background(backgroundColor)
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(20.dp),
@@ -63,12 +64,13 @@ fun FactsCard(
 fun FactsCardSmall(
     headline: String,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Colors.White10,
 ) {
     Box(
         modifier = modifier
             .size(WidgetCardDimens.COMPACT_CARD_SIZE)
             .clip(shape = MaterialTheme.shapes.medium)
-            .background(Colors.White10)
+            .background(backgroundColor)
     ) {
         Column(
             modifier = Modifier
@@ -112,10 +114,10 @@ private fun BitcoinBadge(modifier: Modifier = Modifier) {
 private fun PreviewWide() {
     AppThemeSurface {
         Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+                .padding(16.dp)
         ) {
             FactsCard(
                 headline = "Bitcoin doesn’t need your personal information",

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsPreviewScreen.kt
@@ -20,11 +20,12 @@ import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.widgets.components.WidgetSizeCarousel
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun FactsPreviewScreen(
@@ -45,12 +46,10 @@ fun FactsPreviewScreen(
         isFactsWidgetEnabled = isFactsWidgetEnabled,
         fact = fact,
         onClickDelete = {
-            factsViewModel.removeWidget()
-            onClose()
+            factsViewModel.removeWidget(onComplete = onClose)
         },
         onClickSave = {
-            factsViewModel.saveWidget()
-            onClose()
+            factsViewModel.saveWidget(onComplete = onClose)
         },
         modifier = modifier
     )
@@ -65,12 +64,14 @@ fun FactsPreviewContent(
     fact: String,
     modifier: Modifier = Modifier,
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("facts_preview_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("facts_preview_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__facts__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -119,7 +120,7 @@ fun FactsPreviewContent(
                 .padding(
                     start = 16.dp,
                     end = 16.dp,
-                    bottom = 16.dp,
+                    bottom = Insets.Bottom + 16.dp,
                     top = 22.dp,
                 )
                 .fillMaxWidth()

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/facts/FactsViewModel.kt
@@ -34,15 +34,17 @@ class FactsViewModel @Inject constructor(
             initialValue = DEFAULT_FACT
         )
 
-    fun saveWidget() {
+    fun saveWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.addWidget(WidgetType.FACTS)
+            onComplete()
         }
     }
 
-    fun removeWidget() {
+    fun removeWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.deleteWidget(WidgetType.FACTS)
+            onComplete()
         }
     }
 

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlineCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlineCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
@@ -30,20 +31,22 @@ import to.bitkit.ui.theme.Colors
 @Composable
 fun HeadlineCard(
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Colors.White10,
     showTime: Boolean = true,
     showSource: Boolean = true,
     time: String,
     headline: String,
     source: String,
     link: String,
+    enabled: Boolean = true,
 ) {
     val context = LocalContext.current
 
     Box(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.medium)
-            .background(Colors.White10)
-            .clickableAlpha {
+            .background(backgroundColor)
+            .clickableAlpha(enabled = enabled) {
                 val uri = safeBrowserUri(link) ?: return@clickableAlpha
                 val intent = Intent(Intent.ACTION_VIEW, uri)
                 context.startActivity(intent)
@@ -93,6 +96,7 @@ fun HeadlineCard(
 @Composable
 fun HeadlineCardSmall(
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Colors.White10,
     showTime: Boolean = true,
     time: String,
     headline: String,
@@ -104,7 +108,7 @@ fun HeadlineCardSmall(
         modifier = modifier
             .size(WidgetCardDimens.COMPACT_CARD_SIZE)
             .clip(shape = MaterialTheme.shapes.medium)
-            .background(Colors.White10)
+            .background(backgroundColor)
             .clickableAlpha {
                 val uri = safeBrowserUri(link) ?: return@clickableAlpha
                 val intent = Intent(Intent.ACTION_VIEW, uri)

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesEditScreen.kt
@@ -29,10 +29,11 @@ import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Title
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun HeadlinesEditScreen(
@@ -75,12 +76,14 @@ fun HeadlinesEditContent(
     article: ArticleModel,
     modifier: Modifier = Modifier,
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("headlines_edit_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("headlines_edit_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__news__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -206,11 +209,14 @@ fun HeadlinesEditContent(
             FillHeight()
 
             Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier
-                    .padding(vertical = 21.dp)
+                    .padding(
+                        top = 21.dp,
+                        bottom = Insets.Bottom + 21.dp,
+                    )
                     .fillMaxWidth()
-                    .testTag("buttons_row"),
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    .testTag("buttons_row")
             ) {
                 SecondaryButton(
                     text = stringResource(R.string.common__reset),

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesPreviewScreen.kt
@@ -24,11 +24,12 @@ import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.widgets.components.WidgetSizeCarousel
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun HeadlinesPreviewScreen(
@@ -53,12 +54,10 @@ fun HeadlinesPreviewScreen(
         article = article,
         onClickEdit = navigateEditWidget,
         onClickDelete = {
-            headlinesViewModel.removeWidget()
-            onClose()
+            headlinesViewModel.removeWidget(onComplete = onClose)
         },
         onClickSave = {
-            headlinesViewModel.savePreferences()
-            onClose()
+            headlinesViewModel.savePreferences(onComplete = onClose)
         },
         modifier = modifier
     )
@@ -75,12 +74,14 @@ fun HeadlinesPreviewContent(
     article: ArticleModel,
     modifier: Modifier = Modifier,
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("headlines_preview_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("headlines_preview_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__news__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -150,7 +151,7 @@ fun HeadlinesPreviewContent(
                 .padding(
                     start = 16.dp,
                     end = 16.dp,
-                    bottom = 16.dp,
+                    bottom = Insets.Bottom + 16.dp,
                     top = 22.dp,
                 )
                 .fillMaxWidth()

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/headlines/HeadlinesViewModel.kt
@@ -78,16 +78,18 @@ class HeadlinesViewModel @Inject constructor(
         _customPreferences.value = HeadlinePreferences()
     }
 
-    fun savePreferences() {
+    fun savePreferences(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.updateHeadlinePreferences(_customPreferences.value)
             widgetsRepo.addWidget(WidgetType.NEWS)
+            onComplete()
         }
     }
 
-    fun removeWidget() {
+    fun removeWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.deleteWidget(WidgetType.NEWS)
+            onComplete()
         }
     }
 

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -54,6 +55,7 @@ fun PriceCard(
     pricePreferences: PricePreferences,
     priceDTO: PriceDTO,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Colors.White10,
 ) {
     val widgetData = remember(pricePreferences.enabledPairs, priceDTO.widgets) {
         priceDTO.resolveWidget(pricePreferences)
@@ -62,7 +64,7 @@ fun PriceCard(
     Box(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.medium)
-            .background(Colors.White10)
+            .background(backgroundColor)
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -115,6 +117,7 @@ fun PriceCardSmall(
     pricePreferences: PricePreferences,
     priceDTO: PriceDTO,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Colors.White10,
 ) {
     val widgetData = remember(pricePreferences.enabledPairs, priceDTO.widgets) {
         priceDTO.resolveWidget(pricePreferences)
@@ -123,7 +126,7 @@ fun PriceCardSmall(
     Box(
         modifier = modifier
             .clip(shape = MaterialTheme.shapes.medium)
-            .background(Colors.White10)
+            .background(backgroundColor)
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceEditScreen.kt
@@ -1,12 +1,9 @@
 package to.bitkit.ui.screens.widgets.price
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -14,14 +11,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -84,66 +77,50 @@ fun PriceEditContent(
             .widgetSheetContent()
             .testTag("price_edit_screen")
     ) {
-        Box(
+        SheetTopBar(
+            titleText = stringResource(R.string.widgets__price__name),
+            onBack = onBack,
+        )
+
+        Column(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState())
+                .testTag("WidgetEditScrollView")
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp)
-                    .verticalScroll(rememberScrollState())
-                    .testTag("WidgetEditScrollView")
-            ) {
-                VerticalSpacer(82.dp)
+            VerticalSpacer(16.dp)
 
-                Caption13Up(
-                    text = stringResource(R.string.appwidget__price__currency),
-                    color = Colors.White64,
-                    modifier = Modifier.padding(bottom = 16.dp)
+            Caption13Up(
+                text = stringResource(R.string.appwidget__price__currency),
+                color = Colors.White64,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            for (pair in TradingPair.entries) {
+                SelectableRow(
+                    label = pair.displayName,
+                    isSelected = pair == selectedPair,
+                    onClick = { onSelectTradingPair(pair) },
+                    testTagPrefix = pair.displayName,
                 )
-
-                for (pair in TradingPair.entries) {
-                    SelectableRow(
-                        label = pair.displayName,
-                        isSelected = pair == selectedPair,
-                        onClick = { onSelectTradingPair(pair) },
-                        testTagPrefix = pair.displayName,
-                    )
-                }
-
-                VerticalSpacer(16.dp)
-
-                Caption13Up(
-                    text = stringResource(R.string.appwidget__price__timeframe),
-                    color = Colors.White64,
-                    modifier = Modifier.padding(vertical = 16.dp)
-                )
-
-                for (period in GraphPeriod.entries) {
-                    SelectableRow(
-                        label = period.label(),
-                        isSelected = period == preferences.period,
-                        onClick = { onSelectPeriod(period) },
-                        testTagPrefix = period.value,
-                    )
-                }
             }
 
-            Column {
-                SheetTopBar(
-                    titleText = stringResource(R.string.widgets__price__name),
-                    onBack = onBack,
-                    modifier = Modifier.background(
-                        Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.background,
-                                Color.Transparent,
-                            ),
-                            tileMode = TileMode.Decal,
-                        ),
-                    )
+            VerticalSpacer(16.dp)
+
+            Caption13Up(
+                text = stringResource(R.string.appwidget__price__timeframe),
+                color = Colors.White64,
+                modifier = Modifier.padding(vertical = 16.dp)
+            )
+
+            for (period in GraphPeriod.entries) {
+                SelectableRow(
+                    label = period.label(),
+                    isSelected = period == preferences.period,
+                    onClick = { onSelectPeriod(period) },
+                    testTagPrefix = period.value,
                 )
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceEditScreen.kt
@@ -38,10 +38,11 @@ import to.bitkit.ui.components.Caption13Up
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun PriceEditScreen(
@@ -78,8 +79,10 @@ fun PriceEditContent(
 ) {
     val selectedPair = preferences.enabledPairs.firstOrNull() ?: TradingPair.BTC_USD
 
-    ScreenColumn(
-        modifier = modifier.testTag("price_edit_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("price_edit_screen")
     ) {
         Box(
             modifier = Modifier
@@ -129,9 +132,9 @@ fun PriceEditContent(
             }
 
             Column {
-                AppTopBar(
+                SheetTopBar(
                     titleText = stringResource(R.string.widgets__price__name),
-                    onBackClick = onBack,
+                    onBack = onBack,
                     modifier = Modifier.background(
                         Brush.verticalGradient(
                             colors = listOf(
@@ -148,7 +151,12 @@ fun PriceEditContent(
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
-                .padding(16.dp)
+                .padding(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 16.dp,
+                    bottom = Insets.Bottom + 16.dp,
+                )
                 .fillMaxWidth()
                 .testTag("buttons_row")
         ) {

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PricePreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PricePreviewScreen.kt
@@ -30,12 +30,13 @@ import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.widgets.components.WidgetCardDimens
 import to.bitkit.ui.screens.widgets.components.WidgetSizeCarousel
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun PricePreviewScreen(
@@ -70,8 +71,7 @@ fun PricePreviewScreen(
         priceDTO = previewPrice ?: price,
         onClickEdit = navigateEditWidget,
         onClickDelete = {
-            priceViewModel.removeWidget()
-            onClose()
+            priceViewModel.removeWidget(onComplete = onClose)
         },
         onClickSave = {
             priceViewModel.savePreferences()
@@ -93,12 +93,14 @@ fun PricePreviewContent(
     isLoading: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("price_preview_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("price_preview_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__price__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -169,7 +171,7 @@ fun PricePreviewContent(
                 .padding(
                     start = 16.dp,
                     end = 16.dp,
-                    bottom = 16.dp,
+                    bottom = Insets.Bottom + 16.dp,
                     top = 22.dp,
                 )
                 .fillMaxWidth()

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceViewModel.kt
@@ -107,9 +107,10 @@ class PriceViewModel @Inject constructor(
         }
     }
 
-    fun removeWidget() {
+    fun removeWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.deleteWidget(WidgetType.PRICE)
+            onComplete()
         }
     }
 

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/suggestions/SuggestionsPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/suggestions/SuggestionsPreviewScreen.kt
@@ -1,9 +1,11 @@
 package to.bitkit.ui.screens.widgets.suggestions
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -16,12 +18,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import to.bitkit.R
 import to.bitkit.ext.spaceToNewline
 import to.bitkit.models.Suggestion
@@ -33,19 +38,25 @@ import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.SuggestionCard
 import to.bitkit.ui.components.Text13Up
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.DrawerNavIcon
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
-private val previewSuggestions = listOf(Suggestion.BUY, Suggestion.BACK_UP)
+private val previewSuggestions = persistentListOf(
+    Suggestion.BACK_UP,
+    Suggestion.SECURE,
+    Suggestion.LIGHTNING,
+    Suggestion.SUPPORT,
+)
 
 @Composable
 fun SuggestionsPreviewScreen(
     suggestionsViewModel: SuggestionsViewModel,
     onClose: () -> Unit,
     onBack: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val isSuggestionsWidgetEnabled by suggestionsViewModel.isSuggestionsWidgetEnabled
         .collectAsStateWithLifecycle()
@@ -54,13 +65,12 @@ fun SuggestionsPreviewScreen(
         onBack = onBack,
         isSuggestionsWidgetEnabled = isSuggestionsWidgetEnabled,
         onClickDelete = {
-            suggestionsViewModel.removeWidget()
-            onClose()
+            suggestionsViewModel.removeWidget(onComplete = onClose)
         },
         onClickSave = {
-            suggestionsViewModel.addWidget()
-            onClose()
+            suggestionsViewModel.addWidget(onComplete = onClose)
         },
+        modifier = modifier
     )
 }
 
@@ -70,12 +80,16 @@ private fun Content(
     onBack: () -> Unit,
     onClickDelete: () -> Unit,
     onClickSave: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    ScreenColumn {
-        AppTopBar(
-            titleText = stringResource(R.string.widgets__widget__nav_title),
-            onBackClick = onBack,
-            actions = { DrawerNavIcon() },
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("suggestions_preview_screen")
+    ) {
+        SheetTopBar(
+            titleText = stringResource(R.string.widgets__suggestions__name),
+            onBack = onBack,
         )
 
         Column(
@@ -86,7 +100,7 @@ private fun Content(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth()
             ) {
                 Headline(
                     text = AnnotatedString(stringResource(R.string.widgets__suggestions__name).spaceToNewline()),
@@ -115,40 +129,28 @@ private fun Content(
                 modifier = Modifier.padding(vertical = 16.dp)
             )
 
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                userScrollEnabled = false,
+            SuggestionsPreviewGrid(
+                onSuggestionClick = {},
                 modifier = Modifier.fillMaxWidth()
-            ) {
-                items(
-                    items = previewSuggestions,
-                    key = { it.name }
-                ) { item ->
-                    SuggestionCard(
-                        gradientColor = item.color,
-                        title = stringResource(item.title),
-                        description = stringResource(item.description),
-                        icon = item.icon,
-                        disableGlow = true,
-                        onClick = {},
-                    )
-                }
-            }
+            )
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier
-                    .padding(vertical = 21.dp)
-                    .fillMaxWidth(),
+                    .padding(
+                        top = 21.dp,
+                        bottom = Insets.Bottom + 21.dp,
+                    )
+                    .fillMaxWidth()
             ) {
                 if (isSuggestionsWidgetEnabled) {
                     SecondaryButton(
                         text = stringResource(R.string.common__delete),
                         fullWidth = false,
                         onClick = onClickDelete,
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag("WidgetDelete")
                     )
                 }
 
@@ -156,7 +158,48 @@ private fun Content(
                     text = stringResource(R.string.common__save),
                     fullWidth = false,
                     onClick = onClickSave,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("WidgetSave")
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SuggestionsPreviewGrid(
+    onSuggestionClick: (Suggestion) -> Unit,
+    modifier: Modifier = Modifier,
+    suggestions: ImmutableList<Suggestion> = previewSuggestions,
+) {
+    val rows = (suggestions.size + 1) / 2
+
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val cardSize = (maxWidth - 16.dp) / 2
+        val gridHeight = (cardSize * rows) + (16.dp * (rows - 1))
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            userScrollEnabled = false,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(gridHeight)
+        ) {
+            items(
+                items = suggestions,
+                key = { it.name },
+            ) { item ->
+                SuggestionCard(
+                    gradientColor = item.color,
+                    title = stringResource(item.title),
+                    description = stringResource(item.description),
+                    icon = item.icon,
+                    disableGlow = true,
+                    onClick = { onSuggestionClick(item) },
+                    modifier = Modifier.testTag("Suggestion-${item.name.lowercase()}")
                 )
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/suggestions/SuggestionsViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/suggestions/SuggestionsViewModel.kt
@@ -27,15 +27,17 @@ class SuggestionsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(SUBSCRIBE_TIMEOUT), false)
 
-    fun addWidget() {
+    fun addWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.addWidget(WidgetType.SUGGESTIONS)
+            onComplete()
         }
     }
 
-    fun removeWidget() {
+    fun removeWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.deleteWidget(WidgetType.SUGGESTIONS)
+            onComplete()
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherEditScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherEditScreen.kt
@@ -30,11 +30,12 @@ import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.rememberMoneyText
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.widgets.blocks.WeatherModel
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun WeatherEditScreen(
@@ -67,12 +68,14 @@ fun WeatherEditContent(
     weatherPreferences: WeatherPreferences,
     modifier: Modifier = Modifier,
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("weather_edit_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("weather_edit_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__weather__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -119,7 +122,10 @@ fun WeatherEditContent(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier
-                    .padding(vertical = 21.dp)
+                    .padding(
+                        top = 21.dp,
+                        bottom = Insets.Bottom + 21.dp,
+                    )
                     .fillMaxWidth()
                     .testTag("buttons_row")
             ) {

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherPreviewScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherPreviewScreen.kt
@@ -25,12 +25,13 @@ import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.components.settings.SettingsButtonRow
 import to.bitkit.ui.components.settings.SettingsButtonValue
-import to.bitkit.ui.scaffold.AppTopBar
-import to.bitkit.ui.scaffold.ScreenColumn
+import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.widgets.blocks.WeatherModel
 import to.bitkit.ui.screens.widgets.components.WidgetSizeCarousel
+import to.bitkit.ui.screens.widgets.components.widgetSheetContent
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.theme.Insets
 
 @Composable
 fun WeatherPreviewScreen(
@@ -55,12 +56,10 @@ fun WeatherPreviewScreen(
         weatherModel = weather,
         onClickEdit = navigateEditWidget,
         onClickDelete = {
-            weatherViewModel.removeWidget()
-            onClose()
+            weatherViewModel.removeWidget(onComplete = onClose)
         },
         onClickSave = {
-            weatherViewModel.savePreferences()
-            onClose()
+            weatherViewModel.savePreferences(onComplete = onClose)
         },
         modifier = modifier
     )
@@ -77,12 +76,14 @@ fun WeatherPreviewContent(
     weatherModel: WeatherModel?,
     modifier: Modifier = Modifier,
 ) {
-    ScreenColumn(
-        modifier = modifier.testTag("weather_preview_screen")
+    Column(
+        modifier = modifier
+            .widgetSheetContent()
+            .testTag("weather_preview_screen")
     ) {
-        AppTopBar(
+        SheetTopBar(
             titleText = stringResource(R.string.widgets__weather__name),
-            onBackClick = onBack,
+            onBack = onBack,
         )
 
         Column(
@@ -148,7 +149,7 @@ fun WeatherPreviewContent(
                 .padding(
                     start = 16.dp,
                     end = 16.dp,
-                    bottom = 16.dp,
+                    bottom = Insets.Bottom + 16.dp,
                     top = 22.dp,
                 )
                 .fillMaxWidth()

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/weather/WeatherViewModel.kt
@@ -91,16 +91,18 @@ class WeatherViewModel @Inject constructor(
         _customPreferences.value = WeatherPreferences()
     }
 
-    fun savePreferences() {
+    fun savePreferences(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.updateWeatherPreferences(_customPreferences.value)
             widgetsRepo.addWidget(WidgetType.WEATHER)
+            onComplete()
         }
     }
 
-    fun removeWidget() {
+    fun removeWidget(onComplete: () -> Unit = {}) {
         viewModelScope.launch {
             widgetsRepo.deleteWidget(WidgetType.WEATHER)
+            onComplete()
         }
     }
 

--- a/app/src/main/java/to/bitkit/ui/shared/modifiers/SheetHeight.kt
+++ b/app/src/main/java/to/bitkit/ui/shared/modifiers/SheetHeight.kt
@@ -18,8 +18,10 @@ fun Modifier.sheetHeight(
     size: SheetSize = SheetSize.LARGE,
     isModal: Boolean = false,
 ): Modifier = composed {
-    val offset = if (isModal) Insets.Bottom else 0.dp
-    val topPadding = Insets.Top + Insets.Bottom + offset + TopBarHeight - 6.dp
+    // Bottom safe-area belongs in sheet content padding; including it here moves
+    // non-modal sheet tops down on devices with larger navigation-bar insets.
+    val modalBottomPadding = if (isModal) Insets.Bottom + Insets.Bottom else 0.dp
+    val topPadding = Insets.Top + modalBottomPadding + TopBarHeight - 6.dp
 
     val height = when (size) {
         SheetSize.LARGE -> screenHeight(minus = topPadding) // topbar visible

--- a/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
@@ -230,7 +230,8 @@ fun SendSheet(
                         isNodeRunning = lightningState.nodeLifecycleState.isRunning(),
                         canGoBack = startDestination != SendRoute.Confirm,
                         onBack = {
-                            if (!navController.popBackStack()) {
+                            val didPopToAmount = navController.popBackStack(SendRoute.Amount, inclusive = false)
+                            if (!didPopToAmount && !navController.popBackStack()) {
                                 appViewModel.hideSheet()
                             }
                         },

--- a/app/src/main/java/to/bitkit/ui/sheets/WidgetsSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/WidgetsSheet.kt
@@ -1,0 +1,372 @@
+package to.bitkit.ui.sheets
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.HasDefaultViewModelProviderFactory
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import kotlinx.serialization.Serializable
+import to.bitkit.models.WidgetType
+import to.bitkit.ui.components.BottomSheetPreview
+import to.bitkit.ui.components.Sheet
+import to.bitkit.ui.components.SheetSize
+import to.bitkit.ui.navigateTo
+import to.bitkit.ui.screens.widgets.AddWidgetsSheetContent
+import to.bitkit.ui.screens.widgets.WidgetsGalleryViewModel
+import to.bitkit.ui.screens.widgets.blocks.BlocksEditScreen
+import to.bitkit.ui.screens.widgets.blocks.BlocksPreviewScreen
+import to.bitkit.ui.screens.widgets.blocks.BlocksViewModel
+import to.bitkit.ui.screens.widgets.calculator.CalculatorPreviewScreen
+import to.bitkit.ui.screens.widgets.components.widgetSheetPage
+import to.bitkit.ui.screens.widgets.components.widgetSheetSurface
+import to.bitkit.ui.screens.widgets.facts.FactsPreviewScreen
+import to.bitkit.ui.screens.widgets.facts.FactsViewModel
+import to.bitkit.ui.screens.widgets.headlines.HeadlinesEditScreen
+import to.bitkit.ui.screens.widgets.headlines.HeadlinesPreviewScreen
+import to.bitkit.ui.screens.widgets.headlines.HeadlinesViewModel
+import to.bitkit.ui.screens.widgets.price.PriceEditScreen
+import to.bitkit.ui.screens.widgets.price.PricePreviewScreen
+import to.bitkit.ui.screens.widgets.price.PriceViewModel
+import to.bitkit.ui.screens.widgets.suggestions.SuggestionsPreviewScreen
+import to.bitkit.ui.screens.widgets.suggestions.SuggestionsViewModel
+import to.bitkit.ui.screens.widgets.weather.WeatherEditScreen
+import to.bitkit.ui.screens.widgets.weather.WeatherPreviewScreen
+import to.bitkit.ui.screens.widgets.weather.WeatherViewModel
+import to.bitkit.ui.shared.modifiers.sheetHeight
+import to.bitkit.ui.theme.AppThemeSurface
+import to.bitkit.ui.utils.composableWithDefaultTransitions
+import to.bitkit.viewmodels.AppViewModel
+
+@Composable
+fun WidgetsSheet(
+    sheet: Sheet.Widgets,
+    app: AppViewModel,
+    fiatSymbol: String,
+    showWidgets: Boolean,
+    onNavigateHomeWidgets: () -> Unit,
+    onOpenWidgetsSettings: () -> Unit,
+) {
+    val navController = rememberNavController()
+    val onDismiss = app::hideSheet
+    val onDone = {
+        app.hideSheet()
+        onNavigateHomeWidgets()
+    }
+
+    WidgetsSheetContent(
+        startRoute = sheet.route,
+        navController = navController,
+        fiatSymbol = fiatSymbol,
+        showWidgets = showWidgets,
+        onDismiss = onDismiss,
+        onDone = onDone,
+        onOpenWidgetsSettings = {
+            app.hideSheet()
+            onOpenWidgetsSettings()
+        },
+    )
+}
+
+@Composable
+private fun WidgetsSheetContent(
+    startRoute: WidgetsRoute,
+    navController: NavHostController,
+    fiatSymbol: String,
+    showWidgets: Boolean,
+    onDismiss: () -> Unit,
+    onDone: () -> Unit,
+    onOpenWidgetsSettings: () -> Unit,
+) {
+    val sheetViewModelStoreOwner = rememberSheetViewModelStoreOwner()
+    val galleryScrollState = rememberScrollState()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val isGalleryRoute = navBackStackEntry?.destination?.hasRoute<WidgetsRoute.Gallery>() == true
+
+    LaunchedEffect(isGalleryRoute) {
+        galleryScrollState.scrollTo(0)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .sheetHeight(SheetSize.LARGE)
+            .widgetSheetSurface()
+            .testTag("widgets_navigation_sheet")
+    ) {
+        NavHost(
+            navController = navController,
+            startDestination = startRoute,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            composableWithDefaultTransitions<WidgetsRoute.Gallery> {
+                val galleryViewModel = hiltViewModel<WidgetsGalleryViewModel>(
+                    viewModelStoreOwner = sheetViewModelStoreOwner
+                )
+                val weather by galleryViewModel.currentWeather.collectAsStateWithLifecycle()
+                val block by galleryViewModel.currentBlock.collectAsStateWithLifecycle()
+                val article by galleryViewModel.currentArticle.collectAsStateWithLifecycle()
+                val fact by galleryViewModel.currentFact.collectAsStateWithLifecycle()
+                val price by galleryViewModel.currentPrice.collectAsStateWithLifecycle()
+
+                LaunchedEffect(Unit) {
+                    galleryViewModel.refreshOnDisplay()
+                }
+
+                AddWidgetsSheetContent(
+                    fiatSymbol = fiatSymbol,
+                    showWidgets = showWidgets,
+                    onWidgetSelected = {
+                        navController.navigateTo(it.toWidgetsPreviewRoute())
+                    },
+                    onEnableInSettingsClick = onOpenWidgetsSettings,
+                    galleryScrollState = galleryScrollState,
+                    weatherModel = weather,
+                    article = article,
+                    block = block,
+                    fact = fact,
+                    price = price,
+                    modifier = Modifier
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.PricePreview> {
+                val priceViewModel = hiltViewModel<PriceViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+
+                PricePreviewScreen(
+                    priceViewModel = priceViewModel,
+                    onClose = onDone,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    navigateEditWidget = { navController.navigateTo(WidgetsRoute.PriceEdit) },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.PriceEdit> {
+                val priceViewModel = hiltViewModel<PriceViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+
+                PriceEditScreen(
+                    viewModel = priceViewModel,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    navigatePreview = { navController.popBackStack() },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.WeatherPreview> {
+                val weatherViewModel = hiltViewModel<WeatherViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+
+                WeatherPreviewScreen(
+                    weatherViewModel = weatherViewModel,
+                    onClose = onDone,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    navigateEditWidget = { navController.navigateTo(WidgetsRoute.WeatherEdit) },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.WeatherEdit> {
+                val weatherViewModel = hiltViewModel<WeatherViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+
+                WeatherEditScreen(
+                    weatherViewModel = weatherViewModel,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    navigatePreview = { navController.popBackStack() },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.BlocksPreview> {
+                val blocksViewModel = hiltViewModel<BlocksViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+
+                BlocksPreviewScreen(
+                    blocksViewModel = blocksViewModel,
+                    onClose = onDone,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    navigateEditWidget = { navController.navigateTo(WidgetsRoute.BlocksEdit) },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.BlocksEdit> {
+                val blocksViewModel = hiltViewModel<BlocksViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+
+                BlocksEditScreen(
+                    blocksViewModel = blocksViewModel,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    navigatePreview = { navController.popBackStack() },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.HeadlinesPreview> {
+                val headlinesViewModel = hiltViewModel<HeadlinesViewModel>(
+                    viewModelStoreOwner = sheetViewModelStoreOwner
+                )
+
+                HeadlinesPreviewScreen(
+                    headlinesViewModel = headlinesViewModel,
+                    onClose = onDone,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    navigateEditWidget = { navController.navigateTo(WidgetsRoute.HeadlinesEdit) },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.HeadlinesEdit> {
+                val headlinesViewModel = hiltViewModel<HeadlinesViewModel>(
+                    viewModelStoreOwner = sheetViewModelStoreOwner
+                )
+
+                HeadlinesEditScreen(
+                    headlinesViewModel = headlinesViewModel,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    navigatePreview = { navController.popBackStack() },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.FactsPreview> {
+                val factsViewModel = hiltViewModel<FactsViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+
+                FactsPreviewScreen(
+                    factsViewModel = factsViewModel,
+                    onClose = onDone,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.CalculatorPreview> {
+                CalculatorPreviewScreen(
+                    onClose = onDone,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+            composableWithDefaultTransitions<WidgetsRoute.SuggestionsPreview> {
+                val suggestionsViewModel = hiltViewModel<SuggestionsViewModel>(
+                    viewModelStoreOwner = sheetViewModelStoreOwner
+                )
+
+                SuggestionsPreviewScreen(
+                    suggestionsViewModel = suggestionsViewModel,
+                    onClose = onDone,
+                    onBack = { navController.popOrDismiss(onDismiss) },
+                    modifier = Modifier.widgetSheetPage()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberSheetViewModelStoreOwner(): ViewModelStoreOwner {
+    val parentOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    }
+    val parentFactoryOwner = checkNotNull(parentOwner as? HasDefaultViewModelProviderFactory) {
+        "WidgetsSheet requires a default ViewModelProvider.Factory owner"
+    }
+    val viewModelStore = remember { ViewModelStore() }
+    DisposableEffect(viewModelStore) {
+        onDispose { viewModelStore.clear() }
+    }
+
+    return remember(viewModelStore, parentFactoryOwner) {
+        SheetViewModelStoreOwner(viewModelStore, parentFactoryOwner)
+    }
+}
+
+private class SheetViewModelStoreOwner(
+    private val store: ViewModelStore,
+    private val factoryOwner: HasDefaultViewModelProviderFactory,
+) : ViewModelStoreOwner, HasDefaultViewModelProviderFactory {
+    override val viewModelStore: ViewModelStore = store
+    override val defaultViewModelProviderFactory: ViewModelProvider.Factory
+        get() = factoryOwner.defaultViewModelProviderFactory
+    override val defaultViewModelCreationExtras: CreationExtras
+        get() = factoryOwner.defaultViewModelCreationExtras
+}
+
+private fun NavHostController.popOrDismiss(onDismiss: () -> Unit) {
+    if (!popBackStack()) {
+        onDismiss()
+    }
+}
+
+fun WidgetType.toWidgetsPreviewRoute(): WidgetsRoute = when (this) {
+    WidgetType.BLOCK -> WidgetsRoute.BlocksPreview
+    WidgetType.CALCULATOR -> WidgetsRoute.CalculatorPreview
+    WidgetType.FACTS -> WidgetsRoute.FactsPreview
+    WidgetType.NEWS -> WidgetsRoute.HeadlinesPreview
+    WidgetType.PRICE -> WidgetsRoute.PricePreview
+    WidgetType.WEATHER -> WidgetsRoute.WeatherPreview
+    WidgetType.SUGGESTIONS -> WidgetsRoute.SuggestionsPreview
+}
+
+sealed interface WidgetsRoute {
+    @Serializable
+    data object Gallery : WidgetsRoute
+
+    @Serializable
+    data object PricePreview : WidgetsRoute
+
+    @Serializable
+    data object PriceEdit : WidgetsRoute
+
+    @Serializable
+    data object WeatherPreview : WidgetsRoute
+
+    @Serializable
+    data object WeatherEdit : WidgetsRoute
+
+    @Serializable
+    data object BlocksPreview : WidgetsRoute
+
+    @Serializable
+    data object BlocksEdit : WidgetsRoute
+
+    @Serializable
+    data object HeadlinesPreview : WidgetsRoute
+
+    @Serializable
+    data object HeadlinesEdit : WidgetsRoute
+
+    @Serializable
+    data object FactsPreview : WidgetsRoute
+
+    @Serializable
+    data object CalculatorPreview : WidgetsRoute
+
+    @Serializable
+    data object SuggestionsPreview : WidgetsRoute
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun Preview() {
+    AppThemeSurface {
+        BottomSheetPreview {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .sheetHeight(SheetSize.LARGE, isModal = true)
+                    .widgetSheetSurface()
+            ) {
+                AddWidgetsSheetContent(
+                    showWidgets = true,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/to/bitkit/ui/sheets/WidgetsSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/WidgetsSheet.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -97,10 +98,13 @@ private fun WidgetsSheetContent(
     onDone: () -> Unit,
     onOpenWidgetsSettings: () -> Unit,
 ) {
-    val sheetViewModelStoreOwner = rememberSheetViewModelStoreOwner()
+    val galleryViewModelStoreOwner = rememberSheetViewModelStoreOwner()
     val galleryScrollState = rememberScrollState()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val isGalleryRoute = navBackStackEntry?.destination?.hasRoute<WidgetsRoute.Gallery>() == true
+    val widgetFlowKey = navBackStackEntry?.destination?.widgetFlowKey()
+        ?: startRoute.widgetFlowKey().takeIf { navBackStackEntry == null }
+    val widgetViewModelStoreOwner = rememberWidgetFlowViewModelStoreOwner(widgetFlowKey)
 
     LaunchedEffect(isGalleryRoute) {
         galleryScrollState.scrollTo(0)
@@ -120,7 +124,7 @@ private fun WidgetsSheetContent(
         ) {
             composableWithDefaultTransitions<WidgetsRoute.Gallery> {
                 val galleryViewModel = hiltViewModel<WidgetsGalleryViewModel>(
-                    viewModelStoreOwner = sheetViewModelStoreOwner
+                    viewModelStoreOwner = galleryViewModelStoreOwner
                 )
                 val weather by galleryViewModel.currentWeather.collectAsStateWithLifecycle()
                 val block by galleryViewModel.currentBlock.collectAsStateWithLifecycle()
@@ -149,7 +153,7 @@ private fun WidgetsSheetContent(
                 )
             }
             composableWithDefaultTransitions<WidgetsRoute.PricePreview> {
-                val priceViewModel = hiltViewModel<PriceViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+                val priceViewModel = hiltViewModel<PriceViewModel>(viewModelStoreOwner = widgetViewModelStoreOwner)
 
                 PricePreviewScreen(
                     priceViewModel = priceViewModel,
@@ -160,7 +164,7 @@ private fun WidgetsSheetContent(
                 )
             }
             composableWithDefaultTransitions<WidgetsRoute.PriceEdit> {
-                val priceViewModel = hiltViewModel<PriceViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+                val priceViewModel = hiltViewModel<PriceViewModel>(viewModelStoreOwner = widgetViewModelStoreOwner)
 
                 PriceEditScreen(
                     viewModel = priceViewModel,
@@ -170,7 +174,7 @@ private fun WidgetsSheetContent(
                 )
             }
             composableWithDefaultTransitions<WidgetsRoute.WeatherPreview> {
-                val weatherViewModel = hiltViewModel<WeatherViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+                val weatherViewModel = hiltViewModel<WeatherViewModel>(viewModelStoreOwner = widgetViewModelStoreOwner)
 
                 WeatherPreviewScreen(
                     weatherViewModel = weatherViewModel,
@@ -181,7 +185,7 @@ private fun WidgetsSheetContent(
                 )
             }
             composableWithDefaultTransitions<WidgetsRoute.WeatherEdit> {
-                val weatherViewModel = hiltViewModel<WeatherViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+                val weatherViewModel = hiltViewModel<WeatherViewModel>(viewModelStoreOwner = widgetViewModelStoreOwner)
 
                 WeatherEditScreen(
                     weatherViewModel = weatherViewModel,
@@ -191,7 +195,7 @@ private fun WidgetsSheetContent(
                 )
             }
             composableWithDefaultTransitions<WidgetsRoute.BlocksPreview> {
-                val blocksViewModel = hiltViewModel<BlocksViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+                val blocksViewModel = hiltViewModel<BlocksViewModel>(viewModelStoreOwner = widgetViewModelStoreOwner)
 
                 BlocksPreviewScreen(
                     blocksViewModel = blocksViewModel,
@@ -202,7 +206,7 @@ private fun WidgetsSheetContent(
                 )
             }
             composableWithDefaultTransitions<WidgetsRoute.BlocksEdit> {
-                val blocksViewModel = hiltViewModel<BlocksViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+                val blocksViewModel = hiltViewModel<BlocksViewModel>(viewModelStoreOwner = widgetViewModelStoreOwner)
 
                 BlocksEditScreen(
                     blocksViewModel = blocksViewModel,
@@ -213,7 +217,7 @@ private fun WidgetsSheetContent(
             }
             composableWithDefaultTransitions<WidgetsRoute.HeadlinesPreview> {
                 val headlinesViewModel = hiltViewModel<HeadlinesViewModel>(
-                    viewModelStoreOwner = sheetViewModelStoreOwner
+                    viewModelStoreOwner = widgetViewModelStoreOwner
                 )
 
                 HeadlinesPreviewScreen(
@@ -226,7 +230,7 @@ private fun WidgetsSheetContent(
             }
             composableWithDefaultTransitions<WidgetsRoute.HeadlinesEdit> {
                 val headlinesViewModel = hiltViewModel<HeadlinesViewModel>(
-                    viewModelStoreOwner = sheetViewModelStoreOwner
+                    viewModelStoreOwner = widgetViewModelStoreOwner
                 )
 
                 HeadlinesEditScreen(
@@ -237,7 +241,7 @@ private fun WidgetsSheetContent(
                 )
             }
             composableWithDefaultTransitions<WidgetsRoute.FactsPreview> {
-                val factsViewModel = hiltViewModel<FactsViewModel>(viewModelStoreOwner = sheetViewModelStoreOwner)
+                val factsViewModel = hiltViewModel<FactsViewModel>(viewModelStoreOwner = widgetViewModelStoreOwner)
 
                 FactsPreviewScreen(
                     factsViewModel = factsViewModel,
@@ -255,7 +259,7 @@ private fun WidgetsSheetContent(
             }
             composableWithDefaultTransitions<WidgetsRoute.SuggestionsPreview> {
                 val suggestionsViewModel = hiltViewModel<SuggestionsViewModel>(
-                    viewModelStoreOwner = sheetViewModelStoreOwner
+                    viewModelStoreOwner = widgetViewModelStoreOwner
                 )
 
                 SuggestionsPreviewScreen(
@@ -270,14 +274,24 @@ private fun WidgetsSheetContent(
 }
 
 @Composable
+private fun rememberWidgetFlowViewModelStoreOwner(widgetFlowKey: WidgetFlowKey?): ViewModelStoreOwner {
+    return rememberViewModelStoreOwner(key = widgetFlowKey)
+}
+
+@Composable
 private fun rememberSheetViewModelStoreOwner(): ViewModelStoreOwner {
+    return rememberViewModelStoreOwner(key = "sheet")
+}
+
+@Composable
+private fun rememberViewModelStoreOwner(key: Any?): ViewModelStoreOwner {
     val parentOwner = checkNotNull(LocalViewModelStoreOwner.current) {
         "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
     }
     val parentFactoryOwner = checkNotNull(parentOwner as? HasDefaultViewModelProviderFactory) {
         "WidgetsSheet requires a default ViewModelProvider.Factory owner"
     }
-    val viewModelStore = remember { ViewModelStore() }
+    val viewModelStore = remember(key) { ViewModelStore() }
     DisposableEffect(viewModelStore) {
         onDispose { viewModelStore.clear() }
     }
@@ -312,6 +326,49 @@ fun WidgetType.toWidgetsPreviewRoute(): WidgetsRoute = when (this) {
     WidgetType.PRICE -> WidgetsRoute.PricePreview
     WidgetType.WEATHER -> WidgetsRoute.WeatherPreview
     WidgetType.SUGGESTIONS -> WidgetsRoute.SuggestionsPreview
+}
+
+private fun WidgetsRoute.widgetFlowKey(): WidgetFlowKey? = when (this) {
+    WidgetsRoute.PricePreview,
+    WidgetsRoute.PriceEdit,
+    -> WidgetFlowKey.PRICE
+
+    WidgetsRoute.WeatherPreview,
+    WidgetsRoute.WeatherEdit,
+    -> WidgetFlowKey.WEATHER
+
+    WidgetsRoute.BlocksPreview,
+    WidgetsRoute.BlocksEdit,
+    -> WidgetFlowKey.BLOCKS
+
+    WidgetsRoute.HeadlinesPreview,
+    WidgetsRoute.HeadlinesEdit,
+    -> WidgetFlowKey.HEADLINES
+
+    WidgetsRoute.FactsPreview -> WidgetFlowKey.FACTS
+    WidgetsRoute.SuggestionsPreview -> WidgetFlowKey.SUGGESTIONS
+    WidgetsRoute.Gallery,
+    WidgetsRoute.CalculatorPreview,
+    -> null
+}
+
+private fun NavDestination.widgetFlowKey(): WidgetFlowKey? = when {
+    hasRoute<WidgetsRoute.PricePreview>() || hasRoute<WidgetsRoute.PriceEdit>() -> WidgetFlowKey.PRICE
+    hasRoute<WidgetsRoute.WeatherPreview>() || hasRoute<WidgetsRoute.WeatherEdit>() -> WidgetFlowKey.WEATHER
+    hasRoute<WidgetsRoute.BlocksPreview>() || hasRoute<WidgetsRoute.BlocksEdit>() -> WidgetFlowKey.BLOCKS
+    hasRoute<WidgetsRoute.HeadlinesPreview>() || hasRoute<WidgetsRoute.HeadlinesEdit>() -> WidgetFlowKey.HEADLINES
+    hasRoute<WidgetsRoute.FactsPreview>() -> WidgetFlowKey.FACTS
+    hasRoute<WidgetsRoute.SuggestionsPreview>() -> WidgetFlowKey.SUGGESTIONS
+    else -> null
+}
+
+private enum class WidgetFlowKey {
+    PRICE,
+    WEATHER,
+    BLOCKS,
+    HEADLINES,
+    FACTS,
+    SUGGESTIONS,
 }
 
 sealed interface WidgetsRoute {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1208,6 +1208,7 @@
     <string name="widgets__news__name">Bitcoin Headlines</string>
     <string name="widgets__onboarding__description">Enjoy decentralized feeds from your favorite web services, by adding fun and useful widgets to your Bitkit wallet.</string>
     <string name="widgets__onboarding__title">Hello,\n&lt;accent&gt;Widgets&lt;/accent&gt;</string>
+    <string name="widgets__onboarding__view_organize">View &amp; Organize</string>
     <string name="widgets__onboarding_swipe">Swipe to find\n&lt;accent&gt;your widgets&lt;/accent&gt;</string>
     <string name="widgets__price__description">Check the latest Bitcoin exchange rates for a variety of fiat currencies.</string>
     <string name="widgets__price__name">Bitcoin Price</string>

--- a/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
@@ -2,19 +2,29 @@ package to.bitkit.repositories
 
 import android.content.Context
 import com.synonym.vssclient.VssItem
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import to.bitkit.data.AppCacheData
 import to.bitkit.data.AppDb
 import to.bitkit.data.CacheStore
 import to.bitkit.data.SettingsData
 import to.bitkit.data.SettingsStore
+import to.bitkit.data.WidgetsData
 import to.bitkit.data.WidgetsStore
 import to.bitkit.data.backup.VssBackupClient
 import to.bitkit.data.backup.VssBackupClientLdk
@@ -22,6 +32,7 @@ import to.bitkit.data.dao.TransferDao
 import to.bitkit.data.entities.TransferEntity
 import to.bitkit.di.json
 import to.bitkit.models.BackupCategory
+import to.bitkit.models.BackupItemStatus
 import to.bitkit.models.PrivatePaykitContactLinkBackupV1
 import to.bitkit.models.WalletBackupV1
 import to.bitkit.services.LightningService
@@ -33,7 +44,7 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
-@OptIn(ExperimentalTime::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 class BackupRepoTest : BaseUnitTest() {
     private val context = mock<Context>()
     private val cacheStore = mock<CacheStore>()
@@ -51,7 +62,9 @@ class BackupRepoTest : BaseUnitTest() {
     private val clock = mock<Clock>()
     private val db = mock<AppDb>()
     private val transferDao = mock<TransferDao>()
+    private val cacheData = MutableStateFlow(AppCacheData())
     private val settingsData = MutableStateFlow(SettingsData())
+    private val widgetsData = MutableStateFlow(WidgetsData())
 
     private lateinit var sut: BackupRepo
 
@@ -62,13 +75,20 @@ class BackupRepoTest : BaseUnitTest() {
         whenever { transferDao.upsert(any<List<TransferEntity>>()) }.thenReturn(Unit)
         whenever { cacheStore.updateBackupStatus(any(), any()) }.thenReturn(Unit)
         whenever { cacheStore.update(any()) }.thenReturn(Unit)
+        whenever(cacheStore.data).thenReturn(cacheData)
         whenever(settingsStore.data).thenReturn(settingsData)
         whenever { settingsStore.update(any()) }.thenReturn(Unit)
+        whenever(widgetsStore.data).thenReturn(widgetsData)
         whenever { vssBackupClient.getObject(any()) }.thenReturn(Result.success(null))
         whenever { vssBackupClient.putObject(any(), any()) }
             .thenReturn(Result.success(VssItem(key = BackupCategory.SETTINGS.name, value = byteArrayOf(), version = 1)))
+        whenever { vssBackupClient.setupWithRetry(any(), any(), any()) }.thenReturn(Result.success(Unit))
+        whenever { vssBackupClientLdk.setup() }.thenReturn(Result.success(Unit))
+        whenever { transferDao.getAll() }.thenReturn(emptyList())
         whenever { privatePaykitRepo.restoreBackup(anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { privatePaykitRepo.backupSnapshot() }.thenReturn(Result.success(null))
         whenever { privatePaykitAddressReservationRepo.restoreBackup(any()) }.thenReturn(Result.success(Unit))
+        whenever { privatePaykitAddressReservationRepo.backupSnapshot() }.thenReturn(Result.success(null))
         whenever {
             privatePaykitAddressReservationRepo.reconcileReservedIndexesWithLdk()
         }.thenReturn(Result.success(Unit))
@@ -87,6 +107,72 @@ class BackupRepoTest : BaseUnitTest() {
         assertTrue(result.isFailure)
         verify(privatePaykitRepo, never()).restoreBackup(any())
         verify(settingsStore, never()).update(any())
+    }
+
+    @Test
+    fun `start observing backs up stale required status after clearing running flag`() = test {
+        val backupStatuses = MutableStateFlow(
+            mapOf(
+                BackupCategory.WALLET to BackupItemStatus(
+                    running = true,
+                    synced = 1_000,
+                    required = 2_000,
+                ),
+            )
+        )
+        val allowWalletClear = CompletableDeferred<Unit>()
+        var delayedWalletClear = false
+        stubBackupStatuses(backupStatuses, allowWalletClear) {
+            delayedWalletClear = true
+        }
+        stubBackupObservers()
+
+        try {
+            sut.startObservingBackups()
+            runCurrent()
+            verify(vssBackupClient, never()).putObject(eq(BackupCategory.WALLET.name), any())
+
+            allowWalletClear.complete(Unit)
+            runCurrent()
+            advanceTimeBy(5_000)
+            runCurrent()
+
+            assertTrue(delayedWalletClear)
+            verify(vssBackupClient).putObject(eq(BackupCategory.WALLET.name), any())
+        } finally {
+            sut.stopObservingBackups()
+        }
+    }
+
+    @Test
+    fun `failed automatic backup waits for new required timestamp before retrying`() = test {
+        whenever(clock.now()).thenReturn(Instant.fromEpochMilliseconds(3_000))
+        whenever { vssBackupClient.putObject(eq(BackupCategory.SETTINGS.name), any()) }
+            .thenReturn(Result.failure(BackupRepoTestError("backup failed")))
+        val backupStatuses = MutableStateFlow(
+            mapOf(
+                BackupCategory.SETTINGS to BackupItemStatus(
+                    synced = 1_000,
+                    required = 2_000,
+                ),
+            )
+        )
+        val allowWalletClear = CompletableDeferred<Unit>().apply { complete(Unit) }
+        stubBackupStatuses(backupStatuses, allowWalletClear) {}
+        stubBackupObservers()
+
+        try {
+            sut.startObservingBackups()
+            runCurrent()
+            advanceTimeBy(5_000)
+            runCurrent()
+            advanceTimeBy(5_000)
+            runCurrent()
+
+            verify(vssBackupClient).putObject(eq(BackupCategory.SETTINGS.name), any())
+        } finally {
+            sut.stopObservingBackups()
+        }
     }
 
     @Test
@@ -132,6 +218,37 @@ class BackupRepoTest : BaseUnitTest() {
                     )
                 )
             )
+    }
+
+    private fun stubBackupStatuses(
+        backupStatuses: MutableStateFlow<Map<BackupCategory, BackupItemStatus>>,
+        allowWalletClear: CompletableDeferred<Unit>,
+        onWalletClearDelayed: () -> Unit,
+    ) {
+        whenever(cacheStore.backupStatuses).thenReturn(backupStatuses)
+        whenever { cacheStore.updateBackupStatus(any(), any()) }.doSuspendableAnswer {
+            val category = it.getArgument<BackupCategory>(0)
+            val transform = it.getArgument<(BackupItemStatus) -> BackupItemStatus>(1)
+            if (category == BackupCategory.WALLET && !allowWalletClear.isCompleted) {
+                onWalletClearDelayed()
+                allowWalletClear.await()
+            }
+            backupStatuses.update { statuses ->
+                val currentStatus = statuses[category] ?: BackupItemStatus()
+                statuses + (category to transform(currentStatus))
+            }
+        }
+    }
+
+    private fun stubBackupObservers() {
+        whenever { transferDao.observeAll() }.thenReturn(MutableStateFlow(emptyList()))
+        whenever(blocktankRepo.blocktankState).thenReturn(MutableStateFlow(BlocktankState()))
+        whenever(activityRepo.activitiesChanged).thenReturn(MutableStateFlow(0L))
+        whenever(pubkyRepo.backupStateVersion).thenReturn(MutableStateFlow(0L))
+        whenever(privatePaykitRepo.backupStateVersion).thenReturn(MutableStateFlow(0L))
+        whenever(privatePaykitAddressReservationRepo.backupStateVersion).thenReturn(MutableStateFlow(0L))
+        whenever(preActivityMetadataRepo.preActivityMetadataChanged).thenReturn(MutableStateFlow(0L))
+        whenever(lightningService.syncStatusChanged).thenReturn(MutableSharedFlow())
     }
 
     private fun createSut() = BackupRepo(

--- a/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import to.bitkit.data.AppCacheData
@@ -170,6 +171,56 @@ class BackupRepoTest : BaseUnitTest() {
             runCurrent()
 
             verify(vssBackupClient).putObject(eq(BackupCategory.SETTINGS.name), any())
+        } finally {
+            sut.stopObservingBackups()
+        }
+    }
+
+    @Test
+    fun `failed automatic backup retries newer required timestamp`() = test {
+        whenever(clock.now()).thenReturn(Instant.fromEpochMilliseconds(3_000))
+        val backupStatuses = MutableStateFlow(
+            mapOf(
+                BackupCategory.SETTINGS to BackupItemStatus(
+                    synced = 1_000,
+                    required = 2_000,
+                ),
+            )
+        )
+        var uploadAttempts = 0
+        whenever { vssBackupClient.putObject(eq(BackupCategory.SETTINGS.name), any()) }
+            .doSuspendableAnswer {
+                uploadAttempts += 1
+                if (uploadAttempts == 1) {
+                    backupStatuses.update { statuses ->
+                        val status = statuses.getValue(BackupCategory.SETTINGS)
+                        statuses + (BackupCategory.SETTINGS to status.copy(required = 4_000))
+                    }
+                    whenever(clock.now()).thenReturn(Instant.fromEpochMilliseconds(5_000))
+                    Result.failure(BackupRepoTestError("backup failed"))
+                } else {
+                    Result.success(
+                        VssItem(
+                            key = BackupCategory.SETTINGS.name,
+                            value = byteArrayOf(),
+                            version = 1,
+                        )
+                    )
+                }
+            }
+        val allowWalletClear = CompletableDeferred<Unit>().apply { complete(Unit) }
+        stubBackupStatuses(backupStatuses, allowWalletClear) {}
+        stubBackupObservers()
+
+        try {
+            sut.startObservingBackups()
+            runCurrent()
+            advanceTimeBy(5_000)
+            runCurrent()
+            advanceTimeBy(5_000)
+            runCurrent()
+
+            verify(vssBackupClient, times(2)).putObject(eq(BackupCategory.SETTINGS.name), any())
         } finally {
             sut.stopObservingBackups()
         }

--- a/app/src/test/java/to/bitkit/ui/screens/profile/PubkyChoiceViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/profile/PubkyChoiceViewModelTest.kt
@@ -29,6 +29,7 @@ class PubkyChoiceViewModelTest : BaseUnitTest() {
     private val packageManager: PackageManager = mock()
     private val pubkyRepo: PubkyRepo = mock()
     private val pendingImportContacts = MutableStateFlow<List<PubkyProfile>>(emptyList())
+    private val isAuthenticated = MutableStateFlow(false)
     private val authCancelEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     private lateinit var sut: PubkyChoiceViewModel
@@ -39,7 +40,11 @@ class PubkyChoiceViewModelTest : BaseUnitTest() {
         whenever(context.getString(R.string.common__error)).thenReturn("Error")
         whenever(context.getString(R.string.profile__auth_error_title)).thenReturn("Authorization Failed")
         whenever(pubkyRepo.pendingImportContacts).thenReturn(pendingImportContacts)
+        whenever(pubkyRepo.isAuthenticated).thenReturn(isAuthenticated)
         whenever(pubkyRepo.authCancelEvents).thenReturn(authCancelEvents)
+    }
+
+    private fun createSut() {
         sut = PubkyChoiceViewModel(
             context = context,
             pubkyRepo = pubkyRepo,
@@ -47,7 +52,29 @@ class PubkyChoiceViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `session restoration redirects to profile when already authenticated`() = test {
+        isAuthenticated.value = true
+        createSut()
+
+        advanceUntilIdle()
+
+        assertTrue(sut.uiState.value.navigateToProfile)
+    }
+
+    @Test
+    fun `clearProfileNavigation clears profile redirect`() = test {
+        createSut()
+        isAuthenticated.value = true
+        advanceUntilIdle()
+
+        sut.clearProfileNavigation()
+
+        assertFalse(sut.uiState.value.navigateToProfile)
+    }
+
+    @Test
     fun `waitForApproval prepareImport failure clears loading and emits no navigation`() = test {
+        createSut()
         whenever(pubkyRepo.completeAuthentication()).thenReturn(Result.success(Unit))
         whenever(pubkyRepo.prepareImport()).thenReturn(Result.failure(RuntimeException("Import failed")))
 
@@ -73,6 +100,7 @@ class PubkyChoiceViewModelTest : BaseUnitTest() {
 
     @Test
     fun `startRingAuth shows dialog when Ring is not installed`() = test {
+        createSut()
         whenever(packageManager.getLaunchIntentForPackage(PubkyChoiceViewModel.PUBKY_RING_PACKAGE))
             .thenReturn(null)
 
@@ -95,6 +123,7 @@ class PubkyChoiceViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onRingLaunchFailed shows dialog without toast`() = test {
+        createSut()
         val effects = mutableListOf<PubkyChoiceEffect>()
         val toasts = mutableListOf<Toast>()
         val effectsJob = launch { sut.effects.collect { effects.add(it) } }

--- a/app/src/test/java/to/bitkit/ui/sheets/WidgetsRouteTest.kt
+++ b/app/src/test/java/to/bitkit/ui/sheets/WidgetsRouteTest.kt
@@ -1,0 +1,19 @@
+package to.bitkit.ui.sheets
+
+import to.bitkit.models.WidgetType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WidgetsRouteTest {
+
+    @Test
+    fun `maps widget types to preview routes`() {
+        assertEquals(WidgetsRoute.BlocksPreview, WidgetType.BLOCK.toWidgetsPreviewRoute())
+        assertEquals(WidgetsRoute.CalculatorPreview, WidgetType.CALCULATOR.toWidgetsPreviewRoute())
+        assertEquals(WidgetsRoute.FactsPreview, WidgetType.FACTS.toWidgetsPreviewRoute())
+        assertEquals(WidgetsRoute.HeadlinesPreview, WidgetType.NEWS.toWidgetsPreviewRoute())
+        assertEquals(WidgetsRoute.PricePreview, WidgetType.PRICE.toWidgetsPreviewRoute())
+        assertEquals(WidgetsRoute.WeatherPreview, WidgetType.WEATHER.toWidgetsPreviewRoute())
+        assertEquals(WidgetsRoute.SuggestionsPreview, WidgetType.SUGGESTIONS.toWidgetsPreviewRoute())
+    }
+}

--- a/changelog.d/next/972.changed.md
+++ b/changelog.d/next/972.changed.md
@@ -1,0 +1,1 @@
+The add widget experience now opens as a bottom-sheet flow with in-sheet previews instead of full-screen picker pages.

--- a/docs/e2e-test-ids.md
+++ b/docs/e2e-test-ids.md
@@ -683,4 +683,4 @@ Legend:
 | WidgetSave                 | ✅                           |
 | WidgetsAdd                 | ✅                           |
 | WidgetsEdit                | ✅                           |
-| WidgetsOnboarding-button   | ✅                           |
+| WidgetsOnboardingAddWidget   | ✅                           |

--- a/journeys/widgets/add-widgets-flow.xml
+++ b/journeys/widgets/add-widgets-flow.xml
@@ -1,0 +1,14 @@
+<journey name="add widgets flow">
+  <description>Precondition: onboarded dev wallet, widgets enabled, widgets intro already seen.</description>
+  <actions>
+    <action>Tap the menu icon</action>
+    <action>Tap "Widgets"</action>
+    <action>Verify that the wallet overview widgets section is visible and "Add Widget" is visible</action>
+    <action>Verify that "Hello, Widgets" is not visible</action>
+    <action>Tap "Add Widget"</action>
+    <action>Verify that the "Add Widget" bottom sheet is visible</action>
+    <action>Scroll the bottom sheet down until "Bitcoin Calculator" is visible</action>
+    <action>Tap the "Bitcoin Calculator" widget card</action>
+    <action>Verify that the bottom sheet navigates to "Bitcoin Calculator" and "Save Widget" is visible</action>
+  </actions>
+</journey>

--- a/journeys/widgets/widgets-intro.xml
+++ b/journeys/widgets/widgets-intro.xml
@@ -1,0 +1,16 @@
+<journey name="widgets intro">
+  <description>Precondition: onboarded dev wallet, widgets enabled, widgets intro unseen.</description>
+  <actions>
+    <action>Tap the menu icon</action>
+    <action>Tap "Widgets"</action>
+    <action>Verify that "Hello, Widgets", "View &amp; Organize", and "Add Widget" are visible</action>
+    <action>Tap "Add Widget"</action>
+    <action>Verify that the "Add Widget" bottom sheet is visible with "Bitcoin Price" and "Bitcoin Weather"</action>
+    <action>Verify that the Widgets intro remains visible behind the sheet backdrop at the top</action>
+    <action>Tap the "Bitcoin Weather" widget card</action>
+    <action>Verify that the bottom sheet navigates to "Bitcoin Weather" and "Save Widget" is visible</action>
+    <action>Tap "Save Widget"</action>
+    <action>Verify that the wallet overview widgets section is visible</action>
+    <action>Verify that "Bitcoin Weather" appears as the last widget in the current widget set</action>
+  </actions>
+</journey>


### PR DESCRIPTION
Closes #966

### Description

This PR:

1. Adds the one-time Widgets intro screen and in-sheet flow, routeing the drawer Widgets entry to either the intro or the wallet overview widgets section based on whether the intro has been seen.
2. Moves the Add Widget gallery plus widget preview/edit screens into a large gradient-backed bottom sheet with internal in-sheet navigation.
3. Updates the Add Widget gallery to match the Figma v61 layout, including large sheet sizing, scrolling behavior, equal picker card heights, reused widget preview components, and reliable full-card taps.
4. Rewires save/edit/back behavior so selected widgets save through the existing widget flow, append to the current widget set, and navigation lands on the wallet overview widgets section afterwards.
5. Adds the widget flow journeys for android-cli, Compose/navigation coverage, and the changelog fragment for this user-facing change.
6. Updates action onClick of "Wallet" in menu to scroll to the first home screen vertical slide (visible if you left home on widgets silde)

### Preview

| Initial Update | Last Update |
| - | - |
| <video src="https://github.com/user-attachments/assets/67b79afd-9ca6-44a6-916a-61360738e0c8"> | <video src="https://github.com/user-attachments/assets/69774110-2e60-4fcd-ad93-33623064ee6e"> |

### QA Notes

#### Manual Tests

Optional local QA patches, for a disposable test build only. Apply one or both before `./gradlew installDevDebug`; do not commit them. Undo by running `git apply -R` with the same patch.

Shorten backup retry/failure waits from minutes to seconds:

```sh
git apply <<'PATCH'
diff --git a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -699,10 +699,10 @@ class BackupRepo @Inject constructor(
         private const val TAG = "BackupRepo"
 
         private const val MINUTE_IN_MS = 60_000
-        private const val BACKUP_DEBOUNCE = 5000L // 5 seconds
-        private const val BACKUP_CHECK_INTERVAL = 60 * 1000L // 1 minute
-        private const val FAILED_BACKUP_CHECK_TIME = 30 * 60 * 1000L // 30 minutes
-        private const val FAILED_BACKUP_NOTIFICATION_INTERVAL = 10 * 60 * 1000L // 10 minutes
+        private const val BACKUP_DEBOUNCE = 500L // QA: 0.5 seconds
+        private const val BACKUP_CHECK_INTERVAL = 2 * 1000L // QA: 2 seconds
+        private const val FAILED_BACKUP_CHECK_TIME = 10 * 1000L // QA: 10 seconds
+        private const val FAILED_BACKUP_NOTIFICATION_INTERVAL = 5 * 1000L // QA: 5 seconds
         private const val SYNC_STATUS_DEBOUNCE = 500L // 500ms debounce for sync status updates
         private val VSS_TIMESTAMP_TIMEOUT = 60.seconds
     }
PATCH
```

Shorten Home widget headline/fact rotation while visually checking saved widgets:

```sh
git apply <<'PATCH'
diff --git a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HomeViewModel.kt
@@ -184,14 +184,14 @@ class HomeViewModel @Inject constructor(
     private suspend fun startArticleRotation(articlesList: List<ArticleModel>) {
         while (_uiState.value.showWidgets && articlesList.isNotEmpty()) {
             _currentArticle.update { articlesList.randomOrNull() }
-            delay(30.seconds)
+            delay(3.seconds)
         }
         _currentArticle.update { null }
     }
 
     private suspend fun startFactsRotation(factList: List<String>) {
         while (_uiState.value.showWidgets && factList.isNotEmpty()) {
             _currentFact.update { factList.randomOrNull() }
-            delay(20.seconds)
+            delay(3.seconds)
         }
         _currentFact.update { null }
     }
PATCH
```

Use Dev Settings → `Reset Widgets Intro Flag` to retest the first-run widgets path, and Dev Settings → `Reset Widgets State` when you want the default widget list again.

- [x] **1.** Drawer → Widgets with intro unseen: Widgets Intro opens with "Hello, Widgets", "View & Organize", and "Add Widget" visible.
- [x] **2.** Widgets Intro → Add Widget → Bitcoin Weather → Save Widget: Add Widget opens as an in-sheet gallery, the intro remains visible behind the backdrop, Weather preview opens in-sheet, and save lands on the wallet overview widgets section with Bitcoin Weather appended last.
- [x] **3.** Widgets Intro → View & Organize with widgets enabled: lands on the wallet overview widgets section.
- [x] **4.** Drawer → Widgets with intro already seen and widgets enabled: wallet overview widgets section opens directly and "Hello, Widgets" intro screen is not visible.
- [x] **5.** Widgets disabled → Drawer → Widgets: Add Widget opens in-sheet with disabled picker cards and Enable in Settings visible; Enable in Settings opens Widgets Settings.
- [x] **6.** Wallet Overview widgets section → Add Widget → scroll to Bitcoin Calculator → tap card: the large Add Widget sheet scrolls without content hiding behind the sheet top area, and Calculator preview opens in-sheet.
- [x] **7a.** `regression:` Add Widget gallery → tap Bitcoin Price chart line: Price preview opens in-sheet and no chart tooltip opens.
  - [x] **7b.** `regression:` Add Widget gallery → tap Bitcoin Headlines content: Headlines preview opens in-sheet and no external URL opens.
- [x] **8.** Pubky authenticated session restored → Profile Choice: auto-nav lands on Profile instead of staying on the choice screen.
- [x] **9.** Optional backup timing patch applied + stale WALLET backup status present at launch → Settings → Backup: WALLET leaves `running=true` and completes after the shortened debounce instead of waiting for another data change.
- [x] **4.**  with home screen showing Widgets slide → menu → Wallet: wallet overview home screen section opens (scrolls up from widgets slide).

#### Automated Checks

- Compose UI tests added/updated for Widgets intro actions, drawer Widgets routing, Add Widget gallery layout/scrolling/safe-area behavior, reliable picker taps, and converted sheet previews.
- Unit coverage added for widget route mapping in `app/src/test/java/to/bitkit/ui/sheets/WidgetsRouteTest.kt`.
- Unit coverage added for stale running backup retry in `app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt`.
- Unit coverage added for Pubky restored-session profile navigation in `app/src/test/java/to/bitkit/ui/screens/profile/PubkyChoiceViewModelTest.kt`.
- Android CLI journeys added under `journeys/widgets/` for `widgets intro` and `add widgets flow`.
- Ran `./gradlew compileDevDebugKotlin compileDevDebugAndroidTestKotlin detekt testDevDebugUnitTest`.
- Ran `./gradlew connectedDevDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=to.bitkit.ui.screens.widgets.AddWidgetsSheetContentTest`.
- CI: build, lint, detekt, and E2E checks are green on the latest pushed commit.
