### PR TITLE
fix: refresh widgets after idle

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE"
         tools:ignore="ForegroundServicePermission,ForegroundServicesPolicy" />
@@ -171,6 +172,16 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name=".appwidget.AppWidgetRefreshReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="to.bitkit.appwidget.REFRESH_ALARM" />
+            </intent-filter>
+        </receiver>
 
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app/src/main/java/to/bitkit/App.kt
+++ b/app/src/main/java/to/bitkit/App.kt
@@ -10,6 +10,8 @@ import androidx.work.Configuration
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import dagger.hilt.android.HiltAndroidApp
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.AppWidgetRefreshScheduler
 import to.bitkit.env.Env
 import to.bitkit.services.BluetoothInit
 import javax.inject.Inject
@@ -22,6 +24,9 @@ internal open class App : Application(), Configuration.Provider {
     @Inject
     lateinit var imageLoader: ImageLoader
 
+    @Inject
+    lateinit var appWidgetRefreshScheduler: AppWidgetRefreshScheduler
+
     override val workManagerConfiguration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
@@ -29,9 +34,10 @@ internal open class App : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        Env.initAppStoragePath(filesDir.absolutePath)
         SingletonImageLoader.setSafe { imageLoader }
         currentActivity = CurrentActivity().also { registerActivityLifecycleCallbacks(it) }
-        Env.initAppStoragePath(filesDir.absolutePath)
+        appWidgetRefreshScheduler.ensureScheduled(AppWidgetRefreshReason.APP_START)
         // Initialize btleplug for Bluetooth support (required before any BLE usage)
         BluetoothInit.ensureInitialized()
     }

--- a/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
+++ b/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.launch
 import org.lightningdevkit.ldknode.Event
 import to.bitkit.App
 import to.bitkit.R
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.AppWidgetRefreshScheduler
 import to.bitkit.data.CacheStore
 import to.bitkit.di.UiDispatcher
 import to.bitkit.domain.commands.NotifyPaymentReceived
