### PR TITLE
fix: align widget preview defaults with ios

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/widgets/WidgetSizeDraft.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/WidgetSizeDraft.kt
@@ -14,8 +14,8 @@ import to.bitkit.models.WidgetType
 
 /**
  * Tracks the widget size chosen in a preview sheet's size carousel. Before the user picks a size it
- * reflects the persisted size (or the type default for a not-yet-saved widget); once the user swipes
- * the carousel the draft takes over. [current] is read by the widget's save action.
+ * reflects the persisted size (or small for a not-yet-saved widget, matching iOS); once the user
+ * swipes the carousel the draft takes over. [current] is read by the widget's save action.
  */
 class WidgetSizeDraft(
     scope: CoroutineScope,
@@ -23,16 +23,14 @@ class WidgetSizeDraft(
     widgetsDataFlow: StateFlow<WidgetsData>,
     subscriptionTimeoutMs: Long = SUBSCRIPTION_TIMEOUT,
 ) {
-    private val default = WidgetSize.default(type)
-
     private val savedSize: StateFlow<WidgetSize> = widgetsDataFlow
-        .map { data -> data.widgets.firstOrNull { it.type == type }?.size ?: default }
-        .stateIn(scope, SharingStarted.WhileSubscribed(subscriptionTimeoutMs), default)
+        .map { data -> data.widgets.firstOrNull { it.type == type }?.size ?: WidgetSize.SMALL }
+        .stateIn(scope, SharingStarted.WhileSubscribed(subscriptionTimeoutMs), WidgetSize.SMALL)
 
     private val _draft = MutableStateFlow<WidgetSize?>(null)
 
     val size: StateFlow<WidgetSize> = combine(_draft, savedSize) { draft, saved -> draft ?: saved }
-        .stateIn(scope, SharingStarted.WhileSubscribed(subscriptionTimeoutMs), default)
+        .stateIn(scope, SharingStarted.WhileSubscribed(subscriptionTimeoutMs), WidgetSize.SMALL)
 
     val current: WidgetSize get() = size.value
 

--- a/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceCard.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/widgets/price/PriceCard.kt
@@ -138,7 +138,7 @@ fun PriceCardSmall(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .testTag("price_card_small_pair_row_${widgetData.pair.displayName}")
+                        .testTag("PriceWidgetRow-${widgetData.pair.displayName}")
                 ) {
                     Caption13Up(
                         text = widgetData.pair.displayName,

--- a/app/src/main/java/to/bitkit/ui/sheets/WidgetsSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/WidgetsSheet.kt
@@ -101,14 +101,9 @@ private fun WidgetsSheetContent(
     val galleryViewModelStoreOwner = rememberSheetViewModelStoreOwner()
     val galleryScrollState = rememberScrollState()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val isGalleryRoute = navBackStackEntry?.destination?.hasRoute<WidgetsRoute.Gallery>() == true
     val widgetFlowKey = navBackStackEntry?.destination?.widgetFlowKey()
         ?: startRoute.widgetFlowKey().takeIf { navBackStackEntry == null }
     val widgetViewModelStoreOwner = rememberWidgetFlowViewModelStoreOwner(widgetFlowKey)
-
-    LaunchedEffect(isGalleryRoute) {
-        galleryScrollState.scrollTo(0)
-    }
 
     Column(
         modifier = Modifier

--- a/app/src/test/java/to/bitkit/ui/screens/widgets/WidgetSizeDraftTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/widgets/WidgetSizeDraftTest.kt
@@ -1,0 +1,72 @@
+package to.bitkit.ui.screens.widgets
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import to.bitkit.data.WidgetsData
+import to.bitkit.models.WidgetSize
+import to.bitkit.models.WidgetType
+import to.bitkit.models.WidgetWithPosition
+import org.junit.Before
+import to.bitkit.test.BaseUnitTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WidgetSizeDraftTest : BaseUnitTest() {
+
+    private val widgetsData = MutableStateFlow(WidgetsData(widgets = emptyList()))
+
+    @Before
+    fun setUp() {
+        widgetsData.value = WidgetsData(widgets = emptyList())
+    }
+
+    @Test
+    fun `unsaved widget defaults to small for wide types`() = test {
+        val draft = WidgetSizeDraft(backgroundScope, WidgetType.PRICE, widgetsData)
+        val collector = backgroundScope.launch { draft.size.collect {} }
+
+        advanceUntilIdle()
+
+        assertEquals(WidgetSize.SMALL, draft.size.first())
+        collector.cancel()
+    }
+
+    @Test
+    fun `saved widget reflects persisted size`() = test {
+        widgetsData.value = WidgetsData(
+            widgets = listOf(
+                WidgetWithPosition(type = WidgetType.PRICE, position = 0, size = WidgetSize.WIDE),
+            ),
+        )
+        val draft = WidgetSizeDraft(backgroundScope, WidgetType.PRICE, widgetsData)
+        val collector = backgroundScope.launch { draft.size.collect {} }
+
+        advanceUntilIdle()
+
+        assertEquals(WidgetSize.WIDE, draft.size.first())
+        collector.cancel()
+    }
+
+    @Test
+    fun `user draft overrides saved size`() = test {
+        widgetsData.value = WidgetsData(
+            widgets = listOf(
+                WidgetWithPosition(type = WidgetType.FACTS, position = 0, size = WidgetSize.SMALL),
+            ),
+        )
+        val draft = WidgetSizeDraft(backgroundScope, WidgetType.FACTS, widgetsData)
+        val collector = backgroundScope.launch { draft.size.collect {} }
+
+        advanceUntilIdle()
+        draft.set(WidgetSize.WIDE)
+
+        advanceUntilIdle()
+
+        assertEquals(WidgetSize.WIDE, draft.size.first())
+        collector.cancel()
+    }
+}

--- a/app/src/test/java/to/bitkit/ui/screens/widgets/WidgetSizeDraftTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/widgets/WidgetSizeDraftTest.kt
@@ -5,11 +5,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.Before
 import to.bitkit.data.WidgetsData
 import to.bitkit.models.WidgetSize
 import to.bitkit.models.WidgetType
 import to.bitkit.models.WidgetWithPosition
-import org.junit.Before
 import to.bitkit.test.BaseUnitTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/changelog.d/next/990.fixed.md
+++ b/changelog.d/next/990.fixed.md
@@ -1,0 +1,1 @@
+New widgets now open on compact size in the preview carousel, matching iOS, and the add-widgets list keeps its scroll position when navigating back.


### PR DESCRIPTION
Follow-up to [#985](https://github.com/synonymdev/bitkit-android/pull/985) review feedback from [@piotr-iohk](https://github.com/synonymdev/bitkit-android/pull/985#issuecomment-4625263506).

This PR:
1. Defaults the widget preview size carousel to compact for not-yet-saved widgets, matching iOS.
2. Preserves add-widgets list scroll position when navigating back from a widget preview.
3. Aligns the compact price widget pair-row test tag with iOS so shared E2E assertions keep working.

### Description

Addresses post-merge review notes on #985:

- **Default preview size:** Android previously opened price and news on wide while iOS always proposes compact for new widgets. The preview draft now starts on compact when the widget is not saved yet, while still restoring the persisted size for saved widgets.
- **Scroll position:** Returning from a preview to the add-widgets gallery no longer resets scroll to the top.
- **Price test tag:** Compact price cards now expose `PriceWidgetRow-{pair}` like iOS, so widgets E2E does not need size-specific assertions.

### Preview


https://github.com/user-attachments/assets/c3a37dcf-9940-4268-ab14-edf78c786355



### QA Notes

#### Manual Tests

- [ ] **1.** Add Widgets → scroll down → open Facts preview → back: list stays at the same scroll position.
- [ ] **2a.** Add Widgets → open Price (not on home) preview: size carousel starts on Small.
  - [ ] **2b.** Swipe to Wide → Save: home shows wide price layout.
- [ ] **3.** Open preview for an already-saved wide Price widget: carousel opens on Wide.
- [ ] **4.** `regression:` widgets E2E `@widgets_1` still passes after rebuilding the E2E APK.

#### Automated Checks

- Unit tests added: cover preview draft defaulting and persisted-size behavior in `app/src/test/java/to/bitkit/ui/screens/widgets/WidgetSizeDraftTest.kt`.
- Unit tests unchanged: existing `WidgetSizeTest` suite still passes.
- E2E: widgets suite passes locally with rebuilt APK.
- CI: standard compile, unit test, and detekt checks run by the PR bot.

Made with [Cursor](https://cursor.com)