### PR TITLE
fix: prevent sticky node crash

### DIFF
--- a/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
+++ b/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
@@ -4,10 +4,12 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
@@ -59,13 +61,16 @@ class LightningNodeService : Service() {
     @Inject
     lateinit var cacheStore: CacheStore
 
+    private var hasStartedNode = false
+
     override fun onCreate() {
         super.onCreate()
-        startForeground(ID_NOTIFICATION_NODE, createNotification())
-        setupService()
     }
 
     private fun setupService() {
+        if (hasStartedNode) return
+        hasStartedNode = true
+
         serviceScope.launch {
             lightningRepo.start(
                 eventHandler = { event ->
@@ -149,19 +154,49 @@ class LightningNodeService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        Logger.debug("onStartCommand", context = TAG)
-        when (intent?.action) {
+        val action = intent?.action
+        Logger.debug("Received start command action '$action'", context = TAG)
+        when (action) {
+            ACTION_START_SERVICE -> {
+                if (promoteToForeground(startId)) setupService()
+            }
             ACTION_STOP_SERVICE_AND_APP -> {
-                Logger.debug("ACTION_STOP_SERVICE_AND_APP detected", context = TAG)
-                serviceScope.launch {
-                    lightningRepo.stop()
-                    activityManager.appTasks.forEach { it.finishAndRemoveTask() }
-                    stopSelf()
-                }
-                return START_NOT_STICKY
+                Logger.debug("Received stop service action", context = TAG)
+                stopForegroundService(startId)
+                activityManager.appTasks.forEach { it.finishAndRemoveTask() }
+                serviceScope.launch { lightningRepo.stop() }
+            }
+            else -> {
+                Logger.warn("Stopped service for unsupported action '$action'", context = TAG)
+                stopSelf(startId)
             }
         }
-        return START_STICKY
+        return START_NOT_STICKY
+    }
+
+    private fun promoteToForeground(startId: Int): Boolean {
+        return runCatching {
+            ServiceCompat.startForeground(
+                this,
+                ID_NOTIFICATION_NODE,
+                createNotification(),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        }.fold(
+            onSuccess = { true },
+            onFailure = {
+                if (it !is RuntimeException) throw it
+
+                Logger.error("Failed to promote foreground service", it, context = TAG)
+                stopSelf(startId)
+                false
+            }
+        )
+    }
+
+    private fun stopForegroundService(startId: Int) {
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        stopSelf(startId)
     }
 
     override fun onDestroy() {
@@ -173,11 +208,9 @@ class LightningNodeService : Service() {
 
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     override fun onTimeout(startId: Int, fgsType: Int) {
-        Logger.warn("Foreground service timeout reached", context = TAG)
-        serviceScope.launch {
-            lightningRepo.stop()
-            stopSelf()
-        }
+        Logger.warn("Reached foreground service timeout for type '$fgsType'", context = TAG)
+        stopForegroundService(startId)
+        serviceScope.launch { lightningRepo.stop() }
         super.onTimeout(startId, fgsType)
     }
 
@@ -186,6 +219,7 @@ class LightningNodeService : Service() {
     companion object {
         const val CHANNEL_ID_NODE = "bitkit_notification_channel_node"
         const val TAG = "LightningNodeService"
+        const val ACTION_START_SERVICE = "to.bitkit.androidServices.action.START_SERVICE"
         const val ACTION_STOP_SERVICE_AND_APP = "to.bitkit.androidServices.action.STOP_SERVICE_AND_APP"
     }
 }

--- a/app/src/main/java/to/bitkit/ui/MainActivity.kt
+++ b/app/src/main/java/to/bitkit/ui/MainActivity.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import to.bitkit.R
 import to.bitkit.androidServices.LightningNodeService
+import to.bitkit.androidServices.LightningNodeService.Companion.ACTION_START_SERVICE
 import to.bitkit.androidServices.LightningNodeService.Companion.CHANNEL_ID_NODE
 import to.bitkit.models.NewTransactionSheetDetails
 import to.bitkit.models.SamRockSetupRequest
@@ -231,7 +232,11 @@ class MainActivity : FragmentActivity() {
     private fun tryStartForegroundService() {
         runCatching {
             Logger.debug("Attempting to start LightningNodeService", context = "MainActivity")
-            startForegroundService(Intent(this, LightningNodeService::class.java))
+            startForegroundService(
+                Intent(this, LightningNodeService::class.java).apply {
+                    action = ACTION_START_SERVICE
+                },
+            )
         }.onFailure { error ->
             Logger.error("Failed to start LightningNodeService", error, context = "MainActivity")
         }

--- a/app/src/test/java/to/bitkit/androidServices/LightningNodeServiceTest.kt
+++ b/app/src/test/java/to/bitkit/androidServices/LightningNodeServiceTest.kt
@@ -4,7 +4,10 @@ import android.Manifest
 import android.app.Activity
 import android.app.Application
 import android.app.Notification
+import android.app.Service
 import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
 import androidx.test.core.app.ApplicationProvider
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.testing.BindValue
@@ -12,6 +15,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import dagger.hilt.android.testing.UninstallModules
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
@@ -24,9 +28,11 @@ import org.lightningdevkit.ldknode.Event
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
@@ -58,12 +64,18 @@ import to.bitkit.ui.shared.toast.ToastQueueManager
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @HiltAndroidTest
 @UninstallModules(DispatchersModule::class, DbModule::class, ViewModelModule::class)
 @Config(application = HiltTestApplication::class, sdk = [34]) // Pin Robolectric to an SDK that supports Java 17
 @RunWith(RobolectricTestRunner::class)
 class LightningNodeServiceTest : BaseUnitTest() {
+    companion object {
+        private const val START_ID = 1
+        private const val STOP_START_ID = 2
+        private const val TIMEOUT_START_ID = 3
+    }
 
     @get:Rule(order = 1)
     var hiltRule = HiltAndroidRule(this)
@@ -146,9 +158,110 @@ class LightningNodeServiceTest : BaseUnitTest() {
     }
 
     @Test
+    fun `start action promotes data sync foreground service and starts node`() = test {
+        val service = createService()
+        val result = service.onStartCommand(serviceIntent(), 0, START_ID)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        assertEquals(ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC, service.foregroundServiceType)
+        assertNotNull(Shadows.shadowOf(service).lastForegroundNotification)
+        assertNotNull(capturedHandler, "Event handler should be captured")
+    }
+
+    @Test
+    fun `start action only starts node once`() = test {
+        val service = createService()
+        service.onStartCommand(serviceIntent(), 0, START_ID)
+        service.onStartCommand(serviceIntent(), 0, START_ID + 1)
+        testScheduler.advanceUntilIdle()
+
+        verifyLightningStart(count = 1)
+    }
+
+    @Test
+    fun `null intent stops service without starting node`() = test {
+        val service = createService()
+        val result = service.onStartCommand(null, 0, START_ID)
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        assertEquals(START_ID, Shadows.shadowOf(service).stopSelfId)
+        assertNull(capturedHandler)
+        verifyLightningNeverStarted()
+    }
+
+    @Test
+    fun `unsupported action stops service without starting node`() = test {
+        val service = createService()
+        val result = service.onStartCommand(serviceIntent("unsupported"), 0, START_ID)
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        assertEquals(START_ID, Shadows.shadowOf(service).stopSelfId)
+        assertNull(capturedHandler)
+        verifyLightningNeverStarted()
+    }
+
+    @Test
+    fun `foreground promotion failure stops service without starting node`() = test {
+        val service = createService()
+        val shadowService = Shadows.shadowOf(service)
+        shadowService.setThrowInStartForeground(RuntimeException("blocked"))
+
+        val result = service.onStartCommand(serviceIntent(), 0, START_ID)
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        assertEquals(START_ID, shadowService.stopSelfId)
+        assertNull(capturedHandler)
+        verifyLightningNeverStarted()
+    }
+
+    @Test
+    fun `stop action stops service before node stop completes`() = test {
+        val stopResult = CompletableDeferred<Result<Unit>>()
+        whenever { lightningRepo.stop() }.doSuspendableAnswer { stopResult.await() }
+
+        val service = startService()
+        testScheduler.advanceUntilIdle()
+        val shadowService = Shadows.shadowOf(service)
+
+        val result = service.onStartCommand(
+            serviceIntent(LightningNodeService.ACTION_STOP_SERVICE_AND_APP),
+            0,
+            STOP_START_ID,
+        )
+
+        assertEquals(Service.START_NOT_STICKY, result)
+        assertTrue(shadowService.isStoppedBySelf)
+        assertTrue(shadowService.isForegroundStopped)
+        assertEquals(STOP_START_ID, shadowService.stopSelfId)
+
+        stopResult.complete(Result.success(Unit))
+        testScheduler.advanceUntilIdle()
+    }
+
+    @Test
+    @Config(sdk = [35])
+    fun `foreground service timeout stops service before node stop completes`() = test {
+        val stopResult = CompletableDeferred<Result<Unit>>()
+        whenever { lightningRepo.stop() }.doSuspendableAnswer { stopResult.await() }
+
+        val service = startService()
+        testScheduler.advanceUntilIdle()
+        val shadowService = Shadows.shadowOf(service)
+
+        service.onTimeout(TIMEOUT_START_ID, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+
+        assertTrue(shadowService.isStoppedBySelf)
+        assertTrue(shadowService.isForegroundStopped)
+        assertEquals(TIMEOUT_START_ID, shadowService.stopSelfId)
+
+        stopResult.complete(Result.success(Unit))
+        testScheduler.advanceUntilIdle()
+    }
+
+    @Test
     fun `payment received in background shows notification`() = test {
-        val controller = Robolectric.buildService(LightningNodeService::class.java)
-        controller.create().startCommand(0, 0)
+        startService()
         testScheduler.advanceUntilIdle()
 
         assertNotNull(capturedHandler, "Event handler should be captured")
@@ -186,8 +299,7 @@ class LightningNodeServiceTest : BaseUnitTest() {
         val mockActivity: Activity = mock()
         App.currentActivity?.onActivityStarted(mockActivity)
 
-        val controller = Robolectric.buildService(LightningNodeService::class.java)
-        controller.create().startCommand(0, 0)
+        startService()
         testScheduler.advanceUntilIdle()
 
         val event = Event.PaymentReceived(
@@ -214,8 +326,7 @@ class LightningNodeServiceTest : BaseUnitTest() {
 
     @Test
     fun `notification uses content from use case result`() = test {
-        val controller = Robolectric.buildService(LightningNodeService::class.java)
-        controller.create().startCommand(0, 0)
+        startService()
         testScheduler.advanceUntilIdle()
 
         val event = Event.PaymentReceived(
@@ -252,8 +363,7 @@ class LightningNodeServiceTest : BaseUnitTest() {
             )
         )
 
-        val controller = Robolectric.buildService(LightningNodeService::class.java)
-        controller.create().startCommand(0, 0)
+        startService()
         testScheduler.advanceUntilIdle()
 
         val event = Event.PaymentSuccessful(
@@ -288,8 +398,7 @@ class LightningNodeServiceTest : BaseUnitTest() {
             )
         )
 
-        val controller = Robolectric.buildService(LightningNodeService::class.java)
-        controller.create().startCommand(0, 0)
+        startService()
         testScheduler.advanceUntilIdle()
 
         val event = Event.PaymentFailed(
@@ -325,8 +434,7 @@ class LightningNodeServiceTest : BaseUnitTest() {
             )
         )
 
-        val controller = Robolectric.buildService(LightningNodeService::class.java)
-        controller.create().startCommand(0, 0)
+        startService()
         testScheduler.advanceUntilIdle()
 
         val event = Event.PaymentSuccessful(
@@ -354,8 +462,7 @@ class LightningNodeServiceTest : BaseUnitTest() {
             Result.success(NotifyPendingPaymentResolved.Result.Skip)
         )
 
-        val controller = Robolectric.buildService(LightningNodeService::class.java)
-        controller.create().startCommand(0, 0)
+        startService()
         testScheduler.advanceUntilIdle()
 
         val event = Event.PaymentSuccessful(
@@ -376,5 +483,49 @@ class LightningNodeServiceTest : BaseUnitTest() {
             it.extras.getString(Notification.EXTRA_TITLE) == sentTitle
         }
         assertNull(notification, "Non-pending payment should NOT trigger notification")
+    }
+
+    private fun createService(): LightningNodeService {
+        return Robolectric.buildService(LightningNodeService::class.java)
+            .create()
+            .get()
+    }
+
+    private fun startService(): LightningNodeService {
+        val service = createService()
+        service.onStartCommand(serviceIntent(), 0, START_ID)
+        return service
+    }
+
+    private fun serviceIntent(action: String = LightningNodeService.ACTION_START_SERVICE): Intent {
+        return Intent(context, LightningNodeService::class.java).apply {
+            this.action = action
+        }
+    }
+
+    private suspend fun verifyLightningStart(count: Int) {
+        verify(lightningRepo, times(count)).start(
+            any(),
+            anyOrNull(),
+            any(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            any(),
+        )
+    }
+
+    private suspend fun verifyLightningNeverStarted() {
+        verify(lightningRepo, never()).start(
+            any(),
+            anyOrNull(),
+            any(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            any(),
+        )
     }
 }

--- a/changelog.d/next/987.fixed.md
+++ b/changelog.d/next/987.fixed.md
@@ -1,0 +1,1 @@
+Bitkit no longer crashes when Android stops the background Lightning node service.


### PR DESCRIPTION
Fixes #980
Fixes #981
Refs #986

### Description

This PR:
1. Guards `LightningNodeService` startup so Android does not promote the service from sticky/null restarts.
2. Promotes the service with the explicit `dataSync` foreground-service type.
3. Stops the foreground service immediately on Android timeout or notification stop before running async node cleanup.
4. Adds regression coverage for foreground-service startup, restart, promotion-failure, stop, and timeout behavior.

### Preview

N/A - service lifecycle crash fix, no UI changes.

### QA Notes

#### Repro / Fix Evidence

- Emulator/device setup: API 35+ with dev app `to.bitkit.dev`, target SDK 36, and shortened `dataSync` timeout:
  ```sh
  adb shell device_config put activity_manager data_sync_fgs_timeout_duration 30000
  adb shell device_config get activity_manager data_sync_fgs_timeout_duration
  ```
- Pre-fix repro: checkout `v2.2.0`, install dev build, apply a local-only stress patch that delays `stopSelf()` in `LightningNodeService.onTimeout()` after `lightningRepo.stop()`, start the app, press Home, and wait about 35s.
- Pre-fix crash evidence: `.ai/issue_980_prefix/logcat.txt` line 1187 shows `ForegroundServiceDidNotStopInTimeException` after `FGS (dataSync) timed out`.
- Post-fix verification: checkout this branch, install dev build, use the same 30s timeout, background the app with the node service running, and wait about 35s.
- Post-fix clean timeout evidence: `.ai/issue_980_postfix/logcat.txt` line 2044 shows `FGS (dataSync) timed out`, followed by service timeout handling and `onDestroy`, with no `FGS Crashed`, no `RemoteServiceException`, and no process death.
- Optional symmetric stress on the fix: delay async `lightningRepo.stop()` after `stopForegroundService(startId)` in `onTimeout`; the FGS is already stopped before the delay, so the process still does not crash.
- Reset timeout override after QA:
  ```sh
  adb shell device_config delete activity_manager data_sync_fgs_timeout_duration
  ```

#### Manual Tests

- [x] **1.** `regression:` Android 15+ or 16+ device → enable shortened `dataSync` FGS timeout → background Bitkit with node service running: service stops cleanly without `ForegroundServiceDidNotStopInTimeException`.
- [x] **2.** `regression:` Bitkit with notifications enabled → start background node service → force sticky/null restart condition: service does not promote from `onCreate()` and does not crash with `ForegroundServiceStartNotAllowedException`.
- [x] **3.** `regression:` Node notification → tap Stop: foreground service notification is removed and app/service stops cleanly.

#### Automated Checks

- Unit tests added/updated: `app/src/test/java/to/bitkit/androidServices/LightningNodeServiceTest.kt` covers explicit start action, typed `dataSync` foreground promotion, null/unsupported restart intents, promotion failure, duplicate starts, stop action ordering, and API-35 timeout ordering.
- Local checks passed:
  - `./gradlew testDevDebugUnitTest --tests to.bitkit.androidServices.LightningNodeServiceTest`
  - `just compile`
  - `just test`
  - `just lint`
- `just lint` exited successfully; it printed existing unrelated detekt findings in `AppViewModel.kt` and `SupportScreen.kt`.