@@ -63,6 +65,9 @@ class LightningNodeService : Service() {
 
     @Inject
     lateinit var cacheStore: CacheStore
+
+    @Inject
+    lateinit var appWidgetRefreshScheduler: AppWidgetRefreshScheduler
 
     private var hasStartedNode = false
 
@@ -157,6 +162,8 @@ class LightningNodeService : Service() {
         Logger.debug("Received start command action '$action'", context = TAG)
         when (action) {
             ACTION_STOP_SERVICE_AND_APP -> {
+                appWidgetRefreshScheduler.ensureScheduled(AppWidgetRefreshReason.SERVICE_STOP_ACTION)
+                appWidgetRefreshScheduler.requestCatchUp(AppWidgetRefreshReason.SERVICE_STOP_ACTION)
                 stopForegroundService(startId) { Logger.debug("Received stop service action", context = TAG) }
                 activityManager.appTasks.forEach { it.finishAndRemoveTask() }
                 serviceScope.launch { lightningRepo.stop() }

--- a/app/src/main/java/to/bitkit/appwidget/AppWidgetPreferencesStore.kt
+++ b/app/src/main/java/to/bitkit/appwidget/AppWidgetPreferencesStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.Flow
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import to.bitkit.appwidget.model.AppWidgetData
 import to.bitkit.appwidget.model.AppWidgetEntry
+import to.bitkit.appwidget.model.AppWidgetRefreshMetadata
 import to.bitkit.appwidget.model.AppWidgetType
 import to.bitkit.data.dto.ArticleDTO
 import to.bitkit.data.dto.BlockDTO
@@ -33,8 +35,14 @@ private val Context.appWidgetDataStore: DataStore<AppWidgetData> by dataStore(
 interface AppWidgetEntryPoint {
     fun appWidgetPreferencesStore(): AppWidgetPreferencesStore
     fun appWidgetDataRepository(): AppWidgetDataRepository
+    fun appWidgetRefreshScheduler(): AppWidgetRefreshScheduler
     fun currencyRepo(): CurrencyRepo
 }
+
+val Context.appWidgetRefreshScheduler: AppWidgetRefreshScheduler
+    get() = EntryPointAccessors
+        .fromApplication(applicationContext, AppWidgetEntryPoint::class.java)
+        .appWidgetRefreshScheduler()
 
 @Singleton
 @Suppress("TooManyFunctions")
@@ -80,6 +88,26 @@ class AppWidgetPreferencesStore @Inject constructor(
             .map { it.pricePreferences.period }
             .toSet()
 
+    suspend fun getUncachedActivePricePeriods(): Set<GraphPeriod> {
+        val data = store.data.first()
+        return data.entries
+            .filter { it.type == AppWidgetType.PRICE }
+            .map { it.pricePreferences.period }
+            .filterNot { it in data.cachedPrices }
+            .toSet()
+    }
+
+    suspend fun getRefreshMetadata(type: AppWidgetType): AppWidgetRefreshMetadata =
+        store.data.first().refreshMetadata[type] ?: AppWidgetRefreshMetadata()
+
+    suspend fun markRefreshAttempt(type: AppWidgetType, timestampMs: Long) {
+        updateRefreshMetadata(type) { it.copy(lastAttemptAtMs = timestampMs) }
+    }
+
+    suspend fun markRefreshSuccess(type: AppWidgetType, timestampMs: Long) {
+        updateRefreshMetadata(type) { it.copy(lastSuccessAtMs = timestampMs) }
+    }
+
     fun hasWidgetsOfType(type: AppWidgetType): Flow<Boolean> =
         data.map { it.entries.any { entry -> entry.type == type } }
 
@@ -111,5 +139,15 @@ class AppWidgetPreferencesStore @Inject constructor(
 
     suspend fun cacheWeather(weather: WeatherDTO) {
         store.updateData { it.copy(cachedWeather = weather) }
+    }
+
+    private suspend fun updateRefreshMetadata(
+        type: AppWidgetType,
+        transform: (AppWidgetRefreshMetadata) -> AppWidgetRefreshMetadata,
+    ) {
+        store.updateData {
+            val current = it.refreshMetadata[type] ?: AppWidgetRefreshMetadata()
+            it.copy(refreshMetadata = it.refreshMetadata + (type to transform(current)))
+        }
     }
 }

--- a/app/src/main/java/to/bitkit/appwidget/AppWidgetRefreshPolicy.kt
+++ b/app/src/main/java/to/bitkit/appwidget/AppWidgetRefreshPolicy.kt
@@ -1,0 +1,41 @@
+package to.bitkit.appwidget
+
+import to.bitkit.appwidget.model.AppWidgetRefreshMetadata
+import to.bitkit.appwidget.model.AppWidgetType
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+object AppWidgetRefreshPolicy {
+    fun shouldRefreshRemote(
+        type: AppWidgetType,
+        metadata: AppWidgetRefreshMetadata,
+        nowMs: Long,
+        hasUncachedData: Boolean = false,
+        bypassFailedAttemptBackoff: Boolean = false,
+    ): Boolean {
+        val minRefreshInterval = type.minRefreshInterval ?: return false
+        if (!bypassFailedAttemptBackoff && shouldBackOffFailedAttempt(metadata, nowMs, minRefreshInterval)) {
+            return false
+        }
+        if (hasUncachedData) return true
+        if (metadata.lastSuccessAtMs <= 0L) return true
+        return nowMs - metadata.lastSuccessAtMs >= minRefreshInterval.inWholeMilliseconds
+    }
+
+    fun shouldBackOffFailedAttempt(
+        metadata: AppWidgetRefreshMetadata,
+        nowMs: Long,
+        minRefreshInterval: Duration,
+    ): Boolean =
+        metadata.lastAttemptAtMs > metadata.lastSuccessAtMs &&
+            nowMs - metadata.lastAttemptAtMs < minRefreshInterval.inWholeMilliseconds
+
+    val AppWidgetType.minRefreshInterval: Duration?
+        get() = when (this) {
+            AppWidgetType.PRICE,
+            AppWidgetType.BLOCKS -> AppWidgetRefreshScheduler.REFRESH_INTERVAL
+            AppWidgetType.WEATHER -> 30.minutes
+            AppWidgetType.HEADLINES -> 60.minutes
+            AppWidgetType.FACTS -> null
+        }
+}

--- a/app/src/main/java/to/bitkit/appwidget/AppWidgetRefreshReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/AppWidgetRefreshReceiver.kt
@@ -1,0 +1,44 @@
+package to.bitkit.appwidget
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import to.bitkit.utils.Logger
+import to.bitkit.utils.logBatterySettings
+
+class AppWidgetRefreshReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            Intent.ACTION_BOOT_COMPLETED -> scheduleAfterSystemEvent(
+                context,
+                AppWidgetRefreshReason.BOOT_COMPLETED,
+            )
+
+            Intent.ACTION_MY_PACKAGE_REPLACED -> scheduleAfterSystemEvent(
+                context,
+                AppWidgetRefreshReason.PACKAGE_REPLACED,
+            )
+
+            AppWidgetRefreshScheduler.CATCH_UP_ALARM_ACTION -> {
+                Logger.debug(
+                    "Received widget refresh alarm (${context.logBatterySettings()})",
+                    context = TAG,
+                )
+                context.appWidgetRefreshScheduler.handleCatchUpAlarm(AppWidgetRefreshReason.CATCH_UP_ALARM)
+            }
+        }
+    }
+
+    private fun scheduleAfterSystemEvent(context: Context, reason: AppWidgetRefreshReason) {
+        Logger.debug(
+            "Received widget refresh event for '${reason.name}' (${context.logBatterySettings()})",
+            context = TAG,
+        )
+        context.appWidgetRefreshScheduler.ensureScheduled(reason)
+        context.appWidgetRefreshScheduler.requestCatchUp(reason)
+    }
+
+    private companion object {
+        const val TAG = "AppWidgetRefreshReceiver"
+    }
+}

--- a/app/src/main/java/to/bitkit/appwidget/AppWidgetRefreshScheduler.kt
+++ b/app/src/main/java/to/bitkit/appwidget/AppWidgetRefreshScheduler.kt
@@ -1,0 +1,381 @@
+package to.bitkit.appwidget
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequest
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import dagger.hilt.android.qualifiers.ApplicationContext
+import to.bitkit.appwidget.model.AppWidgetType
+import to.bitkit.appwidget.ui.blocks.BlocksGlanceReceiver
+import to.bitkit.appwidget.ui.facts.FactsGlanceReceiver
+import to.bitkit.appwidget.ui.headlines.HeadlinesGlanceReceiver
+import to.bitkit.appwidget.ui.price.PriceGlanceReceiver
+import to.bitkit.appwidget.ui.weather.WeatherGlanceReceiver
+import to.bitkit.ext.alarmManager
+import to.bitkit.utils.Logger
+import to.bitkit.utils.logBatterySettings
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+@Singleton
+class AppWidgetRefreshScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val activeWidgets: AppWidgetActiveWidgets,
+    private val workClient: AppWidgetWorkClient,
+    private val alarmClient: AppWidgetAlarmClient,
+    private val elapsedRealtimeProvider: ElapsedRealtimeProvider,
+) {
+    fun ensureScheduled(reason: AppWidgetRefreshReason) {
+        if (!activeWidgets.hasActiveWidgets()) {
+            cancelAll(reason)
+            return
+        }
+
+        ensureRemotePeriodicWork()
+        ensureFactsPeriodicWork()
+        scheduleCatchUpAlarm(reason)
+        Logger.debug(
+            "Ensured widget refresh schedule for '${reason.name}' (${context.logBatterySettings()})",
+            context = TAG,
+        )
+    }
+
+    fun requestCatchUp(reason: AppWidgetRefreshReason) {
+        if (!activeWidgets.hasActiveWidgets()) {
+            cancelAll(reason)
+            return
+        }
+
+        requestRemoteCatchUp(reason)
+        requestFactsCatchUp()
+        Logger.debug(
+            "Requested widget catch-up refresh for '${reason.name}' (${context.logBatterySettings()})",
+            context = TAG,
+        )
+    }
+
+    fun handleCatchUpAlarm(reason: AppWidgetRefreshReason) {
+        requestCatchUp(reason)
+        scheduleCatchUpAlarm(reason)
+    }
+
+    private fun ensureRemotePeriodicWork() {
+        if (!activeWidgets.hasRemoteBackedWidgets()) {
+            workClient.cancelUniqueWork(PERIODIC_WORK_NAME)
+            workClient.cancelUniqueWork(CATCH_UP_WORK_NAME)
+            return
+        }
+
+        workClient.enqueueUniquePeriodicWork(
+            PERIODIC_WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            periodicRequest(AppWidgetRefreshReason.REMOTE_PERIODIC_REFRESH, requiresNetwork = true),
+        )
+    }
+
+    private fun ensureFactsPeriodicWork() {
+        if (!activeWidgets.hasActiveWidgets(AppWidgetType.FACTS)) {
+            workClient.cancelUniqueWork(FACTS_PERIODIC_WORK_NAME)
+            workClient.cancelUniqueWork(FACTS_CATCH_UP_WORK_NAME)
+            return
+        }
+
+        workClient.enqueueUniquePeriodicWork(
+            FACTS_PERIODIC_WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            periodicRequest(AppWidgetRefreshReason.FACTS_LOCAL_REFRESH, requiresNetwork = false),
+        )
+    }
+
+    private fun requestRemoteCatchUp(reason: AppWidgetRefreshReason) {
+        if (!activeWidgets.hasRemoteBackedWidgets()) {
+            workClient.cancelUniqueWork(CATCH_UP_WORK_NAME)
+            return
+        }
+
+        workClient.enqueueUniqueWork(
+            CATCH_UP_WORK_NAME,
+            catchUpWorkPolicy(reason),
+            oneTimeRequest(reason, requiresNetwork = true),
+        )
+    }
+
+    private fun catchUpWorkPolicy(reason: AppWidgetRefreshReason): ExistingWorkPolicy =
+        when (reason) {
+            AppWidgetRefreshReason.APP_START,
+            AppWidgetRefreshReason.APP_FOREGROUND -> ExistingWorkPolicy.REPLACE
+            else -> ExistingWorkPolicy.KEEP
+        }
+
+    private fun requestFactsCatchUp() {
+        if (!activeWidgets.hasActiveWidgets(AppWidgetType.FACTS)) {
+            workClient.cancelUniqueWork(FACTS_CATCH_UP_WORK_NAME)
+            return
+        }
+
+        workClient.enqueueUniqueWork(
+            FACTS_CATCH_UP_WORK_NAME,
+            ExistingWorkPolicy.KEEP,
+            oneTimeRequest(AppWidgetRefreshReason.FACTS_LOCAL_REFRESH, requiresNetwork = false),
+        )
+    }
+
+    private fun scheduleCatchUpAlarm(reason: AppWidgetRefreshReason) {
+        if (!activeWidgets.hasActiveWidgets()) {
+            cancelAll(reason)
+            return
+        }
+
+        val batterySettings = context.logBatterySettings()
+        val triggerAt = elapsedRealtimeProvider.elapsedRealtime() + REFRESH_INTERVAL.inWholeMilliseconds
+        runCatching {
+            alarmClient.setAndAllowWhileIdle(
+                AlarmManager.ELAPSED_REALTIME,
+                triggerAt,
+                checkNotNull(
+                    catchUpAlarmPendingIntent(PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE),
+                ) { "Expected catch-up alarm PendingIntent" },
+            )
+        }.onSuccess {
+            Logger.debug(
+                "Scheduled widget catch-up alarm for '${reason.name}' ($batterySettings)",
+                context = TAG,
+            )
+        }.onFailure {
+            Logger.error(
+                "Failed to schedule widget catch-up alarm for '${reason.name}' ($batterySettings)",
+                it,
+                context = TAG,
+            )
+        }
+    }
+
+    private fun cancelAll(reason: AppWidgetRefreshReason) {
+        workClient.cancelUniqueWork(PERIODIC_WORK_NAME)
+        workClient.cancelUniqueWork(CATCH_UP_WORK_NAME)
+        workClient.cancelUniqueWork(FACTS_PERIODIC_WORK_NAME)
+        workClient.cancelUniqueWork(FACTS_CATCH_UP_WORK_NAME)
+        cancelCatchUpAlarm()
+        Logger.debug(
+            "Canceled widget refresh schedule for '${reason.name}' (${context.logBatterySettings()})",
+            context = TAG,
+        )
+    }
+
+    private fun cancelCatchUpAlarm() {
+        val pendingIntent = catchUpAlarmPendingIntent(
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        ) ?: return
+
+        alarmClient.cancel(pendingIntent)
+        pendingIntent.cancel()
+    }
+
+    private fun catchUpAlarmPendingIntent(flags: Int): PendingIntent? =
+        PendingIntent.getBroadcast(
+            context,
+            CATCH_UP_ALARM_REQUEST_CODE,
+            catchUpAlarmIntent(),
+            flags,
+        )
+
+    private fun catchUpAlarmIntent(): Intent =
+        Intent(context, AppWidgetRefreshReceiver::class.java)
+            .setAction(CATCH_UP_ALARM_ACTION)
+
+    private fun periodicRequest(
+        reason: AppWidgetRefreshReason,
+        requiresNetwork: Boolean,
+    ): PeriodicWorkRequest =
+        PeriodicWorkRequestBuilder<AppWidgetRefreshWorker>(REFRESH_INTERVAL.toJavaDuration())
+            .apply {
+                if (requiresNetwork) setConstraints(networkConstraints())
+                setInputData(workDataOf(WORK_INPUT_REASON to reason.name))
+            }
+            .build()
+
+    private fun oneTimeRequest(
+        reason: AppWidgetRefreshReason,
+        requiresNetwork: Boolean,
+    ): OneTimeWorkRequest =
+        OneTimeWorkRequestBuilder<AppWidgetRefreshWorker>()
+            .apply {
+                if (requiresNetwork) setConstraints(networkConstraints())
+                setBackoffCriteria(BackoffPolicy.EXPONENTIAL, CATCH_UP_RETRY_BACKOFF.toJavaDuration())
+                setInputData(workDataOf(WORK_INPUT_REASON to reason.name))
+            }
+            .build()
+
+    private fun networkConstraints(): Constraints =
+        Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+    companion object {
+        const val CATCH_UP_ALARM_ACTION = "to.bitkit.appwidget.REFRESH_ALARM"
+        const val WORK_INPUT_REASON = "reason"
+        const val PERIODIC_WORK_NAME = "appwidget_refresh"
+        const val CATCH_UP_WORK_NAME = "appwidget_refresh_catch_up"
+        const val FACTS_PERIODIC_WORK_NAME = "appwidget_facts_refresh"
+        const val FACTS_CATCH_UP_WORK_NAME = "appwidget_facts_refresh_catch_up"
+        private const val TAG = "AppWidgetRefreshScheduler"
+        private const val CATCH_UP_ALARM_REQUEST_CODE = 0
+        val REFRESH_INTERVAL = 15.minutes
+        private val CATCH_UP_RETRY_BACKOFF = 10.seconds
+    }
+}
+
+enum class AppWidgetRefreshReason {
+    APP_START,
+    APP_FOREGROUND,
+    BLOCKS_WIDGET_DISABLED,
+    BLOCKS_WIDGET_ENABLED,
+    BLOCKS_WIDGET_UPDATE,
+    BOOT_COMPLETED,
+    CATCH_UP_ALARM,
+    FACTS_WIDGET_DISABLED,
+    FACTS_WIDGET_ENABLED,
+    FACTS_LOCAL_REFRESH,
+    FACTS_WIDGET_REGISTERED,
+    FACTS_WIDGET_UPDATE,
+    HEADLINES_WIDGET_DISABLED,
+    HEADLINES_WIDGET_ENABLED,
+    HEADLINES_WIDGET_UPDATE,
+    PACKAGE_REPLACED,
+    PRICE_WIDGET_DISABLED,
+    PRICE_WIDGET_ENABLED,
+    PRICE_WIDGET_UPDATE,
+    REMOTE_PERIODIC_REFRESH,
+    SERVICE_STOP_ACTION,
+    WEATHER_WIDGET_DISABLED,
+    WEATHER_WIDGET_ENABLED,
+    WEATHER_WIDGET_UPDATE,
+    WIDGET_CONFIG_CONFIRM,
+}
+
+fun AppWidgetType.receiverClass(): Class<out GlanceAppWidgetReceiver> = when (this) {
+    AppWidgetType.PRICE -> PriceGlanceReceiver::class.java
+    AppWidgetType.HEADLINES -> HeadlinesGlanceReceiver::class.java
+    AppWidgetType.BLOCKS -> BlocksGlanceReceiver::class.java
+    AppWidgetType.FACTS -> FactsGlanceReceiver::class.java
+    AppWidgetType.WEATHER -> WeatherGlanceReceiver::class.java
+}
+
+interface AppWidgetActiveWidgets {
+    fun hasActiveWidgets(): Boolean
+    fun hasActiveWidgets(type: AppWidgetType): Boolean
+}
+
+private fun AppWidgetActiveWidgets.hasRemoteBackedWidgets(): Boolean =
+    AppWidgetType.entries.any { it != AppWidgetType.FACTS && hasActiveWidgets(it) }
+
+@Singleton
+class AndroidAppWidgetActiveWidgets @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : AppWidgetActiveWidgets {
+    override fun hasActiveWidgets(): Boolean {
+        val manager = AppWidgetManager.getInstance(context)
+        return AppWidgetType.entries.any {
+            manager.getAppWidgetIds(ComponentName(context, it.receiverClass())).isNotEmpty()
+        }
+    }
+
+    override fun hasActiveWidgets(type: AppWidgetType): Boolean {
+        val manager = AppWidgetManager.getInstance(context)
+        return manager.getAppWidgetIds(ComponentName(context, type.receiverClass())).isNotEmpty()
+    }
+}
+
+interface AppWidgetWorkClient {
+    fun enqueueUniquePeriodicWork(
+        uniqueWorkName: String,
+        existingPeriodicWorkPolicy: ExistingPeriodicWorkPolicy,
+        request: PeriodicWorkRequest,
+    )
+
+    fun enqueueUniqueWork(
+        uniqueWorkName: String,
+        existingWorkPolicy: ExistingWorkPolicy,
+        request: OneTimeWorkRequest,
+    )
+
+    fun cancelUniqueWork(uniqueWorkName: String)
+}
+
+@Singleton
+class AndroidAppWidgetWorkClient @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : AppWidgetWorkClient {
+    override fun enqueueUniquePeriodicWork(
+        uniqueWorkName: String,
+        existingPeriodicWorkPolicy: ExistingPeriodicWorkPolicy,
+        request: PeriodicWorkRequest,
+    ) {
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            uniqueWorkName,
+            existingPeriodicWorkPolicy,
+            request,
+        )
+    }
+
+    override fun enqueueUniqueWork(
+        uniqueWorkName: String,
+        existingWorkPolicy: ExistingWorkPolicy,
+        request: OneTimeWorkRequest,
+    ) {
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            uniqueWorkName,
+            existingWorkPolicy,
+            request,
+        )
+    }
+
+    override fun cancelUniqueWork(uniqueWorkName: String) {
+        WorkManager.getInstance(context).cancelUniqueWork(uniqueWorkName)
+    }
+}
+
+interface AppWidgetAlarmClient {
+    fun setAndAllowWhileIdle(type: Int, triggerAtMillis: Long, operation: PendingIntent)
+    fun cancel(operation: PendingIntent)
+}
+
+@Singleton
+class AndroidAppWidgetAlarmClient @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : AppWidgetAlarmClient {
+    override fun setAndAllowWhileIdle(type: Int, triggerAtMillis: Long, operation: PendingIntent) {
+        context.alarmManager.setAndAllowWhileIdle(type, triggerAtMillis, operation)
+    }
+
+    override fun cancel(operation: PendingIntent) {
+        context.alarmManager.cancel(operation)
+    }
+}
+
+interface ElapsedRealtimeProvider {
+    fun elapsedRealtime(): Long
+}
+
+@Singleton
+class AndroidElapsedRealtimeProvider @Inject constructor() : ElapsedRealtimeProvider {
+    override fun elapsedRealtime(): Long = SystemClock.elapsedRealtime()
+}

--- a/app/src/main/java/to/bitkit/appwidget/AppWidgetRefreshWorker.kt
+++ b/app/src/main/java/to/bitkit/appwidget/AppWidgetRefreshWorker.kt
@@ -1,141 +1,243 @@
 package to.bitkit.appwidget
 
-import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.Context
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorker
-import androidx.work.Constraints
 import androidx.work.CoroutineWorker
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.NetworkType
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import to.bitkit.appwidget.model.AppWidgetRefreshMetadata
 import to.bitkit.appwidget.model.AppWidgetType
-import to.bitkit.appwidget.ui.blocks.BlocksGlanceReceiver
-import to.bitkit.appwidget.ui.blocks.BlocksGlanceWidget
-import to.bitkit.appwidget.ui.facts.FactsGlanceReceiver
-import to.bitkit.appwidget.ui.facts.FactsGlanceWidget
-import to.bitkit.appwidget.ui.headlines.HeadlinesGlanceReceiver
-import to.bitkit.appwidget.ui.headlines.HeadlinesGlanceWidget
-import to.bitkit.appwidget.ui.price.PriceGlanceReceiver
-import to.bitkit.appwidget.ui.price.PriceGlanceWidget
-import to.bitkit.appwidget.ui.weather.WeatherGlanceReceiver
-import to.bitkit.appwidget.ui.weather.WeatherGlanceWidget
+import to.bitkit.ext.nowMs
 import to.bitkit.utils.Logger
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.toJavaDuration
+import to.bitkit.utils.isConnectivityFailure
+import to.bitkit.utils.logBatterySettings
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 @HiltWorker
 class AppWidgetRefreshWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val dataRepository: AppWidgetDataRepository,
     private val preferencesStore: AppWidgetPreferencesStore,
