### PR TITLE
fix: core signal abort crash

### DIFF
--- a/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
+++ b/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
@@ -5,7 +5,8 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.content.pm.ServiceInfo
-import android.os.Build
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.IBinder
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
@@ -37,6 +38,8 @@ import to.bitkit.utils.Logger
 import to.bitkit.utils.jsonLogOf
 import javax.inject.Inject
 
+typealias Hook = (() -> Unit)?
+
 @AndroidEntryPoint
 class LightningNodeService : Service() {
 
@@ -62,10 +65,6 @@ class LightningNodeService : Service() {
     lateinit var cacheStore: CacheStore
 
     private var hasStartedNode = false
-
-    override fun onCreate() {
-        super.onCreate()
-    }
 
     private fun setupService() {
         if (hasStartedNode) return
@@ -157,19 +156,14 @@ class LightningNodeService : Service() {
         val action = intent?.action
         Logger.debug("Received start command action '$action'", context = TAG)
         when (action) {
-            ACTION_START_SERVICE -> {
-                if (promoteToForeground(startId)) setupService()
-            }
             ACTION_STOP_SERVICE_AND_APP -> {
-                Logger.debug("Received stop service action", context = TAG)
-                stopForegroundService(startId)
+                stopForegroundService(startId) { Logger.debug("Received stop service action", context = TAG) }
                 activityManager.appTasks.forEach { it.finishAndRemoveTask() }
                 serviceScope.launch { lightningRepo.stop() }
             }
-            else -> {
-                Logger.warn("Stopped service for unsupported action '$action'", context = TAG)
-                stopSelf(startId)
-            }
+
+            ACTION_START_SERVICE -> if (promoteToForeground(startId)) setupService()
+            else -> stop(startId) { Logger.warn("Stopped service for unsupported action '$action'", context = TAG) }
         }
         return START_NOT_STICKY
     }
@@ -180,22 +174,29 @@ class LightningNodeService : Service() {
                 this,
                 ID_NOTIFICATION_NODE,
                 createNotification(),
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                foregroundServiceTypeDataSync(),
             )
         }.fold(
             onSuccess = { true },
             onFailure = {
                 if (it !is RuntimeException) throw it
-
-                Logger.error("Failed to promote foreground service", it, context = TAG)
-                stopSelf(startId)
+                stop(startId) { Logger.error("Failed to promote foreground service", it, context = TAG) }
                 false
             }
         )
     }
 
-    private fun stopForegroundService(startId: Int) {
+    private fun foregroundServiceTypeDataSync(): Int {
+        return if (VERSION.SDK_INT >= VERSION_CODES.Q) ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC else 0
+    }
+
+    private fun stopForegroundService(startId: Int, hook: Hook = null) {
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        stop(startId, hook)
+    }
+
+    private fun stop(startId: Int, hook: Hook = null) {
+        hook?.invoke()
         stopSelf(startId)
     }
 
@@ -206,7 +207,7 @@ class LightningNodeService : Service() {
         super.onDestroy()
     }
 
-    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    @RequiresApi(VERSION_CODES.VANILLA_ICE_CREAM)
     override fun onTimeout(startId: Int, fgsType: Int) {
         Logger.warn("Reached foreground service timeout for type '$fgsType'", context = TAG)
         stopForegroundService(startId)

--- a/changelog.d/next/989.fixed.md
+++ b/changelog.d/next/989.fixed.md
@@ -1,0 +1,1 @@
+Bitkit now handles unexpected native on-chain lookup failures without crashing.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ activity-compose = { module = "androidx.activity:activity-compose", version = "1
 appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
 barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version = "17.3.0" }
 biometric = { module = "androidx.biometric:biometric", version = "1.4.0-alpha05" }
-bitkit-core = { module = "com.synonym:bitkit-core-android", version = "0.1.64" }
+bitkit-core = { module = "com.synonym:bitkit-core-android", version = "0.1.67" }
 paykit = { module = "com.synonym:paykit-android", version = "0.1.0-rc8" }
 bouncycastle-provider-jdk = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.83" }
 camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camera" }


### PR DESCRIPTION
Fixes #982

<!-- Changelog: Added in changelog.d/next/989.fixed.md. -->

This PR updates Android to consume the `bitkit-core` runtime hardening from synonymdev/bitkit-core#95.

### Description

This PR:
1. Bumps `bitkit-core-android` from `0.1.64` to the released `0.1.67` artifact.
2. Keeps `ldk-node-android` unchanged.
3. Adds a changelog fragment for the native on-chain lookup crash hardening.

#982 was reported from production mainnet `2.2.0` / build `181` during normal wallet and Lightning usage. That build used `bitkit-core-android 0.1.56` and `ldk-node-android 0.7.0-rc.36`; its production code exercises native Rust on background workers through wallet sync, activity processing, send/receive/channel flows, Electrum configuration, LDK on-chain payment calls, and bitkit-core address derivation/recovery/database calls.

The strongest available symbolication maps the raw Play PCs into `libbitkitcore.so`, near the on-chain address-info Electrum/BDK blocking task. The affected production tag does not call the current generated address-info wrapper directly, so this PR describes the risk at the native bitkit-core/Electrum boundary instead of attributing it to one app route. It consumes the core release that keeps unexpected failures in that native on-chain lookup boundary as typed errors rather than native aborts.

Related PR #988 only retains native debug symbols for future Play crash symbolication; this PR is the Android dependency bump for the runtime fix.

### Preview

N/A

### QA Notes
With this fix, we can prove the fixed Rust boundary now converts a synthetic panic into `AccountInfoError::SyncError`, which is an error the android side can handle as opposed to `panic`'s; but we cannot say we have a reliable production UI trigger for #982, this crash couldn't be reproduced with a deterministic repro scenario.

#### Manual Tests
- [ ] **1.** Mainnet wallet → foreground sync → Activity: wallet data loads without a native crash.
- [ ] **2.** `regression:` Receive → copy/show on-chain address → return Home: receive flow still works.
- [ ] **3.** `regression:` Send → prepare on-chain send with standard fee: fee estimate and confirmation flow still work.
#### Automated Checks
- `just compile`
- `just test`
- `just lint`
- Core release validation: synonymdev/bitkit-core#95 adds focused Rust coverage and publishes `v0.1.67`.
- Detekt completed successfully; it printed existing findings in `AppViewModel.handleScan` and `SupportScreen` import ordering.
