### PR TITLE
feat: add trezor pin entry and hidden wallets

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
@@ -21,12 +21,14 @@ import com.synonym.bitkitcore.TrezorSignedMessageResponse
 import com.synonym.bitkitcore.TrezorSignedTx
 import com.synonym.bitkitcore.TrezorTransportType
 import com.synonym.bitkitcore.WalletParams
+import com.synonym.bitkitcore.WalletSelection
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -42,6 +44,8 @@ import to.bitkit.models.toCoreNetwork
 import to.bitkit.services.TrezorDebugLog
 import to.bitkit.services.TrezorService
 import to.bitkit.services.TrezorTransport
+import to.bitkit.services.TrezorUiHandler
+import to.bitkit.services.TrezorWalletMode
 import to.bitkit.utils.AppError
 import to.bitkit.utils.Logger
 import java.io.File
@@ -55,6 +59,7 @@ class TrezorRepo @Inject constructor(
     @ApplicationContext private val context: Context,
     private val trezorService: TrezorService,
     private val trezorTransport: TrezorTransport,
+    private val trezorUiHandler: TrezorUiHandler,
     private val trezorStore: TrezorStore,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
@@ -62,6 +67,7 @@ class TrezorRepo @Inject constructor(
         private const val TAG = "TrezorRepo"
         private const val DEFAULT_ADDRESS_PATH = "m/84'/0'/0'/0/0"
         private const val DEFAULT_ACCOUNT_PATH = "m/84'/0'/0'"
+        private const val WALLET_MODE_RECONNECT_DELAY_MS = 1_000L
     }
 
     private val _state = MutableStateFlow(TrezorState())
@@ -85,6 +91,64 @@ class TrezorRepo @Inject constructor(
      */
     fun cancelPairingCode() {
         trezorTransport.cancelPairingCode()
+    }
+
+    val needsPinEntry = trezorUiHandler.needsPinEntry
+
+    fun submitPin(pin: String) {
+        trezorUiHandler.submitPin(pin)
+    }
+
+    fun cancelPin() {
+        trezorUiHandler.cancelPin()
+    }
+
+    val walletMode = trezorUiHandler.walletMode
+
+    /**
+     * Reset to the standard wallet and clear any selected passphrase, without
+     * reconnecting. Call this when the user explicitly picks a device from a
+     * list ([connect]/[connectKnownDevice]) so a passphrase or on-device
+     * selection left over from a previously connected device isn't silently
+     * applied to the newly selected one.
+     *
+     * Silent reconnects ([autoReconnect]/[ensureConnected]) deliberately skip
+     * this, so a dropped link reopens the same hidden wallet the user was using.
+     */
+    fun resetWalletSelection() {
+        trezorUiHandler.setWalletMode(TrezorWalletMode.STANDARD)
+    }
+
+    /**
+     * Switch between the standard wallet and a passphrase (hidden) wallet.
+     *
+     * The Trezor caches the passphrase for the whole session, so switching
+     * requires a fresh session: this sets the desired mode, then disconnects
+     * and reconnects. The new mode takes effect on the next wallet operation.
+     */
+    suspend fun setWalletMode(
+        mode: TrezorWalletMode,
+        passphrase: String = "",
+    ): Result<TrezorFeatures> = withContext(ioDispatcher) {
+        runCatching {
+            val deviceId = _state.value.connectedDeviceId
+                ?: throw AppError("No connected Trezor")
+            TrezorDebugLog.log("WALLET_MODE", "Switching to $mode, resetting session for $deviceId")
+            // Reset the session via disconnect/reconnect. disconnect() resets the
+            // UI handler's wallet mode to standard, so set the desired mode AFTER
+            // the disconnect and right before reconnecting.
+            runCatching { disconnect() }
+            // Reconnect by id WITHOUT a scan: scan() clears the discovered-device
+            // cache and a scan right after a disconnect usually finds nothing,
+            // whereas the cached handle (and direct address resolution) still work.
+            delay(WALLET_MODE_RECONNECT_DELAY_MS)
+            // Record the selection on the handler: THP reads it via
+            // currentSelection() to bind the passphrase at session creation,
+            // while non-THP devices re-request it mid-operation and are answered
+            // from the same value. connect() then derives the wallet from it.
+            trezorUiHandler.setWalletMode(mode, passphrase)
+            connect(deviceId).getOrThrow()
+        }
     }
 
     suspend fun initialize(walletIndex: Int = 0): Result<Unit> = withContext(ioDispatcher) {
@@ -131,7 +195,7 @@ class TrezorRepo @Inject constructor(
         runCatching {
             _state.update { it.copy(isConnecting = true, error = null) }
             TrezorDebugLog.log("CONNECT", "connect() called for deviceId=$deviceId")
-            val features = connectWithThpRetry(deviceId)
+            val features = connectWithThpRetry(deviceId, trezorUiHandler.currentSelection())
             TrezorDebugLog.log("CONNECT", "connect() succeeded: label=${features.label}, model=${features.model}")
             val deviceInfo = _state.value.nearbyDevices.find { it.id == deviceId }
                 ?: _state.value.knownDevices.find { it.id == deviceId }?.let { known ->
@@ -319,6 +383,14 @@ class TrezorRepo @Inject constructor(
     suspend fun disconnect(): Result<Unit> = withContext(ioDispatcher) {
         TrezorDebugLog.log("DISCONNECT", "disconnect() called, connectedDeviceId=${_state.value.connectedDeviceId}")
         val result = runCatching { trezorService.disconnect() }
+        // Mirror the core: trezorService.disconnect() resets the session
+        // passphrase to the standard wallet, so reset the UI handler's wallet
+        // mode too. This keeps the THP path, the legacy PassphraseRequest
+        // callback, and the displayed mode consistent on the next (re)connect —
+        // a hidden wallet must be re-selected explicitly after an explicit
+        // disconnect. (A transient external disconnect does not call this and so
+        // retains the selection, matching the core's behaviour.)
+        trezorUiHandler.setWalletMode(TrezorWalletMode.STANDARD)
         _state.update {
             it.copy(connected = null, lastAddress = null, lastPublicKey = null)
         }
@@ -428,20 +500,13 @@ class TrezorRepo @Inject constructor(
                 "RECONNECT",
                 "Scan found ${scannedDevices.size} devices: ${scannedDevices.map { it.id }}",
             )
-            val exactMatch = scannedDevices.find { it.id == deviceId }
-            val knownIds = _state.value.knownDevices.map { it.id }.toSet()
-            val usbDevice = scannedDevices.find {
-                it.transportType == TrezorTransportType.USB && it.id in knownIds
-            }
-            val device = if (exactMatch?.transportType == TrezorTransportType.BLUETOOTH && usbDevice != null) {
-                TrezorDebugLog.log("RECONNECT", "Preferring USB over BLE")
-                usbDevice
-            } else {
-                exactMatch ?: throw AppError("Device not found nearby — is it powered on?")
-            }
+            // Honor the transport the user selected — connect to exactly the
+            // entry they tapped instead of overriding Bluetooth with USB.
+            val device = scannedDevices.find { it.id == deviceId }
+                ?: throw AppError("Device not found nearby — is it powered on?")
             TrezorDebugLog.log("RECONNECT", "Found matching device: id=${device.id}, name=${device.name}")
             TrezorDebugLog.log("RECONNECT", "Calling connectWithThpRetry...")
-            val features = connectWithThpRetry(device.id)
+            val features = connectWithThpRetry(device.id, trezorUiHandler.currentSelection())
             TrezorDebugLog.log("RECONNECT", "Connected! label=${features.label}, model=${features.model}")
             addOrUpdateKnownDevice(device, features)
             _state.update {
@@ -461,6 +526,9 @@ class TrezorRepo @Inject constructor(
             TrezorDebugLog.log("FORGET", "forgetDevice called for: $deviceId")
             val disconnectResult = if (_state.value.connectedDeviceId == deviceId) {
                 runCatching { trezorService.disconnect() }.also {
+                    // Clear any cached host passphrase so it can't be reused
+                    // against a different device on a later connect.
+                    trezorUiHandler.setWalletMode(TrezorWalletMode.STANDARD)
                     _state.update { it.copy(connected = null) }
                 }
             } else {
@@ -541,7 +609,7 @@ class TrezorRepo @Inject constructor(
         val devices = trezorService.scan()
         val device = devices.find { it.id == deviceId }
             ?: throw AppError("Device not found during reconnect")
-        val features = connectWithThpRetry(device.id)
+        val features = connectWithThpRetry(device.id, trezorUiHandler.currentSelection())
         _state.update { it.copy(connected = ConnectedTrezorDevice(id = deviceId, features = features)) }
     }
 
@@ -555,11 +623,14 @@ class TrezorRepo @Inject constructor(
         }
     }
 
-    private suspend fun connectWithThpRetry(deviceId: String): TrezorFeatures {
+    private suspend fun connectWithThpRetry(
+        deviceId: String,
+        selection: WalletSelection,
+    ): TrezorFeatures {
         TrezorDebugLog.log("THPRetry", "First connect attempt for: $deviceId")
         logCredentialFileState(deviceId, "BEFORE 1st attempt")
         return runCatching {
-            trezorService.connect(deviceId)
+            trezorService.connect(deviceId, selection)
         }.onSuccess {
             logCredentialFileState(deviceId, "AFTER 1st attempt (success)")
             TrezorDebugLog.log("THPRetry", "First attempt succeeded")
@@ -573,7 +644,7 @@ class TrezorRepo @Inject constructor(
             TrezorDebugLog.log("THPRetry", "Error is retryable, attempting second connect...")
             Logger.warn("Connection failed for $deviceId, retrying", e, context = TAG)
             logCredentialFileState(deviceId, "BEFORE 2nd attempt")
-            val result = trezorService.connect(deviceId)
+            val result = trezorService.connect(deviceId, selection)
             logCredentialFileState(deviceId, "AFTER 2nd attempt (success)")
             TrezorDebugLog.log("THPRetry", "Second attempt succeeded")
             result
@@ -591,6 +662,11 @@ class TrezorRepo @Inject constructor(
 
     private fun isRetryableError(e: Throwable): Boolean {
         val msg = e.message?.lowercase() ?: return false
+        // A rejected session (wrong passphrase, or the user cancelling on-device
+        // passphrase entry) is a definitive failure, not a transient THP/transport
+        // hiccup. Retrying it just re-prompts the device and risks wedging the
+        // connection, so don't treat ThpCreateNewSession rejections as retryable.
+        if ("rejected" in msg) return false
         return "thp" in msg || "session" in msg || "timeout" in msg || "disconnect" in msg
     }
 }

--- a/app/src/main/java/to/bitkit/services/TrezorService.kt
+++ b/app/src/main/java/to/bitkit/services/TrezorService.kt
@@ -18,6 +18,7 @@ import com.synonym.bitkitcore.TrezorSignMessageParams
 import com.synonym.bitkitcore.TrezorSignedMessageResponse
 import com.synonym.bitkitcore.TrezorSignedTx
 import com.synonym.bitkitcore.TrezorVerifyMessageParams
+import com.synonym.bitkitcore.WalletSelection
 import com.synonym.bitkitcore.onchainBroadcastRawTx
 import com.synonym.bitkitcore.onchainComposeTransaction
 import com.synonym.bitkitcore.onchainGetAccountInfo
@@ -36,6 +37,7 @@ import com.synonym.bitkitcore.trezorIsInitialized
 import com.synonym.bitkitcore.trezorListDevices
 import com.synonym.bitkitcore.trezorScan
 import com.synonym.bitkitcore.trezorSetTransportCallback
+import com.synonym.bitkitcore.trezorSetUiCallback
 import com.synonym.bitkitcore.trezorSignMessage
 import com.synonym.bitkitcore.trezorSignTxFromPsbt
 import com.synonym.bitkitcore.trezorVerifyMessage
@@ -48,6 +50,7 @@ import com.synonym.bitkitcore.Network as BitkitCoreNetwork
 @Singleton
 class TrezorService @Inject constructor(
     private val transport: TrezorTransport,
+    private val uiHandler: TrezorUiHandler,
 ) {
     @Volatile
     private var callbackRegistered = false
@@ -57,6 +60,7 @@ class TrezorService @Inject constructor(
             synchronized(this) {
                 if (!callbackRegistered) {
                     trezorSetTransportCallback(transport)
+                    trezorSetUiCallback(uiHandler)
                     callbackRegistered = true
                 }
             }
@@ -88,9 +92,14 @@ class TrezorService @Inject constructor(
         }
     }
 
-    suspend fun connect(deviceId: String): TrezorFeatures {
+    /**
+     * Connect to a device, opening the wallet given by [selection]. On THP
+     * devices (Safe 5/7) the passphrase is bound to the session at creation, so
+     * it is supplied per-connect rather than cached between calls.
+     */
+    suspend fun connect(deviceId: String, selection: WalletSelection): TrezorFeatures {
         return ServiceQueue.CORE.background {
-            trezorConnect(deviceId = deviceId)
+            trezorConnect(deviceId = deviceId, selection = selection)
         }
     }
 

--- a/app/src/main/java/to/bitkit/services/TrezorTransport.kt
+++ b/app/src/main/java/to/bitkit/services/TrezorTransport.kt
@@ -834,7 +834,11 @@ class TrezorTransport @Inject constructor(
     @SuppressLint("MissingPermission")
     private fun openBleDevice(path: String): TrezorTransportWriteResult {
         val address = path.removePrefix("ble:")
+        // Prefer a handle from a recent scan, but fall back to resolving the
+        // address directly so we can reconnect to a known device without a
+        // fresh scan — a scan right after a disconnect often finds nothing yet.
         val device = discoveredBleDevices[address]
+            ?: runCatching { bluetoothAdapter?.getRemoteDevice(address) }.getOrNull()
             ?: return TrezorTransportWriteResult(success = false, error = "Device not found: $path")
 
         closeBleDevice(path)

--- a/app/src/main/java/to/bitkit/services/TrezorUiHandler.kt
+++ b/app/src/main/java/to/bitkit/services/TrezorUiHandler.kt
@@ -80,8 +80,11 @@ class TrezorUiHandler @Inject constructor() : TrezorUiCallback {
         TrezorWalletMode.PASSPHRASE_DEVICE -> WalletSelection.OnDevice
         TrezorWalletMode.PASSPHRASE_HOST -> {
             val cached = hostPassphrase
-            if (cached.isNullOrEmpty()) WalletSelection.Standard
-            else WalletSelection.Hidden(passphrase = cached)
+            if (cached.isNullOrEmpty()) {
+                WalletSelection.Standard
+            } else {
+                WalletSelection.Hidden(passphrase = cached)
+            }
         }
     }
 

--- a/app/src/main/java/to/bitkit/services/TrezorUiHandler.kt
+++ b/app/src/main/java/to/bitkit/services/TrezorUiHandler.kt
@@ -1,0 +1,155 @@
+package to.bitkit.services
+
+import com.synonym.bitkitcore.PassphraseResponse
+import com.synonym.bitkitcore.TrezorUiCallback
+import com.synonym.bitkitcore.WalletSelection
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import to.bitkit.utils.Logger
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Which wallet to open when the device asks for a passphrase.
+ *
+ * - [STANDARD]: no passphrase — the default wallet.
+ * - [PASSPHRASE_HOST]: a hidden wallet, passphrase typed on the phone.
+ * - [PASSPHRASE_DEVICE]: a hidden wallet, passphrase typed on the Trezor.
+ */
+enum class TrezorWalletMode { STANDARD, PASSPHRASE_HOST, PASSPHRASE_DEVICE }
+
+@Singleton
+class TrezorUiHandler @Inject constructor() : TrezorUiCallback {
+
+    companion object {
+        private const val TAG = "TrezorUiHandler"
+        private const val UI_TIMEOUT_MS = 120_000L
+    }
+
+    private val pinLock = Object()
+
+    @Volatile
+    private var pinLatch: CountDownLatch? = null
+
+    @Volatile
+    private var submittedPin: String = ""
+
+    private val _needsPinEntry = MutableStateFlow(false)
+    val needsPinEntry: StateFlow<Boolean> = _needsPinEntry
+
+    private val _walletMode = MutableStateFlow(TrezorWalletMode.STANDARD)
+    val walletMode: StateFlow<TrezorWalletMode> = _walletMode
+
+    /**
+     * Host passphrase captured when [TrezorWalletMode.PASSPHRASE_HOST] is
+     * selected. Mirrors the value bound to the THP session so legacy (non-THP)
+     * devices — which re-request the passphrase mid-operation via
+     * [onPassphraseRequest] — can be answered from the value the user already
+     * entered up front. Null when not in host-passphrase mode.
+     */
+    @Volatile
+    private var hostPassphrase: String? = null
+
+    /**
+     * Set which wallet to open. The caller is responsible for resetting the
+     * device session (disconnect/reconnect) so the new mode takes effect — the
+     * Trezor caches the passphrase for the lifetime of a session.
+     *
+     * [hostPassphrase] is only meaningful for [TrezorWalletMode.PASSPHRASE_HOST]
+     * — it is the passphrase the user entered on the phone up front.
+     */
+    fun setWalletMode(mode: TrezorWalletMode, hostPassphrase: String = "") {
+        Logger.info("Wallet mode set to $mode", context = TAG)
+        this.hostPassphrase = if (mode == TrezorWalletMode.PASSPHRASE_HOST) hostPassphrase else null
+        _walletMode.update { mode }
+    }
+
+    /**
+     * The wallet the current mode/passphrase selects, for binding to a THP
+     * session when [connect] runs. Mirrors [onPassphraseRequest] so THP (bound
+     * at session creation) and legacy devices (answered mid-operation) stay in
+     * lockstep from one source of truth. Reconnects derive their wallet from
+     * here, so it reflects the selection until the next [setWalletMode] or
+     * disconnect.
+     */
+    fun currentSelection(): WalletSelection = when (_walletMode.value) {
+        TrezorWalletMode.STANDARD -> WalletSelection.Standard
+        TrezorWalletMode.PASSPHRASE_DEVICE -> WalletSelection.OnDevice
+        TrezorWalletMode.PASSPHRASE_HOST -> {
+            val cached = hostPassphrase
+            if (cached.isNullOrEmpty()) WalletSelection.Standard
+            else WalletSelection.Hidden(passphrase = cached)
+        }
+    }
+
+    override fun onPinRequest(): String {
+        Logger.info("PIN requested by device — showing PIN entry dialog", context = TAG)
+
+        val latch = CountDownLatch(1)
+        synchronized(pinLock) {
+            submittedPin = ""
+            pinLatch = latch
+            _needsPinEntry.update { true }
+        }
+
+        return try {
+            val received = latch.await(UI_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            if (!received) {
+                Logger.warn("PIN entry timed out", context = TAG)
+                _needsPinEntry.update { false }
+                return ""
+            }
+            val pin = submittedPin
+            Logger.info("PIN received (len='${pin.length}')", context = TAG)
+            pin
+        } catch (e: InterruptedException) {
+            Logger.error("PIN wait interrupted", e, context = TAG)
+            _needsPinEntry.update { false }
+            ""
+        }
+    }
+
+    override fun onPassphraseRequest(onDevice: Boolean): PassphraseResponse {
+        // Device-mandated on-device entry always wins, regardless of mode.
+        if (onDevice) {
+            Logger.info("Passphrase requested on-device (device-mandated), deferring to Trezor", context = TAG)
+            return PassphraseResponse.OnDevice
+        }
+
+        return when (_walletMode.value) {
+            TrezorWalletMode.STANDARD -> {
+                Logger.info("Standard wallet — answering passphrase request with Standard", context = TAG)
+                PassphraseResponse.Standard
+            }
+            TrezorWalletMode.PASSPHRASE_DEVICE -> {
+                Logger.info("Passphrase wallet (on-device entry) — deferring to Trezor", context = TAG)
+                PassphraseResponse.OnDevice
+            }
+            TrezorWalletMode.PASSPHRASE_HOST -> {
+                // Answer from the passphrase entered up front (the same value
+                // bound to the THP session). Empty/absent == the standard wallet.
+                val cached = hostPassphrase
+                if (cached.isNullOrEmpty()) {
+                    PassphraseResponse.Standard
+                } else {
+                    Logger.info("Host passphrase wallet — answering with the pre-entered passphrase", context = TAG)
+                    PassphraseResponse.Hidden(value = cached)
+                }
+            }
+        }
+    }
+
+    fun submitPin(pin: String) {
+        synchronized(pinLock) {
+            Logger.info("PIN submitted (len='${pin.length}')", context = TAG)
+            submittedPin = pin
+            _needsPinEntry.update { false }
+            pinLatch?.countDown()
+        }
+    }
+
+    fun cancelPin() = run { submitPin("") }
+}

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/PassphraseDialog.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/PassphraseDialog.kt
@@ -1,0 +1,111 @@
+package to.bitkit.ui.screens.trezor
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import to.bitkit.ui.components.ButtonSize
+import to.bitkit.ui.components.Caption
+import to.bitkit.ui.components.Footnote
+import to.bitkit.ui.components.TertiaryButton
+import to.bitkit.ui.components.Title
+import to.bitkit.ui.components.VerticalSpacer
+import to.bitkit.ui.theme.AppThemeSurface
+import to.bitkit.ui.theme.Colors
+
+@Composable
+internal fun PassphraseDialog(
+    onSubmit: (String) -> Unit,
+    onUseTrezor: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    var passphrase by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onCancel,
+        containerColor = Colors.Gray5,
+        shape = MaterialTheme.shapes.medium,
+        title = {
+            Title(
+                text = "Enter Passphrase",
+                color = Colors.White,
+            )
+        },
+        text = {
+            Column {
+                Caption(
+                    text = "Enter the BIP39 passphrase for this wallet, or leave empty for the standard wallet:",
+                    color = Colors.White80,
+                )
+                VerticalSpacer(16.dp)
+                OutlinedTextField(
+                    value = passphrase,
+                    onValueChange = { passphrase = it },
+                    placeholder = {
+                        Footnote("Passphrase", color = Colors.White32)
+                    },
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Colors.White,
+                        unfocusedTextColor = Colors.White,
+                        focusedBorderColor = Colors.Brand,
+                        unfocusedBorderColor = Colors.White32,
+                        cursorColor = Colors.Brand,
+                    ),
+                )
+                VerticalSpacer(12.dp)
+                TertiaryButton(
+                    text = "Enter on Trezor instead",
+                    onClick = onUseTrezor,
+                    size = ButtonSize.Small,
+                    fullWidth = false,
+                )
+            }
+        },
+        confirmButton = {
+            TertiaryButton(
+                text = "Submit",
+                onClick = { onSubmit(passphrase) },
+                enabled = true,
+                size = ButtonSize.Small,
+                fullWidth = false,
+            )
+        },
+        dismissButton = {
+            TertiaryButton(
+                text = "Cancel",
+                onClick = onCancel,
+                size = ButtonSize.Small,
+                fullWidth = false,
+            )
+        },
+    )
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun PreviewPassphraseDialog() {
+    AppThemeSurface {
+        Box(Modifier.fillMaxSize()) {
+            PassphraseDialog(onSubmit = {}, onUseTrezor = {}, onCancel = {})
+        }
+    }
+}

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/PassphraseDialog.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/PassphraseDialog.kt
@@ -30,6 +30,7 @@ import to.bitkit.ui.theme.Colors
 
 @Composable
 internal fun PassphraseDialog(
+    allowDeviceEntry: Boolean,
     onSubmit: (String) -> Unit,
     onUseTrezor: () -> Unit,
     onCancel: () -> Unit,
@@ -71,13 +72,15 @@ internal fun PassphraseDialog(
                         cursorColor = Colors.Brand,
                     ),
                 )
-                VerticalSpacer(12.dp)
-                TertiaryButton(
-                    text = "Enter on Trezor instead",
-                    onClick = onUseTrezor,
-                    size = ButtonSize.Small,
-                    fullWidth = false,
-                )
+                if (allowDeviceEntry) {
+                    VerticalSpacer(12.dp)
+                    TertiaryButton(
+                        text = "Enter on Trezor instead",
+                        onClick = onUseTrezor,
+                        size = ButtonSize.Small,
+                        fullWidth = false,
+                    )
+                }
             }
         },
         confirmButton = {
@@ -105,7 +108,7 @@ internal fun PassphraseDialog(
 private fun PreviewPassphraseDialog() {
     AppThemeSurface {
         Box(Modifier.fillMaxSize()) {
-            PassphraseDialog(onSubmit = {}, onUseTrezor = {}, onCancel = {})
+            PassphraseDialog(allowDeviceEntry = true, onSubmit = {}, onUseTrezor = {}, onCancel = {})
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/PinEntryDialog.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/PinEntryDialog.kt
@@ -31,6 +31,9 @@ import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 
+// Trezor PINs can be up to 50 digits (https://trezor.io/learn/a/pin-protection-on-trezor-devices).
+private const val MAX_PIN_LENGTH = 50
+
 @Composable
 internal fun PinEntryDialog(
     onSubmit: (String) -> Unit,
@@ -65,7 +68,7 @@ internal fun PinEntryDialog(
                 )
                 VerticalSpacer(12.dp)
                 PinMatrix(
-                    onDigit = { digit -> if (pin.length < 9) pin += digit },
+                    onDigit = { digit -> if (pin.length < MAX_PIN_LENGTH) pin += digit },
                     modifier = Modifier.fillMaxWidth(),
                 )
                 VerticalSpacer(8.dp)

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/PinEntryDialog.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/PinEntryDialog.kt
@@ -1,0 +1,146 @@
+package to.bitkit.ui.screens.trezor
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import to.bitkit.ui.components.ButtonSize
+import to.bitkit.ui.components.Caption
+import to.bitkit.ui.components.TertiaryButton
+import to.bitkit.ui.components.Title
+import to.bitkit.ui.components.VerticalSpacer
+import to.bitkit.ui.theme.AppThemeSurface
+import to.bitkit.ui.theme.Colors
+
+@Composable
+internal fun PinEntryDialog(
+    onSubmit: (String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var pin by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onCancel,
+        containerColor = Colors.Gray5,
+        shape = MaterialTheme.shapes.medium,
+        title = {
+            Title(
+                text = "Enter PIN",
+                color = Colors.White,
+            )
+        },
+        text = {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Caption(
+                    text = "Use the layout shown on your Trezor to enter your PIN:",
+                    color = Colors.White80,
+                )
+                VerticalSpacer(12.dp)
+                Text(
+                    text = "\u25CF".repeat(pin.length).ifEmpty { " " },
+                    color = Colors.White,
+                    fontSize = 24.sp,
+                    textAlign = TextAlign.Center,
+                    letterSpacing = 8.sp,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                VerticalSpacer(12.dp)
+                PinMatrix(
+                    onDigit = { digit -> if (pin.length < 9) pin += digit },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                VerticalSpacer(8.dp)
+                TertiaryButton(
+                    text = "Delete",
+                    onClick = { if (pin.isNotEmpty()) pin = pin.dropLast(1) },
+                    enabled = pin.isNotEmpty(),
+                    size = ButtonSize.Small,
+                    fullWidth = false,
+                )
+            }
+        },
+        confirmButton = {
+            TertiaryButton(
+                text = "Submit",
+                onClick = { onSubmit(pin) },
+                enabled = pin.isNotEmpty(),
+                size = ButtonSize.Small,
+                fullWidth = false,
+            )
+        },
+        dismissButton = {
+            TertiaryButton(
+                text = "Cancel",
+                onClick = onCancel,
+                size = ButtonSize.Small,
+                fullWidth = false,
+            )
+        },
+    )
+}
+
+@Composable
+private fun PinMatrix(
+    onDigit: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val rows = listOf(
+        listOf("7", "8", "9"),
+        listOf("4", "5", "6"),
+        listOf("1", "2", "3"),
+    )
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        rows.forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                row.forEach { digit ->
+                    Button(
+                        onClick = { onDigit(digit) },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Colors.White16,
+                            contentColor = Colors.White,
+                        ),
+                        modifier = Modifier.size(56.dp),
+                    ) {
+                        Text(
+                            text = "\u25CF",
+                            fontSize = 20.sp,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun PreviewPinEntryDialog() {
+    AppThemeSurface {
+        Box(Modifier.fillMaxSize()) {
+            PinEntryDialog(onSubmit = {}, onCancel = {})
+        }
+    }
+}

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorPreviewData.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorPreviewData.kt
@@ -37,6 +37,7 @@ internal object TrezorPreviewData {
         passphraseProtection = false,
         initialized = true,
         needsBackup = false,
+        passphraseEntryCapable = true,
     )
 
     val sampleFeaturesMinimal = TrezorFeatures(
@@ -51,6 +52,7 @@ internal object TrezorPreviewData {
         passphraseProtection = null,
         initialized = null,
         needsBackup = null,
+        passphraseEntryCapable = null,
     )
 
     val sampleKnownDevice = KnownDevice(

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorScreen.kt
@@ -51,6 +51,7 @@ import to.bitkit.repositories.ConnectedTrezorDevice
 import to.bitkit.repositories.KnownDevice
 import to.bitkit.repositories.TrezorState
 import to.bitkit.services.TrezorDebugLog
+import to.bitkit.services.TrezorWalletMode
 import to.bitkit.ui.components.ButtonSize
 import to.bitkit.ui.components.Caption
 import to.bitkit.ui.components.Caption13Up
@@ -96,6 +97,8 @@ private fun TrezorScreenContent(
     val trezorState by viewModel.trezorState.collectAsStateWithLifecycle()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val needsPairingCode by viewModel.needsPairingCode.collectAsStateWithLifecycle()
+    val needsPinEntry by viewModel.needsPinEntry.collectAsStateWithLifecycle()
+    val walletMode by viewModel.walletMode.collectAsStateWithLifecycle()
 
     val permissionsState = rememberMultiplePermissionsState(bluetoothPermissions)
 
@@ -118,6 +121,13 @@ private fun TrezorScreenContent(
         )
     }
 
+    if (needsPinEntry) {
+        PinEntryDialog(
+            onSubmit = viewModel::submitPin,
+            onCancel = viewModel::cancelPin,
+        )
+    }
+
     ScreenColumn {
         AppTopBar(
             titleText = "Trezor",
@@ -132,6 +142,8 @@ private fun TrezorScreenContent(
             onConnectNearby = viewModel::connect,
             onConnectKnown = viewModel::connectKnownDevice,
             onForgetDevice = viewModel::forgetDevice,
+            walletMode = walletMode,
+            onSetWalletMode = viewModel::setWalletMode,
             onGetAddress = viewModel::getAddress,
             onGetPublicKey = viewModel::getPublicKey,
             onIncrementIndex = viewModel::incrementAddressIndex,
@@ -170,6 +182,8 @@ private fun Content(
     onConnectNearby: (String) -> Unit = {},
     onConnectKnown: (String) -> Unit = {},
     onForgetDevice: (KnownDevice) -> Unit = {},
+    walletMode: TrezorWalletMode = TrezorWalletMode.STANDARD,
+    onSetWalletMode: (TrezorWalletMode, String) -> Unit = { _, _ -> },
     onGetAddress: (Boolean) -> Unit = {},
     onGetPublicKey: (Boolean) -> Unit = {},
     onIncrementIndex: () -> Unit = {},
@@ -231,6 +245,14 @@ private fun Content(
                     onDisconnect = onDisconnect,
                     permissionsGranted = permissionsGranted,
                 )
+
+                if (trezorState.connected != null) {
+                    WalletModeRow(
+                        walletMode = walletMode,
+                        passphraseEntryCapable = trezorState.connectedDevice?.passphraseEntryCapable == true,
+                        onSetWalletMode = onSetWalletMode,
+                    )
+                }
 
                 // Known Devices Section
                 AnimatedVisibility(
@@ -409,6 +431,76 @@ private fun Content(
                 DebugLogSection()
             }
         }
+    }
+}
+
+@Composable
+private fun WalletModeRow(
+    walletMode: TrezorWalletMode,
+    passphraseEntryCapable: Boolean,
+    onSetWalletMode: (TrezorWalletMode, String) -> Unit,
+) {
+    var showChooser by remember { mutableStateOf(false) }
+    var showHostEntry by remember { mutableStateOf(false) }
+
+    Column {
+        VerticalSpacer(16.dp)
+        Caption13Up("WALLET", color = Colors.White64)
+        VerticalSpacer(8.dp)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            TagButton(
+                text = "Standard",
+                onClick = { onSetWalletMode(TrezorWalletMode.STANDARD, "") },
+                isSelected = walletMode == TrezorWalletMode.STANDARD,
+            )
+            TagButton(
+                text = "Passphrase",
+                onClick = {
+                    // Capable devices can enter on-device, so offer the choice;
+                    // otherwise go straight to host passphrase entry.
+                    if (passphraseEntryCapable) showChooser = true else showHostEntry = true
+                },
+                isSelected = walletMode != TrezorWalletMode.STANDARD,
+            )
+        }
+        VerticalSpacer(4.dp)
+        Footnote(
+            text = when (walletMode) {
+                TrezorWalletMode.STANDARD -> "Standard wallet (no passphrase)"
+                TrezorWalletMode.PASSPHRASE_HOST -> "Hidden wallet — passphrase entered on this phone"
+                TrezorWalletMode.PASSPHRASE_DEVICE -> "Hidden wallet — passphrase entered on the Trezor"
+            },
+            color = Colors.White64,
+        )
+    }
+
+    if (showChooser) {
+        WalletModeChooserDialog(
+            onHost = {
+                showChooser = false
+                showHostEntry = true
+            },
+            onTrezor = {
+                showChooser = false
+                onSetWalletMode(TrezorWalletMode.PASSPHRASE_DEVICE, "")
+            },
+            onCancel = { showChooser = false },
+        )
+    }
+
+    if (showHostEntry) {
+        // Collect the passphrase up front — on THP it's bound at session creation.
+        PassphraseDialog(
+            onSubmit = { passphrase ->
+                showHostEntry = false
+                onSetWalletMode(TrezorWalletMode.PASSPHRASE_HOST, passphrase)
+            },
+            onUseTrezor = {
+                showHostEntry = false
+                onSetWalletMode(TrezorWalletMode.PASSPHRASE_DEVICE, "")
+            },
+            onCancel = { showHostEntry = false },
+        )
     }
 }
 

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorScreen.kt
@@ -490,7 +490,10 @@ private fun WalletModeRow(
 
     if (showHostEntry) {
         // Collect the passphrase up front — on THP it's bound at session creation.
+        // Only offer the "enter on Trezor" shortcut when the device supports it;
+        // otherwise picking it would select PASSPHRASE_DEVICE and fail to connect.
         PassphraseDialog(
+            allowDeviceEntry = passphraseEntryCapable,
             onSubmit = { passphrase ->
                 showHostEntry = false
                 onSetWalletMode(TrezorWalletMode.PASSPHRASE_HOST, passphrase)

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorViewModel.kt
@@ -28,6 +28,7 @@ import to.bitkit.models.toTrezorCoinType
 import to.bitkit.repositories.KnownDevice
 import to.bitkit.repositories.TrezorRepo
 import to.bitkit.services.TrezorDebugLog
+import to.bitkit.services.TrezorWalletMode
 import to.bitkit.ui.shared.toast.ToastEventBus
 import javax.inject.Inject
 import com.synonym.bitkitcore.Network as BitkitCoreNetwork
@@ -52,6 +53,12 @@ class TrezorViewModel @Inject constructor(
      */
     val needsPairingCode = trezorRepo.needsPairingCode
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    val needsPinEntry = trezorRepo.needsPinEntry
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    val walletMode = trezorRepo.walletMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), TrezorWalletMode.STANDARD)
 
     private val _uiState = MutableStateFlow(TrezorUiState())
     val uiState = _uiState.asStateFlow()
@@ -95,6 +102,10 @@ class TrezorViewModel @Inject constructor(
 
     fun connect(deviceId: String) {
         viewModelScope.launch(bgDispatcher) {
+            // Explicit device pick starts from the standard wallet; the user
+            // opts back into a passphrase wallet afterwards. Prevents a stale
+            // on-device/passphrase selection from a prior device being applied.
+            trezorRepo.resetWalletSelection()
             trezorRepo.connect(deviceId)
                 .onSuccess { features ->
                     val label = features.label ?: features.model ?: "Trezor"
@@ -106,6 +117,10 @@ class TrezorViewModel @Inject constructor(
 
     fun connectKnownDevice(deviceId: String) {
         viewModelScope.launch(bgDispatcher) {
+            // Explicit device pick starts from the standard wallet; the user
+            // opts back into a passphrase wallet afterwards. Prevents a stale
+            // on-device/passphrase selection from a prior device being applied.
+            trezorRepo.resetWalletSelection()
             trezorRepo.connectKnownDevice(deviceId)
                 .onSuccess { features ->
                     val label = features.label ?: features.model ?: "Trezor"
@@ -603,6 +618,25 @@ class TrezorViewModel @Inject constructor(
      */
     fun cancelPairingCode() {
         trezorRepo.cancelPairingCode()
+    }
+
+    fun submitPin(pin: String) {
+        trezorRepo.submitPin(pin)
+    }
+
+    fun cancelPin() {
+        trezorRepo.cancelPin()
+    }
+
+    /**
+     * Switch between the standard wallet and a passphrase (hidden) wallet.
+     * Resets the device session (disconnect/reconnect) so the choice applies.
+     */
+    fun setWalletMode(mode: TrezorWalletMode, passphrase: String = "") {
+        viewModelScope.launch(bgDispatcher) {
+            trezorRepo.setWalletMode(mode, passphrase)
+                .onFailure { ToastEventBus.send(it) }
+        }
     }
 
     /**

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/WalletModeChooserDialog.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/WalletModeChooserDialog.kt
@@ -1,0 +1,79 @@
+package to.bitkit.ui.screens.trezor
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import to.bitkit.ui.components.ButtonSize
+import to.bitkit.ui.components.Caption
+import to.bitkit.ui.components.PrimaryButton
+import to.bitkit.ui.components.TertiaryButton
+import to.bitkit.ui.components.Title
+import to.bitkit.ui.components.VerticalSpacer
+import to.bitkit.ui.theme.AppThemeSurface
+import to.bitkit.ui.theme.Colors
+
+/**
+ * Asks where the user wants to enter the passphrase for a hidden wallet —
+ * on the phone (host) or on the Trezor's own screen. Only shown when the
+ * device reports it can accept on-device passphrase entry.
+ */
+@Composable
+internal fun WalletModeChooserDialog(
+    onHost: () -> Unit,
+    onTrezor: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onCancel,
+        containerColor = Colors.Gray5,
+        shape = MaterialTheme.shapes.medium,
+        title = {
+            Title(text = "Passphrase Entry", color = Colors.White)
+        },
+        text = {
+            Column {
+                Caption(
+                    text = "Where do you want to enter the passphrase for your hidden wallet?",
+                    color = Colors.White80,
+                )
+                VerticalSpacer(16.dp)
+                PrimaryButton(
+                    text = "On this phone",
+                    onClick = onHost,
+                    size = ButtonSize.Small,
+                )
+                VerticalSpacer(8.dp)
+                PrimaryButton(
+                    text = "On the Trezor",
+                    onClick = onTrezor,
+                    size = ButtonSize.Small,
+                )
+            }
+        },
+        dismissButton = {
+            TertiaryButton(
+                text = "Cancel",
+                onClick = onCancel,
+                size = ButtonSize.Small,
+                fullWidth = false,
+            )
+        },
+        confirmButton = {},
+    )
+}
+
+@Preview(showSystemUi = true)
+@Composable
+private fun PreviewWalletModeChooserDialog() {
+    AppThemeSurface {
+        Box(Modifier.fillMaxSize()) {
+            WalletModeChooserDialog(onHost = {}, onTrezor = {}, onCancel = {})
+        }
+    }
+}

--- a/app/src/test/java/to/bitkit/repositories/TrezorRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/TrezorRepoTest.kt
@@ -8,6 +8,7 @@ import com.synonym.bitkitcore.TrezorFeatures
 import com.synonym.bitkitcore.TrezorPublicKeyResponse
 import com.synonym.bitkitcore.TrezorSignedMessageResponse
 import com.synonym.bitkitcore.TrezorTransportType
+import com.synonym.bitkitcore.WalletSelection
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
@@ -17,6 +18,7 @@ import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -25,6 +27,7 @@ import to.bitkit.data.TrezorStore
 import to.bitkit.env.Env
 import to.bitkit.services.TrezorService
 import to.bitkit.services.TrezorTransport
+import to.bitkit.services.TrezorUiHandler
 import to.bitkit.test.BaseUnitTest
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -51,6 +54,7 @@ class TrezorRepoTest : BaseUnitTest() {
     private val context = mock<Context>()
     private val trezorService = mock<TrezorService>()
     private val trezorTransport = mock<TrezorTransport>()
+    private val trezorUiHandler = mock<TrezorUiHandler>()
     private val trezorStore = mock<TrezorStore>()
     private val prefs = mock<SharedPreferences>()
     private val prefsEditor = mock<SharedPreferences.Editor>()
@@ -66,6 +70,8 @@ class TrezorRepoTest : BaseUnitTest() {
         whenever(prefsEditor.putString(any(), any())).thenReturn(prefsEditor)
         whenever(trezorTransport.needsPairingCode).thenReturn(MutableStateFlow(false))
         whenever(trezorTransport.externalDisconnect).thenReturn(MutableSharedFlow())
+        whenever(trezorUiHandler.needsPinEntry).thenReturn(MutableStateFlow(false))
+        whenever(trezorUiHandler.currentSelection()).thenReturn(WalletSelection.Standard)
         whenever(context.filesDir).thenReturn(tempFolder.root)
         whenever { trezorStore.loadKnownDevices() }.thenReturn(emptyList())
     }
@@ -74,6 +80,7 @@ class TrezorRepoTest : BaseUnitTest() {
         context = context,
         trezorService = trezorService,
         trezorTransport = trezorTransport,
+        trezorUiHandler = trezorUiHandler,
         trezorStore = trezorStore,
         ioDispatcher = testDispatcher,
     )
@@ -201,7 +208,7 @@ class TrezorRepoTest : BaseUnitTest() {
     fun `connect should return features and update connectedDevice state`() = test {
         val features = mockFeatures()
         val device = mockDeviceInfo()
-        whenever(trezorService.connect(DEVICE_ID)).thenReturn(features)
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
         whenever(trezorService.scan()).thenReturn(listOf(device))
         sut = createSut()
 
@@ -221,7 +228,7 @@ class TrezorRepoTest : BaseUnitTest() {
     fun `connect should persist connected device as known device`() = test {
         val features = mockFeatures(label = "Savings", model = "Safe 5")
         val device = mockDeviceInfo()
-        whenever(trezorService.connect(DEVICE_ID)).thenReturn(features)
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
         whenever(trezorService.scan()).thenReturn(listOf(device))
         sut = createSut()
 
@@ -242,7 +249,7 @@ class TrezorRepoTest : BaseUnitTest() {
     fun `connect should retry once for retryable THP errors`() = test {
         val features = mockFeatures()
         val device = mockDeviceInfo()
-        whenever(trezorService.connect(DEVICE_ID))
+        whenever(trezorService.connect(eq(DEVICE_ID), any()))
             .thenThrow(RuntimeException("thp timeout"))
             .thenReturn(features)
         whenever(trezorService.scan()).thenReturn(listOf(device))
@@ -253,23 +260,23 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         assertEquals(features, result.getOrNull())
-        verify(trezorService, times(2)).connect(DEVICE_ID)
+        verify(trezorService, times(2)).connect(eq(DEVICE_ID), any())
     }
 
     @Test
     fun `connect should not retry non-retryable errors`() = test {
-        whenever(trezorService.connect(DEVICE_ID)).thenThrow(RuntimeException("bad pin"))
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenThrow(RuntimeException("bad pin"))
         sut = createSut()
 
         val result = sut.connect(DEVICE_ID)
 
         assertTrue(result.isFailure)
-        verify(trezorService, times(1)).connect(DEVICE_ID)
+        verify(trezorService, times(1)).connect(eq(DEVICE_ID), any())
     }
 
     @Test
     fun `connect should set error on failure`() = test {
-        whenever(trezorService.connect(DEVICE_ID)).thenThrow(RuntimeException("connect failed"))
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenThrow(RuntimeException("connect failed"))
         sut = createSut()
 
         val result = sut.connect(DEVICE_ID)
@@ -287,7 +294,7 @@ class TrezorRepoTest : BaseUnitTest() {
     fun `disconnect should clear connectedDevice state`() = test {
         val features = mockFeatures()
         val device = mockDeviceInfo()
-        whenever(trezorService.connect(DEVICE_ID)).thenReturn(features)
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
         whenever(trezorService.scan()).thenReturn(listOf(device))
         sut = createSut()
 
@@ -310,7 +317,7 @@ class TrezorRepoTest : BaseUnitTest() {
         val device = mockDeviceInfo()
         val addressResponse = mock<TrezorAddressResponse>()
         val publicKeyResponse = mock<TrezorPublicKeyResponse>()
-        whenever(trezorService.connect(DEVICE_ID)).thenReturn(features)
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
         whenever(trezorService.scan()).thenReturn(listOf(device))
         whenever(trezorService.isConnected()).thenReturn(true)
         whenever(
@@ -496,7 +503,7 @@ class TrezorRepoTest : BaseUnitTest() {
         val features = mockFeatures()
         whenever(trezorStore.loadKnownDevices()).thenReturn(listOf(knownDevice))
         whenever(trezorService.scan()).thenReturn(listOf(device))
-        whenever(trezorService.connect(DEVICE_ID)).thenReturn(features)
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
         whenever(trezorService.isConnected()).thenReturn(false)
         sut = createSut()
 
@@ -520,7 +527,7 @@ class TrezorRepoTest : BaseUnitTest() {
         val features = mockFeatures()
         whenever(trezorStore.loadKnownDevices()).thenReturn(listOf(knownDevice))
         whenever(trezorService.scan()).thenReturn(listOf(device))
-        whenever(trezorService.connect(DEVICE_ID)).thenReturn(features)
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
         sut = createSut()
 
         sut.initialize()
@@ -578,7 +585,7 @@ class TrezorRepoTest : BaseUnitTest() {
         whenever(trezorStore.loadKnownDevices()).thenReturn(listOf(knownDevice))
         whenever(trezorService.isConnected()).thenReturn(false)
         whenever(trezorService.scan()).thenReturn(listOf(device))
-        whenever(trezorService.connect(DEVICE_ID)).thenReturn(features)
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
         whenever(
             trezorService.getAddress(
                 path = any(),
@@ -596,7 +603,7 @@ class TrezorRepoTest : BaseUnitTest() {
         assertEquals(addressResponse, result.getOrNull())
         assertEquals(DEVICE_ID, sut.state.value.connectedDeviceId)
         verify(trezorService).scan()
-        verify(trezorService).connect(DEVICE_ID)
+        verify(trezorService).connect(eq(DEVICE_ID), any())
     }
 
     // endregion
@@ -609,7 +616,7 @@ class TrezorRepoTest : BaseUnitTest() {
         val features = mockFeatures()
         val device = mockDeviceInfo()
         whenever(trezorStore.loadKnownDevices()).thenReturn(listOf(knownDevice))
-        whenever(trezorService.connect(DEVICE_ID)).thenReturn(features)
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
         whenever(trezorService.scan()).thenReturn(listOf(device))
         sut = createSut()
 

--- a/app/src/test/java/to/bitkit/ui/screens/trezor/TrezorViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/trezor/TrezorViewModelTest.kt
@@ -11,12 +11,14 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import to.bitkit.repositories.TrezorRepo
 import to.bitkit.repositories.TrezorState
+import to.bitkit.services.TrezorWalletMode
 import to.bitkit.test.BaseUnitTest
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -30,6 +32,8 @@ class TrezorViewModelTest : BaseUnitTest() {
     private val trezorRepo: TrezorRepo = mock()
     private val trezorStateFlow = MutableStateFlow(TrezorState())
     private val needsPairingCodeFlow = MutableStateFlow(false)
+    private val needsPinEntryFlow = MutableStateFlow(false)
+    private val walletModeFlow = MutableStateFlow(TrezorWalletMode.STANDARD)
 
     private lateinit var sut: TrezorViewModel
 
@@ -37,6 +41,8 @@ class TrezorViewModelTest : BaseUnitTest() {
     fun setUp() {
         whenever(trezorRepo.state).thenReturn(trezorStateFlow)
         whenever(trezorRepo.needsPairingCode).thenReturn(needsPairingCodeFlow)
+        whenever(trezorRepo.needsPinEntry).thenReturn(needsPinEntryFlow)
+        whenever(trezorRepo.walletMode).thenReturn(walletModeFlow)
         whenever(trezorRepo.observeExternalDisconnects(any())).then { }
         sut = createViewModel()
     }
@@ -180,14 +186,33 @@ class TrezorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `connect should call trezorRepo connect with deviceId`() = test {
+    fun `connect should reset wallet selection then call trezorRepo connect with deviceId`() = test {
         val deviceId = "device-123"
         whenever(trezorRepo.connect(deviceId)).thenReturn(Result.failure(RuntimeException("test")))
 
         sut.connect(deviceId)
         advanceUntilIdle()
 
-        verify(trezorRepo).connect(deviceId)
+        // An explicit device pick starts from the standard wallet, so the reset
+        // must happen before the connect.
+        inOrder(trezorRepo) {
+            verify(trezorRepo).resetWalletSelection()
+            verify(trezorRepo).connect(deviceId)
+        }
+    }
+
+    @Test
+    fun `connectKnownDevice should reset wallet selection then call trezorRepo connectKnownDevice`() = test {
+        val deviceId = "device-123"
+        whenever(trezorRepo.connectKnownDevice(deviceId)).thenReturn(Result.failure(RuntimeException("test")))
+
+        sut.connectKnownDevice(deviceId)
+        advanceUntilIdle()
+
+        inOrder(trezorRepo) {
+            verify(trezorRepo).resetWalletSelection()
+            verify(trezorRepo).connectKnownDevice(deviceId)
+        }
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ activity-compose = { module = "androidx.activity:activity-compose", version = "1
 appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
 barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version = "17.3.0" }
 biometric = { module = "androidx.biometric:biometric", version = "1.4.0-alpha05" }
-bitkit-core = { module = "com.synonym:bitkit-core-android", version = "0.1.58" }
+bitkit-core = { module = "com.synonym:bitkit-core-android", version = "0.1.62" }
 paykit = { module = "com.synonym:paykit-android", version = "0.1.0-rc8" }
 bouncycastle-provider-jdk = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.83" }
 camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camera" }


### PR DESCRIPTION
Adds on-screen Trezor PIN entry and passphrase (hidden wallet) selection, built on the typed TrezorUiCallback from bitkit-core 0.1.62.

- Passphrase: WalletModeChooserDialog + PassphraseDialog let the user open the standard wallet or a hidden wallet, entering the passphrase on the phone (host) or on the Trezor. Modeled as TrezorWalletMode (STANDARD / PASSPHRASE_HOST / PASSPHRASE_DEVICE).

Bumps bitkit-core 0.1.58 -> 0.1.62.

### Description

App-side adoption of the typed Trezor UI callback and per-connection wallet
selection from bitkit-core 0.1.62 (`trezor-connect-rs` 0.2.8 → 0.3.2). The
library replaced the stringly-typed passphrase callback — where `""` was
overloaded to mean *cancel*, leaving no way to express the standard wallet
(`Some("")` on the device) — with a typed `PassphraseResponse`, and made each
connection declare which wallet it opens.

**PIN entry**
- `PinEntryDialog` renders the 3×3 matrix; the user maps it to the scrambled
  layout shown on the Trezor. `onPinRequest` blocks on a `CountDownLatch`
  (120s timeout) until the PIN is submitted or cancelled (empty string).

**Passphrase / hidden wallets**
- A `WALLET` row lets the user open the standard wallet or a hidden wallet.
  Devices reporting `passphraseEntryCapable` are offered a choice
  (`WalletModeChooserDialog`) of entering the passphrase on the phone (host,
  via `PassphraseDialog`) or on the Trezor; otherwise host entry is used.
  Modeled as `TrezorWalletMode` (`STANDARD` / `PASSPHRASE_HOST` /
  `PASSPHRASE_DEVICE`).
- `onPassphraseRequest` answers with `PassphraseResponse.Standard` /
  `Hidden { value }` / `OnDevice` from a single source of truth, so THP
  devices (Safe 5/7) — which bind the passphrase at session creation via the
  new `WalletSelection` passed to `connect()` — and legacy devices — asked
  mid-operation — stay in lockstep.

**Transport / reconnect fixes**
- Reconnect honors the tapped transport instead of overriding Bluetooth with
  USB; BLE falls back to `getRemoteDevice(address)` when there's no fresh scan
  handle; rejected sessions (wrong passphrase/on-device cancel) are treated
  as definitive failures rather than retried.

Adopts the breaking FFI changes from bitkit-core 0.1.62: `onPassphraseRequest`
now returns `PassphraseResponse` (was `String`) and `trezorConnect` takes a
required `selection: WalletSelection`.

### QA Notes

Manual (PIN-protected device, ideally both a THP device — Safe 5/7 — and a legacy device):
- **PIN:** connect a PIN-protected device → the on-screen matrix maps to the
  scrambled layout on the Trezor; submit / delete / cancel / 120s timeout all
  behave.
- **Standard wallet:** keep/select Standard → operations proceed (the case the
  old `""`-means-cancel encoding broke).
- **Hidden wallet (host entry):** Passphrase → On this phone, enter a
  passphrase → the hidden wallet's addresses differ from standard.
- **On-device entry:** Passphrase → On the Trezor → entry defers to the device
  and the matching wallet opens.
- **Wallet switch:** switch mode on a connected device → the session resets and
  the new mode applies on the next operation.
- **Forget / disconnect:** forget or disconnect, then reconnect → starts on the
  standard wallet.
- **Transport:** reconnect a device known over both BLE and USB via its BLE
  entry → it connects over BLE, not hijacked to USB.

### Preview
<img width="1080" height="2404" alt="Screenshot_20260527-110803" src="https://github.com/user-attachments/assets/ea101a01-9680-4c3e-99ae-102676e7e3ff" />