+    private val appWidgetUpdater: AppWidgetUpdater,
+    private val clock: Clock,
 ) : CoroutineWorker(appContext, workerParams) {
 
-    companion object {
+    private companion object {
         private const val TAG = "AppWidgetRefreshWorker"
-        private const val WORK_NAME = "appwidget_refresh"
-
-        fun enqueue(context: Context) {
-            val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .build()
-
-            val request = PeriodicWorkRequestBuilder<AppWidgetRefreshWorker>(15.minutes.toJavaDuration())
-                .setConstraints(constraints)
-                .build()
-
-            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                WORK_NAME,
-                ExistingPeriodicWorkPolicy.KEEP,
-                request,
-            )
-        }
-
-        fun cancelIfNoWidgets(context: Context) {
-            val manager = AppWidgetManager.getInstance(context)
-            val hasAny = AppWidgetType.entries.any { type ->
-                manager.getAppWidgetIds(ComponentName(context, receiverClassFor(type))).isNotEmpty()
-            }
-            if (!hasAny) {
-                WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
-            }
-        }
-
-        private fun receiverClassFor(type: AppWidgetType): Class<out GlanceAppWidgetReceiver> = when (type) {
-            AppWidgetType.PRICE -> PriceGlanceReceiver::class.java
-            AppWidgetType.HEADLINES -> HeadlinesGlanceReceiver::class.java
-            AppWidgetType.BLOCKS -> BlocksGlanceReceiver::class.java
-            AppWidgetType.FACTS -> FactsGlanceReceiver::class.java
-            AppWidgetType.WEATHER -> WeatherGlanceReceiver::class.java
-        }
     }
 
     override suspend fun doWork(): Result {
-        val activeTypes = preferencesStore.getActiveWidgetTypes()
-        if (activeTypes.isEmpty()) return Result.success()
+        val reason = inputData.getString(AppWidgetRefreshScheduler.WORK_INPUT_REASON) ?: "unknown"
+        val batterySettings = appContext.logBatterySettings()
+        val activeTypes = activeWidgetTypesFor(reason)
+        if (activeTypes.isEmpty()) {
+            Logger.debug(
+                "Skipped widget refresh for '$reason' because no active types matched ($batterySettings)",
+                context = TAG,
+            )
+            return Result.success()
+        }
 
-        Logger.debug("Refreshing data for widget types: '$activeTypes'", context = TAG)
+        val nowMs = clock.nowMs()
+        Logger.debug("Refreshing widget types '$activeTypes' for '$reason' ($batterySettings)", context = TAG)
 
+        var shouldRetry = false
         for (type in activeTypes) {
-            when (type) {
-                AppWidgetType.PRICE -> {
-                    val periods = preferencesStore.getActivePricePeriods()
-                    periods.forEach { period ->
-                        dataRepository.fetchPriceData(period)
-                            .onSuccess { preferencesStore.cachePriceData(period, it) }
-                            .onFailure {
-                                Logger.warn("Failed to refresh price for '$period'", it, context = TAG)
-                            }
-                    }
-                    PriceGlanceWidget().updateAll(appContext)
+            val result = runCatching { refresh(type, reason, nowMs, batterySettings) }
+                .getOrElse {
+                    if (it is CancellationException) throw it
+                    Logger.warn(
+                        "Failed to refresh widget type '$type' ($batterySettings)",
+                        it,
+                        context = TAG,
+                    )
+                    it.toRefreshResult()
                 }
-
-                AppWidgetType.HEADLINES -> {
-                    dataRepository.fetchArticles()
-                        .onSuccess { preferencesStore.cacheArticlesAndRotate(it) }
-                        .onFailure {
-                            Logger.warn("Failed to refresh headlines", it, context = TAG)
-                        }
-                    HeadlinesGlanceWidget().updateAll(appContext)
-                }
-
-                AppWidgetType.BLOCKS -> {
-                    dataRepository.fetchBlock()
-                        .onSuccess { preferencesStore.cacheBlock(it) }
-                        .onFailure {
-                            Logger.warn("Failed to refresh block", it, context = TAG)
-                        }
-                    BlocksGlanceWidget().updateAll(appContext)
-                }
-
-                AppWidgetType.FACTS -> {
-                    dataRepository.fetchFacts()
-                        .onSuccess { preferencesStore.cacheFacts(it) }
-                        .onFailure {
-                            Logger.warn("Failed to refresh facts", it, context = TAG)
-                        }
-                    preferencesStore.bumpFactsRotationTick()
-                    FactsGlanceWidget().updateAll(appContext)
-                }
-
-                AppWidgetType.WEATHER -> {
-                    dataRepository.fetchWeather()
-                        .onSuccess { preferencesStore.cacheWeather(it) }
-                        .onFailure {
-                            Logger.warn("Failed to refresh weather", it, context = TAG)
-                        }
-                    WeatherGlanceWidget().updateAll(appContext)
-                }
+            if (result == RefreshResult.ConnectivityFailure) {
+                shouldRetry = true
+                Logger.debug(
+                    "Queued widget refresh retry after connectivity failure for '$type' ($batterySettings)",
+                    context = TAG,
+                )
             }
         }
 
-        return Result.success()
+        return if (shouldRetry) Result.retry() else Result.success()
     }
+
+    private suspend fun activeWidgetTypesFor(reason: String): List<AppWidgetType> {
+        val activeTypes = preferencesStore.getActiveWidgetTypes()
+        return AppWidgetType.entries.filter {
+            it in activeTypes && shouldRefreshForReason(type = it, reason = reason)
+        }
+    }
+
+    private fun shouldRefreshForReason(type: AppWidgetType, reason: String): Boolean {
+        val isFactsLocalRefresh = reason == AppWidgetRefreshReason.FACTS_LOCAL_REFRESH.name
+        return if (isFactsLocalRefresh) type == AppWidgetType.FACTS else type != AppWidgetType.FACTS
+    }
+
+    private suspend fun refresh(
+        type: AppWidgetType,
+        reason: String,
+        nowMs: Long,
+        batterySettings: String,
+    ): RefreshResult {
+        if (type == AppWidgetType.FACTS) {
+            refreshFacts(batterySettings)
+            return RefreshResult.Success
+        }
+
+        val metadata = preferencesStore.getRefreshMetadata(type)
+        if (!shouldRefreshRemote(type = type, reason = reason, metadata = metadata, nowMs = nowMs)) {
+            Logger.debug("Skipped widget type '$type' because refresh is not due ($batterySettings)", context = TAG)
+            appWidgetUpdater.update(type, appContext)
+            return RefreshResult.Success
+        }
+
+        preferencesStore.markRefreshAttempt(type, nowMs)
+        val refreshResult = refreshRemote(type, batterySettings)
+        if (refreshResult == RefreshResult.Success) {
+            preferencesStore.markRefreshSuccess(type, nowMs)
+        }
+        appWidgetUpdater.update(type, appContext)
+        return refreshResult
+    }
+
+    private suspend fun shouldRefreshRemote(
+        type: AppWidgetType,
+        reason: String,
+        metadata: AppWidgetRefreshMetadata,
+        nowMs: Long,
+    ): Boolean {
+        val hasUncachedPricePeriods = type == AppWidgetType.PRICE &&
+            preferencesStore.getUncachedActivePricePeriods().isNotEmpty()
+
+        return AppWidgetRefreshPolicy.shouldRefreshRemote(
+            type = type,
+            metadata = metadata,
+            nowMs = nowMs,
+            hasUncachedData = hasUncachedPricePeriods,
+            bypassFailedAttemptBackoff = shouldBypassFailedAttemptBackoff(reason),
+        )
+    }
+
+    private fun shouldBypassFailedAttemptBackoff(reason: String): Boolean =
+        runAttemptCount > 0 ||
+            reason == AppWidgetRefreshReason.APP_START.name ||
+            reason == AppWidgetRefreshReason.APP_FOREGROUND.name
+
+    private suspend fun refreshRemote(
+        type: AppWidgetType,
+        batterySettings: String,
+    ): RefreshResult = when (type) {
+        AppWidgetType.PRICE -> refreshPrice(batterySettings)
+        AppWidgetType.HEADLINES -> refreshHeadlines(batterySettings)
+        AppWidgetType.BLOCKS -> refreshBlocks(batterySettings)
+        AppWidgetType.WEATHER -> refreshWeather(batterySettings)
+        AppWidgetType.FACTS -> RefreshResult.Failure
+    }
+
+    private suspend fun refreshPrice(batterySettings: String): RefreshResult {
+        val periods = preferencesStore.getActivePricePeriods()
+        if (periods.isEmpty()) return RefreshResult.Failure
+
+        var refreshResult: RefreshResult = RefreshResult.Success
+
+        for (period in periods) {
+            dataRepository.fetchPriceData(period)
+                .onSuccess { preferencesStore.cachePriceData(period, it) }
+                .onFailure {
+                    val periodResult = it.toRefreshResult()
+                    refreshResult = refreshResult.merge(periodResult)
+                    Logger.warn(
+                        "Failed to refresh price for '$period' ($batterySettings)",
+                        it,
+                        context = TAG,
+                    )
+                    if (periodResult == RefreshResult.ConnectivityFailure) return refreshResult
+                }
+        }
+
+        return refreshResult
+    }
+
+    private suspend fun refreshHeadlines(batterySettings: String): RefreshResult =
+        dataRepository.fetchArticles()
+            .fold(
+                onSuccess = {
+                    preferencesStore.cacheArticlesAndRotate(it)
+                    RefreshResult.Success
+                },
+                onFailure = {
+                    val result = it.toRefreshResult()
+                    Logger.warn("Failed to refresh headlines ($batterySettings)", it, context = TAG)
+                    result
+                },
+            )
+
+    private suspend fun refreshBlocks(batterySettings: String): RefreshResult =
+        dataRepository.fetchBlock()
+            .fold(
+                onSuccess = {
+                    preferencesStore.cacheBlock(it)
+                    RefreshResult.Success
+                },
+                onFailure = {
+                    val result = it.toRefreshResult()
+                    Logger.warn("Failed to refresh block ($batterySettings)", it, context = TAG)
+                    result
+                },
+            )
+
+    private suspend fun refreshFacts(batterySettings: String) {
+        dataRepository.fetchFacts()
+            .onSuccess { preferencesStore.cacheFacts(it) }
+            .onFailure {
+                it.throwIfCancellation()
+                Logger.warn("Failed to refresh facts ($batterySettings)", it, context = TAG)
+            }
+        preferencesStore.bumpFactsRotationTick()
+        appWidgetUpdater.update(AppWidgetType.FACTS, appContext)
+    }
+
+    private suspend fun refreshWeather(batterySettings: String): RefreshResult =
+        dataRepository.fetchWeather()
+            .fold(
+                onSuccess = {
+                    preferencesStore.cacheWeather(it)
+                    RefreshResult.Success
+                },
+                onFailure = {
+                    val result = it.toRefreshResult()
+                    Logger.warn("Failed to refresh weather ($batterySettings)", it, context = TAG)
+                    result
+                },
+            )
+}
+
+private sealed interface RefreshResult {
+    object Success : RefreshResult
+    object ConnectivityFailure : RefreshResult
+    object Failure : RefreshResult
+}
+
+private fun Throwable.toRefreshResult(): RefreshResult {
+    throwIfCancellation()
+    return if (isConnectivityFailure()) RefreshResult.ConnectivityFailure else RefreshResult.Failure
+}
+
+private fun Throwable.throwIfCancellation() {
+    if (this is CancellationException) throw this
+}
+
+private fun RefreshResult.merge(other: RefreshResult): RefreshResult = when (this) {
+    RefreshResult.ConnectivityFailure -> this
+    RefreshResult.Failure -> if (other == RefreshResult.ConnectivityFailure) other else this
+    RefreshResult.Success -> other
 }

--- a/app/src/main/java/to/bitkit/appwidget/AppWidgetUpdater.kt
+++ b/app/src/main/java/to/bitkit/appwidget/AppWidgetUpdater.kt
@@ -1,0 +1,25 @@
+package to.bitkit.appwidget
+
+import android.content.Context
+import androidx.glance.appwidget.updateAll
+import to.bitkit.appwidget.model.AppWidgetType
+import to.bitkit.appwidget.ui.blocks.BlocksGlanceWidget
+import to.bitkit.appwidget.ui.facts.FactsGlanceWidget
+import to.bitkit.appwidget.ui.headlines.HeadlinesGlanceWidget
+import to.bitkit.appwidget.ui.price.PriceGlanceWidget
+import to.bitkit.appwidget.ui.weather.WeatherGlanceWidget
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppWidgetUpdater @Inject constructor() {
+    suspend fun update(type: AppWidgetType, context: Context) {
+        when (type) {
+            AppWidgetType.PRICE -> PriceGlanceWidget().updateAll(context)
+            AppWidgetType.HEADLINES -> HeadlinesGlanceWidget().updateAll(context)
+            AppWidgetType.BLOCKS -> BlocksGlanceWidget().updateAll(context)
+            AppWidgetType.FACTS -> FactsGlanceWidget().updateAll(context)
+            AppWidgetType.WEATHER -> WeatherGlanceWidget().updateAll(context)
+        }
+    }
+}

--- a/app/src/main/java/to/bitkit/appwidget/RefreshingGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/RefreshingGlanceReceiver.kt
@@ -1,0 +1,32 @@
+package to.bitkit.appwidget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+abstract class RefreshingGlanceReceiver(
+    private val enabledReason: AppWidgetRefreshReason,
+    private val updateReason: AppWidgetRefreshReason,
+    private val disabledReason: AppWidgetRefreshReason,
+) : GlanceAppWidgetReceiver() {
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        context.appWidgetRefreshScheduler.ensureScheduled(enabledReason)
+        context.appWidgetRefreshScheduler.requestCatchUp(enabledReason)
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        context.appWidgetRefreshScheduler.ensureScheduled(updateReason)
+        context.appWidgetRefreshScheduler.requestCatchUp(updateReason)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        context.appWidgetRefreshScheduler.ensureScheduled(disabledReason)
+    }
+}

--- a/app/src/main/java/to/bitkit/appwidget/config/AppWidgetConfigActivity.kt
+++ b/app/src/main/java/to/bitkit/appwidget/config/AppWidgetConfigActivity.kt
@@ -8,7 +8,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.glance.appwidget.updateAll
 import dagger.hilt.android.AndroidEntryPoint
-import to.bitkit.appwidget.AppWidgetRefreshWorker
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.AppWidgetRefreshScheduler
 import to.bitkit.appwidget.model.AppWidgetType
 import to.bitkit.appwidget.ui.blocks.BlocksGlanceReceiver
 import to.bitkit.appwidget.ui.blocks.BlocksGlanceWidget
@@ -21,6 +22,7 @@ import to.bitkit.appwidget.ui.weather.WeatherGlanceWidget
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.utils.enableAppEdgeToEdge
 import to.bitkit.utils.Logger
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AppWidgetConfigActivity : ComponentActivity() {
@@ -31,6 +33,9 @@ class AppWidgetConfigActivity : ComponentActivity() {
     }
 
     private val viewModel: AppWidgetConfigViewModel by viewModels()
+
+    @Inject
+    lateinit var appWidgetRefreshScheduler: AppWidgetRefreshScheduler
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -66,7 +71,8 @@ class AppWidgetConfigActivity : ComponentActivity() {
                             AppWidgetType.FACTS -> Unit
                             AppWidgetType.WEATHER -> WeatherGlanceWidget().updateAll(this@AppWidgetConfigActivity)
                         }
-                        AppWidgetRefreshWorker.enqueue(this@AppWidgetConfigActivity)
+                        appWidgetRefreshScheduler.ensureScheduled(AppWidgetRefreshReason.WIDGET_CONFIG_CONFIRM)
+                        appWidgetRefreshScheduler.requestCatchUp(AppWidgetRefreshReason.WIDGET_CONFIG_CONFIRM)
                         val result = Intent().putExtra(
                             AppWidgetManager.EXTRA_APPWIDGET_ID,
                             appWidgetId,

--- a/app/src/main/java/to/bitkit/appwidget/model/AppWidgetPreferences.kt
+++ b/app/src/main/java/to/bitkit/appwidget/model/AppWidgetPreferences.kt
@@ -65,10 +65,18 @@ data class HomeWeatherPreferences(
 data class AppWidgetData(
     val entries: List<AppWidgetEntry> = emptyList(),
     val cachedPrices: Map<GraphPeriod, PriceDTO> = emptyMap(),
+    val refreshMetadata: Map<AppWidgetType, AppWidgetRefreshMetadata> = emptyMap(),
     val cachedArticles: List<ArticleDTO> = emptyList(),
     val articleRotationTick: Int = 0,
     val cachedBlock: BlockDTO? = null,
     val cachedFacts: List<String> = emptyList(),
     val factsRotationTick: Int = 0,
     val cachedWeather: WeatherDTO? = null,
+)
+
+@Stable
+@Serializable
+data class AppWidgetRefreshMetadata(
+    val lastAttemptAtMs: Long = 0L,
+    val lastSuccessAtMs: Long = 0L,
 )

--- a/app/src/main/java/to/bitkit/appwidget/ui/blocks/BlocksGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/blocks/BlocksGlanceReceiver.kt
@@ -1,20 +1,13 @@
 package to.bitkit.appwidget.ui.blocks
 
-import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import to.bitkit.appwidget.AppWidgetRefreshWorker
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.RefreshingGlanceReceiver
 
-class BlocksGlanceReceiver : GlanceAppWidgetReceiver() {
+class BlocksGlanceReceiver : RefreshingGlanceReceiver(
+    enabledReason = AppWidgetRefreshReason.BLOCKS_WIDGET_ENABLED,
+    updateReason = AppWidgetRefreshReason.BLOCKS_WIDGET_UPDATE,
+    disabledReason = AppWidgetRefreshReason.BLOCKS_WIDGET_DISABLED,
+) {
     override val glanceAppWidget: GlanceAppWidget = BlocksGlanceWidget()
-
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
-        AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        AppWidgetRefreshWorker.cancelIfNoWidgets(context)
-    }
 }

--- a/app/src/main/java/to/bitkit/appwidget/ui/facts/FactsGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/facts/FactsGlanceReceiver.kt
@@ -1,20 +1,13 @@
 package to.bitkit.appwidget.ui.facts
 
-import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import to.bitkit.appwidget.AppWidgetRefreshWorker
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.RefreshingGlanceReceiver
 
-class FactsGlanceReceiver : GlanceAppWidgetReceiver() {
+class FactsGlanceReceiver : RefreshingGlanceReceiver(
+    enabledReason = AppWidgetRefreshReason.FACTS_WIDGET_ENABLED,
+    updateReason = AppWidgetRefreshReason.FACTS_WIDGET_UPDATE,
+    disabledReason = AppWidgetRefreshReason.FACTS_WIDGET_DISABLED,
+) {
     override val glanceAppWidget: GlanceAppWidget = FactsGlanceWidget()
-
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
-        AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        AppWidgetRefreshWorker.cancelIfNoWidgets(context)
-    }
 }

--- a/app/src/main/java/to/bitkit/appwidget/ui/facts/FactsGlanceWidget.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/facts/FactsGlanceWidget.kt
@@ -11,7 +11,7 @@ import androidx.glance.appwidget.provideContent
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.flow.first
 import to.bitkit.appwidget.AppWidgetEntryPoint
-import to.bitkit.appwidget.AppWidgetRefreshWorker
+import to.bitkit.appwidget.AppWidgetRefreshReason
 import to.bitkit.appwidget.model.AppWidgetData
 import to.bitkit.appwidget.model.AppWidgetType
 
@@ -24,6 +24,7 @@ class FactsGlanceWidget : GlanceAppWidget() {
             .fromApplication(context, AppWidgetEntryPoint::class.java)
         val store = accessor.appWidgetPreferencesStore()
         val repo = accessor.appWidgetDataRepository()
+        val appWidgetRefreshScheduler = accessor.appWidgetRefreshScheduler()
         val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(id)
 
         val current = store.data.first()
@@ -33,7 +34,8 @@ class FactsGlanceWidget : GlanceAppWidget() {
             if (current.cachedFacts.isEmpty()) {
                 repo.fetchFacts().onSuccess { store.cacheFacts(it) }
             }
-            AppWidgetRefreshWorker.enqueue(context)
+            appWidgetRefreshScheduler.ensureScheduled(AppWidgetRefreshReason.FACTS_WIDGET_REGISTERED)
+            appWidgetRefreshScheduler.requestCatchUp(AppWidgetRefreshReason.FACTS_WIDGET_REGISTERED)
         }
 
         provideContent {

--- a/app/src/main/java/to/bitkit/appwidget/ui/headlines/HeadlinesGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/headlines/HeadlinesGlanceReceiver.kt
@@ -1,20 +1,13 @@
 package to.bitkit.appwidget.ui.headlines
 
-import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import to.bitkit.appwidget.AppWidgetRefreshWorker
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.RefreshingGlanceReceiver
 
-class HeadlinesGlanceReceiver : GlanceAppWidgetReceiver() {
+class HeadlinesGlanceReceiver : RefreshingGlanceReceiver(
+    enabledReason = AppWidgetRefreshReason.HEADLINES_WIDGET_ENABLED,
+    updateReason = AppWidgetRefreshReason.HEADLINES_WIDGET_UPDATE,
+    disabledReason = AppWidgetRefreshReason.HEADLINES_WIDGET_DISABLED,
+) {
     override val glanceAppWidget: GlanceAppWidget = HeadlinesGlanceWidget()
-
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
-        AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        AppWidgetRefreshWorker.cancelIfNoWidgets(context)
-    }
 }

--- a/app/src/main/java/to/bitkit/appwidget/ui/price/PriceGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/price/PriceGlanceReceiver.kt
@@ -1,20 +1,13 @@
 package to.bitkit.appwidget.ui.price
 
-import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import to.bitkit.appwidget.AppWidgetRefreshWorker
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.RefreshingGlanceReceiver
 
-class PriceGlanceReceiver : GlanceAppWidgetReceiver() {
+class PriceGlanceReceiver : RefreshingGlanceReceiver(
+    enabledReason = AppWidgetRefreshReason.PRICE_WIDGET_ENABLED,
+    updateReason = AppWidgetRefreshReason.PRICE_WIDGET_UPDATE,
+    disabledReason = AppWidgetRefreshReason.PRICE_WIDGET_DISABLED,
+) {
     override val glanceAppWidget: GlanceAppWidget = PriceGlanceWidget()
-
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
-        AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        AppWidgetRefreshWorker.cancelIfNoWidgets(context)
-    }
 }

--- a/app/src/main/java/to/bitkit/appwidget/ui/weather/WeatherGlanceReceiver.kt
+++ b/app/src/main/java/to/bitkit/appwidget/ui/weather/WeatherGlanceReceiver.kt
@@ -1,20 +1,13 @@
 package to.bitkit.appwidget.ui.weather
 
-import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import to.bitkit.appwidget.AppWidgetRefreshWorker
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.RefreshingGlanceReceiver
 
-class WeatherGlanceReceiver : GlanceAppWidgetReceiver() {
+class WeatherGlanceReceiver : RefreshingGlanceReceiver(
+    enabledReason = AppWidgetRefreshReason.WEATHER_WIDGET_ENABLED,
+    updateReason = AppWidgetRefreshReason.WEATHER_WIDGET_UPDATE,
+    disabledReason = AppWidgetRefreshReason.WEATHER_WIDGET_DISABLED,
+) {
     override val glanceAppWidget: GlanceAppWidget = WeatherGlanceWidget()
-
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
-        AppWidgetRefreshWorker.enqueue(context)
-    }
-
-    override fun onDisabled(context: Context) {
-        super.onDisabled(context)
-        AppWidgetRefreshWorker.cancelIfNoWidgets(context)
-    }
 }

--- a/app/src/main/java/to/bitkit/data/widgets/PriceService.kt
+++ b/app/src/main/java/to/bitkit/data/widgets/PriceService.kt
@@ -21,6 +21,7 @@ import to.bitkit.env.Env
 import to.bitkit.models.WidgetType
 import to.bitkit.utils.AppError
 import to.bitkit.utils.Logger
+import to.bitkit.utils.isConnectivityFailure
 import java.text.NumberFormat
 import java.util.Locale
 import javax.inject.Inject
@@ -50,15 +51,25 @@ class PriceService @Inject constructor(
         pairs: List<TradingPair>,
         period: GraphPeriod,
     ): Result<PriceDTO> = runCatching {
+        val failures = mutableListOf<Throwable>()
         val widgets = pairs.mapNotNull { pair ->
             runCatching { fetchPairData(pair = pair, period = period) }
-                .onFailure { Logger.warn(e = it, msg = "Failed to fetch ${pair.ticker}", context = TAG) }
+                .onFailure {
+                    failures.add(it)
+                    Logger.warn("Failed to fetch '${pair.ticker}'", it, context = TAG)
+                }
                 .getOrNull()
         }
-        if (widgets.isEmpty()) throw PriceError.InvalidResponse("No price data available")
+        if (widgets.isEmpty()) {
+            val connectivityFailure = failures.firstOrNull { it.isConnectivityFailure() }
+            if (connectivityFailure != null) {
+                throw PriceError.NetworkError("Failed to fetch price data", connectivityFailure)
+            }
+            throw PriceError.InvalidResponse("No price data available")
+        }
         PriceDTO(widgets = widgets)
     }.onFailure {
-        Logger.warn(e = it, msg = "Failed to fetch price data", context = TAG)
+        Logger.warn("Failed to fetch price data", it, context = TAG)
     }
 
     suspend fun fetchAllPeriods(): Result<List<PriceDTO>> = runCatching {
@@ -174,9 +185,12 @@ class PriceService @Inject constructor(
 /**
  * Price-specific error types
  */
-sealed class PriceError(message: String) : AppError(message) {
+sealed class PriceError(message: String, cause: Throwable? = null) : AppError(message, cause) {
     class InvalidResponse(override val message: String) : PriceError(message)
-    class NetworkError(override val message: String) : PriceError(message)
+    class NetworkError(
+        override val message: String,
+        cause: Throwable? = null,
+    ) : PriceError(message, cause)
 }
 
 private const val GROUPED_PRICE_THRESHOLD = 1_000.0

--- a/app/src/main/java/to/bitkit/di/AppWidgetRefreshSchedulerModule.kt
+++ b/app/src/main/java/to/bitkit/di/AppWidgetRefreshSchedulerModule.kt
@@ -1,0 +1,30 @@
+package to.bitkit.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import to.bitkit.appwidget.AndroidAppWidgetActiveWidgets
+import to.bitkit.appwidget.AndroidAppWidgetAlarmClient
+import to.bitkit.appwidget.AndroidAppWidgetWorkClient
+import to.bitkit.appwidget.AndroidElapsedRealtimeProvider
+import to.bitkit.appwidget.AppWidgetActiveWidgets
+import to.bitkit.appwidget.AppWidgetAlarmClient
+import to.bitkit.appwidget.AppWidgetWorkClient
+import to.bitkit.appwidget.ElapsedRealtimeProvider
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface AppWidgetRefreshSchedulerModule {
+    @Binds
+    fun bindActiveWidgets(impl: AndroidAppWidgetActiveWidgets): AppWidgetActiveWidgets
+
+    @Binds
+    fun bindWorkClient(impl: AndroidAppWidgetWorkClient): AppWidgetWorkClient
+
+    @Binds
+    fun bindAlarmClient(impl: AndroidAppWidgetAlarmClient): AppWidgetAlarmClient
+
+    @Binds
+    fun bindElapsedRealtimeProvider(impl: AndroidElapsedRealtimeProvider): ElapsedRealtimeProvider
+}

--- a/app/src/main/java/to/bitkit/ext/Context.kt
+++ b/app/src/main/java/to/bitkit/ext/Context.kt
@@ -2,7 +2,9 @@ package to.bitkit.ext
 
 import android.app.Activity
 import android.app.ActivityManager
+import android.app.AlarmManager
 import android.app.NotificationManager
+import android.app.usage.UsageStatsManager
 import android.bluetooth.BluetoothManager
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -12,6 +14,7 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.hardware.usb.UsbManager
+import android.os.PowerManager
 import android.provider.Settings
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -33,11 +36,20 @@ val Context.clipboardManager: ClipboardManager
 val Context.activityManager: ActivityManager
     get() = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
 
+val Context.alarmManager: AlarmManager
+    get() = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
 val Context.usbManager: UsbManager
     get() = getSystemService(Context.USB_SERVICE) as UsbManager
 
 val Context.bluetoothManager: BluetoothManager
     get() = getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+
+val Context.powerManager: PowerManager
+    get() = getSystemService(Context.POWER_SERVICE) as PowerManager
+
+val Context.usageStatsManager: UsageStatsManager
+    get() = getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
 
 // Permissions
 

--- a/app/src/main/java/to/bitkit/repositories/LogsRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LogsRepo.kt
@@ -19,8 +19,10 @@ import to.bitkit.ext.toBase64
 import to.bitkit.ext.utcDateFormatterOf
 import to.bitkit.models.ChatwootMessage
 import to.bitkit.models.NodeLifecycleState
+import to.bitkit.utils.BatterySettingsSnapshot
 import to.bitkit.utils.LogSource
 import to.bitkit.utils.Logger
+import to.bitkit.utils.batterySettingsSnapshot
 import java.io.BufferedReader
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -160,6 +162,7 @@ class LogsRepo @Inject constructor(
             lifecycle = state.nodeLifecycleState.supportName(),
             isSyncingWallet = state.isSyncingWallet,
             isGeoBlocked = state.isGeoBlocked,
+            batterySettings = context.batterySettingsSnapshot(),
             lastSuccessfulSyncAt = state.lastSuccessfulSyncAt?.toString(),
             lastSyncError = state.lastSyncError?.javaClass?.simpleName,
             blockHeight = state.nodeStatus?.currentBestBlock?.height?.toString(),
@@ -324,6 +327,7 @@ private data class SupportSnapshot(
     val lifecycle: String,
     val isSyncingWallet: Boolean,
     val isGeoBlocked: Boolean,
+    val batterySettings: BatterySettingsSnapshot,
     val lastSuccessfulSyncAt: String?,
     val lastSyncError: String?,
     val blockHeight: String?,

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -45,6 +45,8 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.appWidgetRefreshScheduler
 import to.bitkit.env.Env
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.Toast
@@ -224,6 +226,7 @@ fun ContentView(
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val context = LocalContext.current
+    val appWidgetRefreshScheduler = remember(context) { context.appWidgetRefreshScheduler }
     val lifecycle = LocalLifecycleOwner.current.lifecycle
 
     val walletUiState by walletViewModel.walletState.collectAsStateWithLifecycle()
@@ -245,6 +248,8 @@ fun ContentView(
 
                     appViewModel.consumePaymentReceivedInBackground()
 
+                    appWidgetRefreshScheduler.ensureScheduled(AppWidgetRefreshReason.APP_FOREGROUND)
+                    appWidgetRefreshScheduler.requestCatchUp(AppWidgetRefreshReason.APP_FOREGROUND)
                     currencyViewModel.triggerRefresh()
                     blocktankViewModel.refreshOrders()
                     appViewModel.refreshPublicPaykitEndpoints()

--- a/app/src/main/java/to/bitkit/utils/BatterySettingsSnapshot.kt
+++ b/app/src/main/java/to/bitkit/utils/BatterySettingsSnapshot.kt
@@ -1,0 +1,82 @@
+package to.bitkit.utils
+
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import kotlinx.serialization.Serializable
+import to.bitkit.ext.powerManager
+import to.bitkit.ext.usageStatsManager
+
+@Serializable
+data class BatterySettingsSnapshot(
+    val isPowerSaveMode: Boolean?,
+    val isIgnoringBatteryOptimizations: Boolean?,
+    val isDeviceIdleMode: Boolean?,
+    val isDeviceLightIdleMode: Boolean?,
+    val isLowPowerStandbyEnabled: Boolean?,
+    val isExemptFromLowPowerStandby: Boolean?,
+    val appStandbyBucket: String?,
+) {
+    val logSummary: String
+        get() = listOf(
+            "powerSaveMode='${isPowerSaveMode.logValue()}'",
+            "ignoringBatteryOptimizations='${isIgnoringBatteryOptimizations.logValue()}'",
+            "deviceIdleMode='${isDeviceIdleMode.logValue()}'",
+            "deviceLightIdleMode='${isDeviceLightIdleMode.logValue()}'",
+            "lowPowerStandbyEnabled='${isLowPowerStandbyEnabled.logValue()}'",
+            "exemptFromLowPowerStandby='${isExemptFromLowPowerStandby.logValue()}'",
+            "appStandbyBucket='${appStandbyBucket.logValue()}'",
+        ).joinToString()
+}
+
+fun Context.batterySettingsSnapshot(): BatterySettingsSnapshot {
+    val powerManager = powerManager
+    return BatterySettingsSnapshot(
+        isPowerSaveMode = runCatching { powerManager.isPowerSaveMode }.getOrNull(),
+        isIgnoringBatteryOptimizations = if (VERSION.SDK_INT >= VERSION_CODES.M) {
+            runCatching { powerManager.isIgnoringBatteryOptimizations(packageName) }.getOrNull()
+        } else {
+            null
+        },
+        isDeviceIdleMode = if (VERSION.SDK_INT >= VERSION_CODES.M) {
+            runCatching { powerManager.isDeviceIdleMode }.getOrNull()
+        } else {
+            null
+        },
+        isDeviceLightIdleMode = if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            runCatching { powerManager.isDeviceLightIdleMode }.getOrNull()
+        } else {
+            null
+        },
+        isLowPowerStandbyEnabled = if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            runCatching { powerManager.isLowPowerStandbyEnabled }.getOrNull()
+        } else {
+            null
+        },
+        isExemptFromLowPowerStandby = if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            runCatching { powerManager.isExemptFromLowPowerStandby }.getOrNull()
+        } else {
+            null
+        },
+        appStandbyBucket = if (VERSION.SDK_INT >= VERSION_CODES.P) {
+            runCatching { usageStatsManager.appStandbyBucket.toAppStandbyBucketName() }.getOrNull()
+        } else {
+            null
+        },
+    )
+}
+
+fun Context.logBatterySettings(): String = batterySettingsSnapshot().logSummary
+
+private fun Int.toAppStandbyBucketName(): String =
+    when (this) {
+        UsageStatsManager.STANDBY_BUCKET_ACTIVE -> "ACTIVE"
+        UsageStatsManager.STANDBY_BUCKET_WORKING_SET -> "WORKING_SET"
+        UsageStatsManager.STANDBY_BUCKET_FREQUENT -> "FREQUENT"
+        UsageStatsManager.STANDBY_BUCKET_RARE -> "RARE"
+        UsageStatsManager.STANDBY_BUCKET_RESTRICTED -> "RESTRICTED"
+        else -> "UNKNOWN_$this"
+    }
+
+private fun Any?.logValue(): String = this?.toString() ?: "unknown"

--- a/app/src/main/java/to/bitkit/utils/ConnectivityErrors.kt
+++ b/app/src/main/java/to/bitkit/utils/ConnectivityErrors.kt
@@ -1,0 +1,25 @@
+package to.bitkit.utils
+
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.nio.channels.UnresolvedAddressException
+
+fun Throwable.isConnectivityFailure(): Boolean {
+    var failure: Throwable? = this
+    while (failure != null) {
+        when (failure) {
+            is HttpRequestTimeoutException,
+            is UnknownHostException,
+            is SocketTimeoutException,
+            is ConnectException,
+            is NoRouteToHostException,
+            is UnresolvedAddressException -> return true
+        }
+        failure = failure.cause.takeIf { it !== failure }
+    }
+
+    return false
+}

--- a/app/src/main/res/xml/appwidget_info_blocks.xml
+++ b/app/src/main/res/xml/appwidget_info_blocks.xml
@@ -15,5 +15,5 @@
     android:description="@string/widgets__blocks__description"
     android:configure="to.bitkit.appwidget.config.AppWidgetConfigActivity"
     android:widgetFeatures="reconfigurable"
-    android:updatePeriodMillis="0"
+    android:updatePeriodMillis="1800000"
     tools:targetApi="31" />

--- a/app/src/main/res/xml/appwidget_info_facts.xml
+++ b/app/src/main/res/xml/appwidget_info_facts.xml
@@ -12,5 +12,5 @@
     android:initialLayout="@layout/glance_default_loading_layout"
     android:previewLayout="@layout/appwidget_preview_facts"
     android:description="@string/widgets__facts__description"
-    android:updatePeriodMillis="0"
+    android:updatePeriodMillis="1800000"
     tools:targetApi="31" />

--- a/app/src/main/res/xml/appwidget_info_headlines.xml
+++ b/app/src/main/res/xml/appwidget_info_headlines.xml
@@ -14,5 +14,5 @@
     android:description="@string/widgets__news__description"
     android:configure="to.bitkit.appwidget.config.AppWidgetConfigActivity"
     android:widgetFeatures="reconfigurable"
-    android:updatePeriodMillis="0"
+    android:updatePeriodMillis="1800000"
     tools:targetApi="31" />

--- a/app/src/main/res/xml/appwidget_info_price.xml
+++ b/app/src/main/res/xml/appwidget_info_price.xml
@@ -14,5 +14,5 @@
     android:description="@string/appwidget__price__description"
     android:configure="to.bitkit.appwidget.config.AppWidgetConfigActivity"
     android:widgetFeatures="reconfigurable"
-    android:updatePeriodMillis="0"
+    android:updatePeriodMillis="1800000"
     tools:targetApi="31" />

--- a/app/src/main/res/xml/appwidget_info_weather.xml
+++ b/app/src/main/res/xml/appwidget_info_weather.xml
@@ -14,5 +14,5 @@
     android:description="@string/widgets__weather__description"
     android:configure="to.bitkit.appwidget.config.AppWidgetConfigActivity"
     android:widgetFeatures="reconfigurable"
-    android:updatePeriodMillis="0"
+    android:updatePeriodMillis="1800000"
     tools:targetApi="31" />

--- a/app/src/test/java/to/bitkit/androidServices/LightningNodeServiceTest.kt
+++ b/app/src/test/java/to/bitkit/androidServices/LightningNodeServiceTest.kt
@@ -29,6 +29,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
@@ -42,6 +43,8 @@ import org.robolectric.annotation.Config
 import to.bitkit.App
 import to.bitkit.CurrentActivity
 import to.bitkit.R
+import to.bitkit.appwidget.AppWidgetRefreshReason
+import to.bitkit.appwidget.AppWidgetRefreshScheduler
 import to.bitkit.data.AppCacheData
 import to.bitkit.data.CacheStore
 import to.bitkit.di.DbModule
@@ -100,6 +103,9 @@ class LightningNodeServiceTest : BaseUnitTest() {
 
     @BindValue
     val cacheStore = mock<CacheStore>()
+
+    @BindValue
+    val appWidgetRefreshScheduler = mock<AppWidgetRefreshScheduler>()
 
     private var capturedHandler: NodeEventHandler? = null
     private val cacheData = MutableSharedFlow<AppCacheData>(replay = 1)
@@ -483,6 +489,24 @@ class LightningNodeServiceTest : BaseUnitTest() {
             it.extras.getString(Notification.EXTRA_TITLE) == sentTitle
         }
         assertNull(notification, "Non-pending payment should NOT trigger notification")
+    }
+
+    @Test
+    fun `stop service action schedules widget catch-up before shutdown`() = test {
+        val service = createService()
+
+        service.onStartCommand(
+            serviceIntent(LightningNodeService.ACTION_STOP_SERVICE_AND_APP),
+            0,
+            STOP_START_ID,
+        )
+        testScheduler.advanceUntilIdle()
+
+        inOrder(appWidgetRefreshScheduler, lightningRepo) {
+            verify(appWidgetRefreshScheduler).ensureScheduled(AppWidgetRefreshReason.SERVICE_STOP_ACTION)
+            verify(appWidgetRefreshScheduler).requestCatchUp(AppWidgetRefreshReason.SERVICE_STOP_ACTION)
+            verify(lightningRepo).stop()
+        }
     }
 
     private fun createService(): LightningNodeService {

--- a/app/src/test/java/to/bitkit/appwidget/AppWidgetRefreshPolicyTest.kt
+++ b/app/src/test/java/to/bitkit/appwidget/AppWidgetRefreshPolicyTest.kt
@@ -1,0 +1,162 @@
+package to.bitkit.appwidget
+
+import org.junit.Test
+import to.bitkit.appwidget.model.AppWidgetRefreshMetadata
+import to.bitkit.appwidget.model.AppWidgetType
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+
+class AppWidgetRefreshPolicyTest {
+    @Test
+    fun `fresh remote widget type is skipped`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata(
+            lastAttemptAtMs = nowMs - 1.minutes.inWholeMilliseconds,
+            lastSuccessAtMs = nowMs - 1.minutes.inWholeMilliseconds,
+        )
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            AppWidgetType.HEADLINES,
+            metadata,
+            nowMs,
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `stale remote widget type is refreshed`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata(
+            lastAttemptAtMs = nowMs - 16.minutes.inWholeMilliseconds,
+            lastSuccessAtMs = nowMs - 16.minutes.inWholeMilliseconds,
+        )
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            AppWidgetType.BLOCKS,
+            metadata,
+            nowMs,
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `recent failed remote widget attempt is skipped`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata(
+            lastAttemptAtMs = nowMs - 1.minutes.inWholeMilliseconds,
+            lastSuccessAtMs = nowMs - 16.minutes.inWholeMilliseconds,
+        )
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            AppWidgetType.WEATHER,
+            metadata,
+            nowMs,
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `recent failed remote widget attempt is refreshed when backoff is bypassed`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata(
+            lastAttemptAtMs = nowMs - 1.minutes.inWholeMilliseconds,
+            lastSuccessAtMs = nowMs - 16.minutes.inWholeMilliseconds,
+        )
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            type = AppWidgetType.BLOCKS,
+            metadata = metadata,
+            nowMs = nowMs,
+            bypassFailedAttemptBackoff = true,
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `uncached remote data still honors recent failed attempt backoff`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata(
+            lastAttemptAtMs = nowMs - 1.minutes.inWholeMilliseconds,
+            lastSuccessAtMs = nowMs - 16.minutes.inWholeMilliseconds,
+        )
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            type = AppWidgetType.PRICE,
+            metadata = metadata,
+            nowMs = nowMs,
+            hasUncachedData = true,
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `weather widget uses longer refresh interval`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata(
+            lastAttemptAtMs = nowMs - 16.minutes.inWholeMilliseconds,
+            lastSuccessAtMs = nowMs - 16.minutes.inWholeMilliseconds,
+        )
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            AppWidgetType.WEATHER,
+            metadata,
+            nowMs,
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `headlines widget uses longer refresh interval`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata(
+            lastAttemptAtMs = nowMs - 31.minutes.inWholeMilliseconds,
+            lastSuccessAtMs = nowMs - 31.minutes.inWholeMilliseconds,
+        )
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            AppWidgetType.HEADLINES,
+            metadata,
+            nowMs,
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `headlines widget refreshes after longer interval`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata(
+            lastAttemptAtMs = nowMs - 61.minutes.inWholeMilliseconds,
+            lastSuccessAtMs = nowMs - 61.minutes.inWholeMilliseconds,
+        )
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            AppWidgetType.HEADLINES,
+            metadata,
+            nowMs,
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `facts widget type is never treated as remote backed`() {
+        val nowMs = 10_000_000L
+        val metadata = AppWidgetRefreshMetadata()
+
+        val result = AppWidgetRefreshPolicy.shouldRefreshRemote(
+            AppWidgetType.FACTS,
+            metadata,
+            nowMs,
+        )
+
+        assertFalse(result)
+    }
+}

--- a/app/src/test/java/to/bitkit/appwidget/AppWidgetRefreshReceiverTest.kt
+++ b/app/src/test/java/to/bitkit/appwidget/AppWidgetRefreshReceiverTest.kt
@@ -1,0 +1,60 @@
+package to.bitkit.appwidget
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.BindValue
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import to.bitkit.test.BaseUnitTest
+
+@HiltAndroidTest
+@Config(application = HiltTestApplication::class, sdk = [34])
+@RunWith(RobolectricTestRunner::class)
+class AppWidgetRefreshReceiverTest : BaseUnitTest() {
+    @get:Rule(order = 1)
+    val hiltRule = HiltAndroidRule(this)
+
+    @BindValue
+    val appWidgetRefreshScheduler = mock<AppWidgetRefreshScheduler>()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val receiver = AppWidgetRefreshReceiver()
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun `boot completed delegates to scheduler`() {
+        receiver.onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+
+        verify(appWidgetRefreshScheduler).ensureScheduled(AppWidgetRefreshReason.BOOT_COMPLETED)
+        verify(appWidgetRefreshScheduler).requestCatchUp(AppWidgetRefreshReason.BOOT_COMPLETED)
+    }
+
+    @Test
+    fun `package replaced delegates to scheduler`() {
+        receiver.onReceive(context, Intent(Intent.ACTION_MY_PACKAGE_REPLACED))
+
+        verify(appWidgetRefreshScheduler).ensureScheduled(AppWidgetRefreshReason.PACKAGE_REPLACED)
+        verify(appWidgetRefreshScheduler).requestCatchUp(AppWidgetRefreshReason.PACKAGE_REPLACED)
+    }
+
+    @Test
+    fun `catch-up alarm delegates to scheduler`() {
+        receiver.onReceive(context, Intent(AppWidgetRefreshScheduler.CATCH_UP_ALARM_ACTION))
+
+        verify(appWidgetRefreshScheduler).handleCatchUpAlarm(AppWidgetRefreshReason.CATCH_UP_ALARM)
+    }
+}

--- a/app/src/test/java/to/bitkit/appwidget/AppWidgetRefreshSchedulerTest.kt
+++ b/app/src/test/java/to/bitkit/appwidget/AppWidgetRefreshSchedulerTest.kt
@@ -1,0 +1,294 @@
+package to.bitkit.appwidget
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.BackoffPolicy
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import to.bitkit.appwidget.model.AppWidgetType
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+@Config(sdk = [34])
+@RunWith(RobolectricTestRunner::class)
+class AppWidgetRefreshSchedulerTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val activeWidgets = FakeActiveWidgets()
+    private val workClient = FakeWorkClient()
+    private val alarmClient = FakeAlarmClient()
+    private val elapsedRealtimeProvider = FakeElapsedRealtimeProvider()
+    private val scheduler = AppWidgetRefreshScheduler(
+        context = context,
+        activeWidgets = activeWidgets,
+        workClient = workClient,
+        alarmClient = alarmClient,
+        elapsedRealtimeProvider = elapsedRealtimeProvider,
+    )
+
+    @After
+    fun tearDown() {
+        PendingIntent.getBroadcast(
+            context,
+            0,
+            Intent(context, AppWidgetRefreshReceiver::class.java)
+                .setAction(AppWidgetRefreshScheduler.CATCH_UP_ALARM_ACTION),
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        )?.cancel()
+    }
+
+    @Test
+    fun `ensure scheduled enqueues periodic work and alarm`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE)
+
+        scheduler.ensureScheduled(AppWidgetRefreshReason.APP_START)
+
+        assertEquals(listOf(AppWidgetRefreshScheduler.PERIODIC_WORK_NAME), workClient.periodicNames)
+        assertEquals(listOf(ExistingPeriodicWorkPolicy.KEEP), workClient.periodicPolicies)
+        assertEquals(
+            AppWidgetRefreshReason.REMOTE_PERIODIC_REFRESH.name,
+            workClient.periodicRequests.single().workSpec.input.getString(AppWidgetRefreshScheduler.WORK_INPUT_REASON),
+        )
+        assertEquals(AlarmManager.ELAPSED_REALTIME, alarmClient.lastType)
+        assertEquals(
+            elapsedRealtimeProvider.nowMs + AppWidgetRefreshScheduler.REFRESH_INTERVAL.inWholeMilliseconds,
+            alarmClient.lastTriggerAtMs,
+        )
+    }
+
+    @Test
+    fun `ensure scheduled enqueues local facts work without network`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.FACTS)
+
+        scheduler.ensureScheduled(AppWidgetRefreshReason.APP_START)
+
+        assertEquals(listOf(AppWidgetRefreshScheduler.FACTS_PERIODIC_WORK_NAME), workClient.periodicNames)
+        assertEquals(
+            NetworkType.NOT_REQUIRED,
+            workClient.periodicRequests.single().workSpec.constraints.requiredNetworkType,
+        )
+        assertEquals(
+            AppWidgetRefreshReason.FACTS_LOCAL_REFRESH.name,
+            workClient.periodicRequests.single().workSpec.input.getString(AppWidgetRefreshScheduler.WORK_INPUT_REASON),
+        )
+    }
+
+    @Test
+    fun `ensure scheduled keeps periodic work when alarm scheduling fails`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE)
+        alarmClient.throwOnSet = true
+
+        scheduler.ensureScheduled(AppWidgetRefreshReason.APP_START)
+
+        assertEquals(listOf(AppWidgetRefreshScheduler.PERIODIC_WORK_NAME), workClient.periodicNames)
+        assertEquals(0, alarmClient.setCount)
+    }
+
+    @Test
+    fun `request catch up replaces remote retry work when app foregrounds`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE)
+
+        scheduler.requestCatchUp(AppWidgetRefreshReason.APP_FOREGROUND)
+
+        assertEquals(listOf(AppWidgetRefreshScheduler.CATCH_UP_WORK_NAME), workClient.oneTimeNames)
+        assertEquals(listOf(ExistingWorkPolicy.REPLACE), workClient.oneTimePolicies)
+        assertEquals(BackoffPolicy.EXPONENTIAL, workClient.oneTimeRequests.single().workSpec.backoffPolicy)
+        assertEquals(10.seconds.inWholeMilliseconds, workClient.oneTimeRequests.single().workSpec.backoffDelayDuration)
+    }
+
+    @Test
+    fun `request catch up replaces remote retry work when app starts`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE)
+
+        scheduler.requestCatchUp(AppWidgetRefreshReason.APP_START)
+
+        assertEquals(listOf(AppWidgetRefreshScheduler.CATCH_UP_WORK_NAME), workClient.oneTimeNames)
+        assertEquals(listOf(ExistingWorkPolicy.REPLACE), workClient.oneTimePolicies)
+    }
+
+    @Test
+    fun `request catch up keeps remote retry work for alarm refresh`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE)
+
+        scheduler.requestCatchUp(AppWidgetRefreshReason.CATCH_UP_ALARM)
+
+        assertEquals(listOf(AppWidgetRefreshScheduler.CATCH_UP_WORK_NAME), workClient.oneTimeNames)
+        assertEquals(listOf(ExistingWorkPolicy.KEEP), workClient.oneTimePolicies)
+    }
+
+    @Test
+    fun `request catch up enqueues local facts work without network`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.FACTS)
+
+        scheduler.requestCatchUp(AppWidgetRefreshReason.FACTS_WIDGET_UPDATE)
+
+        assertEquals(listOf(AppWidgetRefreshScheduler.FACTS_CATCH_UP_WORK_NAME), workClient.oneTimeNames)
+        assertEquals(
+            NetworkType.NOT_REQUIRED,
+            workClient.oneTimeRequests.single().workSpec.constraints.requiredNetworkType,
+        )
+        assertEquals(
+            AppWidgetRefreshReason.FACTS_LOCAL_REFRESH.name,
+            workClient.oneTimeRequests.single().workSpec.input.getString(AppWidgetRefreshScheduler.WORK_INPUT_REASON),
+        )
+    }
+
+    @Test
+    fun `ensure scheduled cancels all work and alarm when no widgets remain`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE, AppWidgetType.FACTS)
+        scheduler.ensureScheduled(AppWidgetRefreshReason.APP_START)
+
+        activeWidgets.activeTypes = emptySet()
+        scheduler.ensureScheduled(AppWidgetRefreshReason.PRICE_WIDGET_DISABLED)
+
+        assertEquals(
+            listOf(
+                AppWidgetRefreshScheduler.PERIODIC_WORK_NAME,
+                AppWidgetRefreshScheduler.CATCH_UP_WORK_NAME,
+                AppWidgetRefreshScheduler.FACTS_PERIODIC_WORK_NAME,
+                AppWidgetRefreshScheduler.FACTS_CATCH_UP_WORK_NAME,
+            ),
+            workClient.canceledNames,
+        )
+        assertEquals(1, alarmClient.cancelCount)
+    }
+
+    @Test
+    fun `ensure scheduled cancels facts work when facts widget is removed`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE, AppWidgetType.FACTS)
+        scheduler.ensureScheduled(AppWidgetRefreshReason.APP_START)
+        scheduler.requestCatchUp(AppWidgetRefreshReason.APP_START)
+        workClient.reset()
+
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE)
+        scheduler.ensureScheduled(AppWidgetRefreshReason.FACTS_WIDGET_DISABLED)
+
+        assertEquals(
+            listOf(
+                AppWidgetRefreshScheduler.FACTS_PERIODIC_WORK_NAME,
+                AppWidgetRefreshScheduler.FACTS_CATCH_UP_WORK_NAME,
+            ),
+            workClient.canceledNames,
+        )
+        assertEquals(listOf(AppWidgetRefreshScheduler.PERIODIC_WORK_NAME), workClient.periodicNames)
+    }
+
+    @Test
+    fun `ensure scheduled cancels remote work when last remote widget is removed`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE, AppWidgetType.FACTS)
+        scheduler.ensureScheduled(AppWidgetRefreshReason.APP_START)
+        scheduler.requestCatchUp(AppWidgetRefreshReason.APP_START)
+        workClient.reset()
+
+        activeWidgets.activeTypes = setOf(AppWidgetType.FACTS)
+        scheduler.ensureScheduled(AppWidgetRefreshReason.PRICE_WIDGET_DISABLED)
+
+        assertEquals(
+            listOf(
+                AppWidgetRefreshScheduler.PERIODIC_WORK_NAME,
+                AppWidgetRefreshScheduler.CATCH_UP_WORK_NAME,
+            ),
+            workClient.canceledNames,
+        )
+        assertEquals(listOf(AppWidgetRefreshScheduler.FACTS_PERIODIC_WORK_NAME), workClient.periodicNames)
+    }
+
+    @Test
+    fun `catch-up alarm requests work and schedules next alarm`() {
+        activeWidgets.activeTypes = setOf(AppWidgetType.PRICE)
+
+        scheduler.handleCatchUpAlarm(AppWidgetRefreshReason.CATCH_UP_ALARM)
+
+        assertEquals(listOf(AppWidgetRefreshScheduler.CATCH_UP_WORK_NAME), workClient.oneTimeNames)
+        assertEquals(listOf(ExistingWorkPolicy.KEEP), workClient.oneTimePolicies)
+        assertEquals(1, alarmClient.setCount)
+    }
+}
+
+private class FakeActiveWidgets : AppWidgetActiveWidgets {
+    var activeTypes = emptySet<AppWidgetType>()
+
+    override fun hasActiveWidgets(): Boolean = activeTypes.isNotEmpty()
+
+    override fun hasActiveWidgets(type: AppWidgetType): Boolean = type in activeTypes
+}
+
+private class FakeWorkClient : AppWidgetWorkClient {
+    val periodicNames = mutableListOf<String>()
+    val periodicPolicies = mutableListOf<ExistingPeriodicWorkPolicy>()
+    val periodicRequests = mutableListOf<PeriodicWorkRequest>()
+    val oneTimeNames = mutableListOf<String>()
+    val oneTimePolicies = mutableListOf<ExistingWorkPolicy>()
+    val oneTimeRequests = mutableListOf<OneTimeWorkRequest>()
+    val canceledNames = mutableListOf<String>()
+
+    override fun enqueueUniquePeriodicWork(
+        uniqueWorkName: String,
+        existingPeriodicWorkPolicy: ExistingPeriodicWorkPolicy,
+        request: PeriodicWorkRequest,
+    ) {
+        periodicNames += uniqueWorkName
+        periodicPolicies += existingPeriodicWorkPolicy
+        periodicRequests += request
+    }
+
+    override fun enqueueUniqueWork(
+        uniqueWorkName: String,
+        existingWorkPolicy: ExistingWorkPolicy,
+        request: OneTimeWorkRequest,
+    ) {
+        oneTimeNames += uniqueWorkName
+        oneTimePolicies += existingWorkPolicy
+        oneTimeRequests += request
+    }
+
+    override fun cancelUniqueWork(uniqueWorkName: String) {
+        canceledNames += uniqueWorkName
+    }
+
+    fun reset() {
+        periodicNames.clear()
+        periodicPolicies.clear()
+        periodicRequests.clear()
+        oneTimeNames.clear()
+        oneTimePolicies.clear()
+        oneTimeRequests.clear()
+        canceledNames.clear()
+    }
+}
+
+private class FakeAlarmClient : AppWidgetAlarmClient {
+    var setCount = 0
+    var cancelCount = 0
+    var lastType: Int? = null
+    var lastTriggerAtMs: Long? = null
+    var throwOnSet = false
+
+    override fun setAndAllowWhileIdle(type: Int, triggerAtMillis: Long, operation: PendingIntent) {
+        if (throwOnSet) error("Alarm failure")
+
+        setCount += 1
+        lastType = type
+        lastTriggerAtMs = triggerAtMillis
+    }
+
+    override fun cancel(operation: PendingIntent) {
+        cancelCount += 1
+    }
+}
+
+private class FakeElapsedRealtimeProvider : ElapsedRealtimeProvider {
+    val nowMs = 10_000L
+
+    override fun elapsedRealtime(): Long = nowMs
+}

--- a/app/src/test/java/to/bitkit/appwidget/AppWidgetRefreshWorkerTest.kt
+++ b/app/src/test/java/to/bitkit/appwidget/AppWidgetRefreshWorkerTest.kt
@@ -1,0 +1,363 @@
+package to.bitkit.appwidget
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import to.bitkit.appwidget.model.AppWidgetRefreshMetadata
+import to.bitkit.appwidget.model.AppWidgetType
+import to.bitkit.data.dto.ArticleDTO
+import to.bitkit.data.dto.BlockDTO
+import to.bitkit.data.dto.FeeCondition
+import to.bitkit.data.dto.PublisherDTO
+import to.bitkit.data.dto.WeatherDTO
+import to.bitkit.data.dto.price.Change
+import to.bitkit.data.dto.price.GraphPeriod
+import to.bitkit.data.dto.price.PriceDTO
+import to.bitkit.data.dto.price.PriceWidgetData
+import to.bitkit.data.dto.price.TradingPair
+import to.bitkit.test.BaseUnitTest
+import to.bitkit.utils.AppError
+import java.net.UnknownHostException
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+@Config(sdk = [34])
+@RunWith(RobolectricTestRunner::class)
+class AppWidgetRefreshWorkerTest : BaseUnitTest() {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val dataRepository = mock<AppWidgetDataRepository>()
+    private val preferencesStore = mock<AppWidgetPreferencesStore>()
+    private val appWidgetUpdater = mock<AppWidgetUpdater>()
+    private val clock = mock<Clock>()
+    private val workerParameters = mock<WorkerParameters>()
+
+    @Before
+    fun setUp() {
+        whenever(clock.now()).thenReturn(Instant.fromEpochMilliseconds(NOW_MS))
+        whenever(workerParameters.inputData).thenReturn(
+            workDataOf(AppWidgetRefreshScheduler.WORK_INPUT_REASON to AppWidgetRefreshReason.APP_START.name),
+        )
+    }
+
+    @Test
+    fun `fresh remote widget type skips network refresh`() = test {
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.HEADLINES))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.HEADLINES)).thenReturn(
+            AppWidgetRefreshMetadata(
+                lastAttemptAtMs = NOW_MS - 1.minutes.inWholeMilliseconds,
+                lastSuccessAtMs = NOW_MS - 1.minutes.inWholeMilliseconds,
+            ),
+        )
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        verify(dataRepository, never()).fetchArticles()
+        verify(preferencesStore, never()).markRefreshAttempt(any(), any())
+        verify(preferencesStore, never()).markRefreshSuccess(any(), any())
+        verify(appWidgetUpdater).update(AppWidgetType.HEADLINES, context)
+    }
+
+    @Test
+    fun `fresh price widget refreshes uncached active period`() = test {
+        val period = GraphPeriod.ONE_WEEK
+        val price = price(period)
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.PRICE))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.PRICE)).thenReturn(
+            AppWidgetRefreshMetadata(
+                lastAttemptAtMs = NOW_MS - 1.minutes.inWholeMilliseconds,
+                lastSuccessAtMs = NOW_MS - 1.minutes.inWholeMilliseconds,
+            ),
+        )
+        whenever(preferencesStore.getUncachedActivePricePeriods()).thenReturn(setOf(period))
+        whenever(preferencesStore.getActivePricePeriods()).thenReturn(setOf(period))
+        whenever(dataRepository.fetchPriceData(period)).thenReturn(Result.success(price))
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.PRICE, NOW_MS)
+        verify(dataRepository).fetchPriceData(period)
+        verify(preferencesStore).cachePriceData(period, price)
+        verify(preferencesStore).markRefreshSuccess(AppWidgetType.PRICE, NOW_MS)
+        verify(appWidgetUpdater).update(AppWidgetType.PRICE, context)
+    }
+
+    @Test
+    fun `connectivity remote refresh failure retries and updates cached widget`() = test {
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.HEADLINES))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.HEADLINES)).thenReturn(
+            AppWidgetRefreshMetadata(
+                lastAttemptAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+                lastSuccessAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+            ),
+        )
+        whenever(dataRepository.fetchArticles()).thenReturn(Result.failure(UnknownHostException("dns")))
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.retry(), result)
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.HEADLINES, NOW_MS)
+        verify(dataRepository).fetchArticles()
+        verify(preferencesStore, never()).markRefreshSuccess(any(), any())
+        verify(appWidgetUpdater).update(AppWidgetType.HEADLINES, context)
+    }
+
+    @Test
+    fun `non-connectivity remote refresh failure updates cached widget without retry`() = test {
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.HEADLINES))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.HEADLINES)).thenReturn(
+            AppWidgetRefreshMetadata(
+                lastAttemptAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+                lastSuccessAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+            ),
+        )
+        whenever(dataRepository.fetchArticles()).thenReturn(Result.failure(AppWidgetRefreshWorkerTestError("failed")))
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.HEADLINES, NOW_MS)
+        verify(dataRepository).fetchArticles()
+        verify(preferencesStore, never()).markRefreshSuccess(any(), any())
+        verify(appWidgetUpdater).update(AppWidgetType.HEADLINES, context)
+    }
+
+    @Test
+    fun `recent failed alarm refresh backs off without fetching remote data`() = test {
+        whenever(workerParameters.inputData).thenReturn(
+            workDataOf(AppWidgetRefreshScheduler.WORK_INPUT_REASON to AppWidgetRefreshReason.CATCH_UP_ALARM.name),
+        )
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.HEADLINES))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.HEADLINES)).thenReturn(
+            AppWidgetRefreshMetadata(
+                lastAttemptAtMs = NOW_MS - 1.minutes.inWholeMilliseconds,
+                lastSuccessAtMs = NOW_MS - 16.minutes.inWholeMilliseconds,
+            ),
+        )
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        verify(dataRepository, never()).fetchArticles()
+        verify(preferencesStore, never()).markRefreshAttempt(any(), any())
+        verify(preferencesStore, never()).markRefreshSuccess(any(), any())
+        verify(appWidgetUpdater).update(AppWidgetType.HEADLINES, context)
+    }
+
+    @Test
+    fun `price connectivity refresh failure retries and updates cached widget`() = test {
+        val period = GraphPeriod.ONE_DAY
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.PRICE))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.PRICE)).thenReturn(
+            AppWidgetRefreshMetadata(
+                lastAttemptAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+                lastSuccessAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+            ),
+        )
+        whenever(preferencesStore.getUncachedActivePricePeriods()).thenReturn(emptySet())
+        whenever(preferencesStore.getActivePricePeriods()).thenReturn(setOf(period))
+        whenever(dataRepository.fetchPriceData(period)).thenReturn(Result.failure(UnknownHostException("dns")))
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.retry(), result)
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.PRICE, NOW_MS)
+        verify(dataRepository).fetchPriceData(period)
+        verify(preferencesStore, never()).markRefreshSuccess(any(), any())
+        verify(appWidgetUpdater).update(AppWidgetType.PRICE, context)
+    }
+
+    @Test
+    fun `connectivity failure continues remaining remote refreshes before retry`() = test {
+        val firstPeriod = GraphPeriod.ONE_DAY
+        val secondPeriod = GraphPeriod.ONE_WEEK
+        val article = article()
+        val block = block()
+        val weather = weather()
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(AppWidgetType.entries.toSet())
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.PRICE)).thenReturn(metadata(minutesAgo = 61))
+        whenever(preferencesStore.getUncachedActivePricePeriods()).thenReturn(emptySet())
+        whenever(preferencesStore.getActivePricePeriods()).thenReturn(linkedSetOf(firstPeriod, secondPeriod))
+        whenever(dataRepository.fetchPriceData(firstPeriod)).thenReturn(Result.failure(UnknownHostException("dns")))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.HEADLINES)).thenReturn(metadata(minutesAgo = 61))
+        whenever(dataRepository.fetchArticles()).thenReturn(Result.success(listOf(article)))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.BLOCKS)).thenReturn(metadata(minutesAgo = 61))
+        whenever(dataRepository.fetchBlock()).thenReturn(Result.success(block))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.WEATHER)).thenReturn(metadata(minutesAgo = 31))
+        whenever(dataRepository.fetchWeather()).thenReturn(Result.success(weather))
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.retry(), result)
+        verify(dataRepository).fetchPriceData(firstPeriod)
+        verify(dataRepository, never()).fetchPriceData(secondPeriod)
+        verify(dataRepository).fetchArticles()
+        verify(dataRepository).fetchBlock()
+        verify(dataRepository).fetchWeather()
+        verify(dataRepository, never()).fetchFacts()
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.PRICE, NOW_MS)
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.HEADLINES, NOW_MS)
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.BLOCKS, NOW_MS)
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.WEATHER, NOW_MS)
+        verify(preferencesStore).cacheArticlesAndRotate(listOf(article))
+        verify(preferencesStore).cacheBlock(block)
+        verify(preferencesStore).cacheWeather(weather)
+        verify(preferencesStore).markRefreshSuccess(AppWidgetType.HEADLINES, NOW_MS)
+        verify(preferencesStore).markRefreshSuccess(AppWidgetType.BLOCKS, NOW_MS)
+        verify(preferencesStore).markRefreshSuccess(AppWidgetType.WEATHER, NOW_MS)
+        verify(preferencesStore, never()).markRefreshSuccess(AppWidgetType.PRICE, NOW_MS)
+        verify(appWidgetUpdater).update(AppWidgetType.PRICE, context)
+        verify(appWidgetUpdater).update(AppWidgetType.HEADLINES, context)
+        verify(appWidgetUpdater).update(AppWidgetType.BLOCKS, context)
+        verify(appWidgetUpdater).update(AppWidgetType.WEATHER, context)
+        verify(appWidgetUpdater, never()).update(AppWidgetType.FACTS, context)
+    }
+
+    @Test
+    fun `remote refresh cancellation is rethrown`() = test {
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.HEADLINES))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.HEADLINES)).thenReturn(
+            AppWidgetRefreshMetadata(
+                lastAttemptAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+                lastSuccessAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+            ),
+        )
+        whenever(dataRepository.fetchArticles()).thenThrow(CancellationException("cancelled"))
+
+        assertFailsWith<CancellationException> {
+            worker().doWork()
+        }
+
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.HEADLINES, NOW_MS)
+        verify(appWidgetUpdater, never()).update(any(), any())
+    }
+
+    @Test
+    fun `remote refresh result cancellation is rethrown`() = test {
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.HEADLINES))
+        whenever(preferencesStore.getRefreshMetadata(AppWidgetType.HEADLINES)).thenReturn(
+            AppWidgetRefreshMetadata(
+                lastAttemptAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+                lastSuccessAtMs = NOW_MS - 61.minutes.inWholeMilliseconds,
+            ),
+        )
+        whenever(dataRepository.fetchArticles()).thenReturn(Result.failure(CancellationException("cancelled")))
+
+        assertFailsWith<CancellationException> {
+            worker().doWork()
+        }
+
+        verify(preferencesStore).markRefreshAttempt(AppWidgetType.HEADLINES, NOW_MS)
+        verify(appWidgetUpdater, never()).update(any(), any())
+    }
+
+    @Test
+    fun `facts refresh rotates locally and does not mark remote success`() = test {
+        val facts = listOf("Bitcoin does not have a CEO.")
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.FACTS))
+        whenever(workerParameters.inputData).thenReturn(
+            workDataOf(
+                AppWidgetRefreshScheduler.WORK_INPUT_REASON to AppWidgetRefreshReason.FACTS_LOCAL_REFRESH.name,
+            ),
+        )
+        whenever(dataRepository.fetchFacts()).thenReturn(Result.success(facts))
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        verify(dataRepository).fetchFacts()
+        verify(preferencesStore).cacheFacts(facts)
+        verify(preferencesStore).bumpFactsRotationTick()
+        verify(preferencesStore, never()).getRefreshMetadata(any())
+        verify(preferencesStore, never()).markRefreshAttempt(any(), any())
+        verify(preferencesStore, never()).markRefreshSuccess(any(), any())
+        verify(appWidgetUpdater).update(AppWidgetType.FACTS, context)
+    }
+
+    @Test
+    fun `remote refresh reason skips facts because local work handles it`() = test {
+        whenever(preferencesStore.getActiveWidgetTypes()).thenReturn(setOf(AppWidgetType.FACTS))
+
+        val result = worker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        verify(dataRepository, never()).fetchFacts()
+        verify(preferencesStore, never()).bumpFactsRotationTick()
+        verify(appWidgetUpdater, never()).update(any(), any())
+    }
+
+    private fun worker(): AppWidgetRefreshWorker =
+        AppWidgetRefreshWorker(
+            appContext = context,
+            workerParams = workerParameters,
+            dataRepository = dataRepository,
+            preferencesStore = preferencesStore,
+            appWidgetUpdater = appWidgetUpdater,
+            clock = clock,
+        )
+
+    private fun metadata(minutesAgo: Long) = AppWidgetRefreshMetadata(
+        lastAttemptAtMs = NOW_MS - minutesAgo.minutes.inWholeMilliseconds,
+        lastSuccessAtMs = NOW_MS - minutesAgo.minutes.inWholeMilliseconds,
+    )
+
+    private fun price(period: GraphPeriod) = PriceDTO(
+        widgets = listOf(
+            PriceWidgetData(
+                pair = TradingPair.BTC_USD,
+                period = period,
+                change = Change(isPositive = false, formatted = "-1%"),
+                price = "\$1",
+                pastValues = listOf(1.0),
+            ),
+        ),
+    )
+
+    private fun article() = ArticleDTO(
+        title = "Bitkit",
+        publishedDate = "2026-06-05",
+        link = "https://bitkit.to",
+        publisher = PublisherDTO(title = "Bitkit"),
+    )
+
+    private fun block() = BlockDTO(
+        hash = "hash",
+        height = "1",
+        timestamp = NOW_MS,
+        transactionCount = "1",
+        size = "1",
+        weight = "1",
+        difficulty = "1",
+        merkleRoot = "root",
+    )
+
+    private fun weather() = WeatherDTO(
+        condition = FeeCondition.GOOD,
+        currentFee = "1",
+        nextBlockFee = 1,
+    )
+
+    private companion object {
+        const val NOW_MS = 10_000_000L
+    }
+}
+
+private class AppWidgetRefreshWorkerTestError(message: String) : AppError(message)

--- a/app/src/test/java/to/bitkit/utils/ConnectivityErrorsTest.kt
+++ b/app/src/test/java/to/bitkit/utils/ConnectivityErrorsTest.kt
@@ -1,0 +1,34 @@
+package to.bitkit.utils
+
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import java.net.ProtocolException
+import java.nio.channels.UnresolvedAddressException
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ConnectivityErrorsTest {
+    @Test
+    fun `returns true for ktor request timeout`() {
+        val error = HttpRequestTimeoutException("https://feeds.synonym.to", 10_000, null)
+
+        assertTrue(error.isConnectivityFailure())
+    }
+
+    @Test
+    fun `returns true for unresolved address`() {
+        assertTrue(UnresolvedAddressException().isConnectivityFailure())
+    }
+
+    @Test
+    fun `returns true for nested connectivity failure`() {
+        val error = IllegalStateException("Wrapped timeout", UnresolvedAddressException())
+
+        assertTrue(error.isConnectivityFailure())
+    }
+
+    @Test
+    fun `returns false for non connectivity failure`() {
+        assertFalse(ProtocolException("Bad response").isConnectivityFailure())
+    }
+}

--- a/changelog.d/next/978.fixed.md
+++ b/changelog.d/next/978.fixed.md
@@ -1,0 +1,1 @@
+Android home-screen widgets now refresh after unlocking and keep retrying with backoff while connectivity is still coming back.


### PR DESCRIPTION
Fixes #975

### Description

This PR:
1. Refactors Android widget refresh scheduling into one `AppWidgetRefreshScheduler` entry point.
2. Keeps periodic WorkManager refresh as the primary 15-minute best-effort engine, with a sparse inexact idle alarm for app-not-running catch-up and a 30-minute native widget fallback.
3. Restores scheduling from app startup, foreground, widget enable/update/configuration, boot, package replacement, and the foreground-service stop action.
4. Updates the worker to refresh only active widget types, track per-type attempt/success freshness, skip fresh remote-backed types, and retry stale/failed types independently.
5. Treats Facts as local cached rotation, so a Facts update is not counted as proof that remote-backed widgets refreshed.
6. Removes runtime-only user-present/idle-mode receiver registration and avoids tying widget refresh to `LightningNodeService.onDestroy`.

### Preview

| Before Idle | After Idle |
| - | - |
| <img width="300" alt="beforeIdle" src="https://github.com/user-attachments/assets/23a564f4-9ea8-4dbd-b154-0226ea5794ca" /> | <img width="300" alt="afterIdle" src="https://github.com/user-attachments/assets/9adcff25-0e82-4f19-b4da-fcb3952b5abc" /> |

### QA Notes
#### Manual Tests
- [x] **1.** Android launcher → install the PR dev build → add Price, Headlines, Blocks, Facts, and Weather OS widgets → open Bitkit once → stop Bitkit from the persistent notification → keep Wi-Fi/data on → unplug USB/power → lock the phone and leave it untouched for 30+ minutes → unlock without opening Bitkit: remote-backed widgets update without launching the app.
  **Result:** Real idle wait from 19:15 to 20:43 on June 2, 2026: Price changed from `$67.443` to `$67.314`, Blocks changed from `952,132` to `952,138`, News changed headline, and Facts rotated locally. Weather stayed at `$0.28`, which is valid when the fee estimate itself has not changed.
- [x] **3.** Logs: device logs after the real wait show Bitkit widget update notifications after unlock, successful widget update records, and a later catch-up alarm/worker pass that saw all active widget types and skipped remote-backed types as fresh.
- [x] **4.** `negative:` Android quick settings → disable Wi-Fi/data → repeat the idle test: remote-backed widgets may stay stale while offline; Facts may still rotate from local cached facts only.
- [x] **5.** `negative:` Android Settings → Apps → Bitkit → Force stop → return to launcher: Android 15 may disable widget updates/pending intents until the user launches or interacts with Bitkit again; this is expected platform behavior.

#### Automated Checks
- Unit tests added: cover widget freshness policy, scheduler cancel/schedule behavior, boot/package/alarm receiver delegation, and worker attempt/success handling in `app/src/test/java/to/bitkit/appwidget/`.
- Unit test modified: covers the foreground-service stop action scheduling widget catch-up before shutdown in `app/src/test/java/to/bitkit/androidServices/LightningNodeServiceTest.kt`.
- `git diff --check` passed locally.
- `./gradlew compileDevDebugKotlin` passed locally.
- `./gradlew testDevDebugUnitTest` passed locally.
- `./gradlew detekt` passed locally.