### PR TITLE
chore: bump version 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fix Spending and Savings screens scrolling behind top bar and add gradient fade effect #892
+
+## [2.3.0] - 2026-06-05
+
+### Added
+- Added Trezor hardware wallet support for connecting devices, signing messages, and managing on-chain transactions. #792
+- Connection issues overlay with connectivity fixes across Send, Receive, and Transfer flows #878
+- Home screen widgets foundation with Glance, including price widget as the first implementation #895
+- Return to Bitkit after Pubky Ring approval, cancellation, or error callbacks #917
+- Headlines home screen widget with v61 wide and compact layouts, including redesigned in-app preview and edit screens #919
+- Bitcoin Blocks home screen widget with v61 wide and compact layouts, including redesigned in-app preview and edit screens #922
+- Support public Paykit contact payments. #924
+- Bitcoin Facts home screen widget with v61 wide and compact layouts, including redesigned in-app facts card and preview screen #926
+- Bitcoin Weather home screen widget with v61 wide and compact layouts, including redesigned in-app weather card, preview, and edit screens #927
+- Added private Paykit contact payments with dedicated contact endpoints, rotation, cleanup, and restore-safe address reservations. #936
+- Added contact payment flows, activity contact attribution, and payment preference controls for private payments. #945
+- Added BTCPay wallet connection support for sharing Bitcoin receive descriptors. #961
+- Added a Legacy Recovery option in developer settings to help recover funds from affected legacy channel closes. #974
+- Home widgets can now be resized between compact and wide from the preview sheet, with a redesigned two-column grid, inline edit mode, and an interactive compact calculator. #985
 
 ### Changed
+- Redesign price widget with v61 wide and compact layouts, new preview and edit screens, and tap-to-edit behavior #914
+- Activity, Shop and Settings now keep their tabs pinned with a drop shadow as content scrolls behind them, the Add Widget button shows its icon, and the Shop list has more bottom spacing. #916
+- Redesigned the Bitcoin Calculator widget to v61 design and replaced the OS keyboard with a dark-themed in-app numpad #942
+- Hide experimental Paykit profile, contacts, and contact payment controls behind a developer setting. #954
+- The add widget experience now opens as a bottom-sheet flow with in-sheet previews instead of full-screen picker pages. #972
 - Improve Pubky profile restore, contact editing, and contact routing flows #905
 
 ### Fixed
+- Fix Spending and Savings screens scrolling behind top bar and add gradient fade effect #892
+- Align currency settings and calculator widget behavior with iOS #884
+- Align onboarding slides and Create Wallet screen image size, spacing, and dots layout with iOS #904
+- Align tab colors, Show details button, notifications bell figure, and home activity count with iOS #907
+- Payment QR scans now route reliably and avoid unnecessary delays when Lightning channels are unavailable. #925
+- Fix gift card flow showing false-positive confetti when the LSP payment fails, and re-opening unexpectedly after an app language change. #929
+- Improved public contact payment flows for manual Pubky entry, add-contact payments, and RBF activity display. #931
+- Fix several OS widget issues including an intermittent crash when removing or cancelling a home screen widget, ordering of widget options, and the color of disabled checkboxes in widget configuration screens. #935
+- Improved OS widgets so previews, settings, currency display, and OS-home interactions match v61 design iteration. #952
+- Improved logs, support diagnostics and channel peer recovery after wallet restore. #969
+- The Support page now shows the current copyright year automatically. #971
+- Android home-screen widgets now refresh after unlocking and keep retrying with backoff while connectivity is still coming back. #978
+- Improved BTCPay setup link handling so Bitkit opens supported connection links reliably and shows clearer setup errors. #979
+- Bitkit no longer crashes when Android stops the background Lightning node service. #987
+- Bitkit now handles unexpected native on-chain lookup failures without crashing. #989
+- New widgets now open on compact size in the preview carousel, matching iOS, and the add-widgets list keeps its scroll position when navigating back. #990
 - Fix probe results and add keysend probes #920
 - Align top bar back arrow and passphrase input cursor/placeholder with iOS #906
 - Polish Terms of Use screen padding to match iOS #903
@@ -56,5 +94,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - About screen (content merged into Support) #857
 - Standalone General, Security, and Advanced settings screens (merged into tabs) #857
 
-[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/synonymdev/bitkit-android/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/synonymdev/bitkit-android/compare/v2.1.2...v2.2.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,8 +149,8 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 181
-        versionName = "2.2.0"
+        versionCode = 182
+        versionName = "2.3.0"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         bitkitAndroidTestAnnotation?.let {
             testInstrumentationRunnerArguments["annotation"] = it

--- a/changelog.d/next/792.added.md
+++ b/changelog.d/next/792.added.md
@@ -1,1 +1,0 @@
-Added Trezor hardware wallet support for connecting devices, signing messages, and managing on-chain transactions.

--- a/changelog.d/next/878.added.md
+++ b/changelog.d/next/878.added.md
@@ -1,1 +1,0 @@
-Connection issues overlay with connectivity fixes across Send, Receive, and Transfer flows

--- a/changelog.d/next/884.fixed.md
+++ b/changelog.d/next/884.fixed.md
@@ -1,1 +1,0 @@
-Align currency settings and calculator widget behavior with iOS

--- a/changelog.d/next/895.added.md
+++ b/changelog.d/next/895.added.md
@@ -1,1 +1,0 @@
-Home screen widgets foundation with Glance, including price widget as the first implementation

--- a/changelog.d/next/904.fixed.md
+++ b/changelog.d/next/904.fixed.md
@@ -1,1 +1,0 @@
-Align onboarding slides and Create Wallet screen image size, spacing, and dots layout with iOS

--- a/changelog.d/next/907.fixed.md
+++ b/changelog.d/next/907.fixed.md
@@ -1,1 +1,0 @@
-Align tab colors, Show details button, notifications bell figure, and home activity count with iOS

--- a/changelog.d/next/914.changed.md
+++ b/changelog.d/next/914.changed.md
@@ -1,1 +1,0 @@
-Redesign price widget with v61 wide and compact layouts, new preview and edit screens, and tap-to-edit behavior

--- a/changelog.d/next/916.changed.md
+++ b/changelog.d/next/916.changed.md
@@ -1,1 +1,0 @@
-Activity, Shop and Settings now keep their tabs pinned with a drop shadow as content scrolls behind them, the Add Widget button shows its icon, and the Shop list has more bottom spacing.

--- a/changelog.d/next/917.added.md
+++ b/changelog.d/next/917.added.md
@@ -1,1 +1,0 @@
-Return to Bitkit after Pubky Ring approval, cancellation, or error callbacks

--- a/changelog.d/next/919.added.md
+++ b/changelog.d/next/919.added.md
@@ -1,1 +1,0 @@
-Headlines home screen widget with v61 wide and compact layouts, including redesigned in-app preview and edit screens

--- a/changelog.d/next/922.added.md
+++ b/changelog.d/next/922.added.md
@@ -1,1 +1,0 @@
-Bitcoin Blocks home screen widget with v61 wide and compact layouts, including redesigned in-app preview and edit screens

--- a/changelog.d/next/924.added.md
+++ b/changelog.d/next/924.added.md
@@ -1,1 +1,0 @@
-Support public Paykit contact payments.

--- a/changelog.d/next/925.fixed.md
+++ b/changelog.d/next/925.fixed.md
@@ -1,1 +1,0 @@
-Payment QR scans now route reliably and avoid unnecessary delays when Lightning channels are unavailable.

--- a/changelog.d/next/926.added.md
+++ b/changelog.d/next/926.added.md
@@ -1,1 +1,0 @@
-Bitcoin Facts home screen widget with v61 wide and compact layouts, including redesigned in-app facts card and preview screen

--- a/changelog.d/next/927.added.md
+++ b/changelog.d/next/927.added.md
@@ -1,1 +1,0 @@
-Bitcoin Weather home screen widget with v61 wide and compact layouts, including redesigned in-app weather card, preview, and edit screens

--- a/changelog.d/next/929.fixed.md
+++ b/changelog.d/next/929.fixed.md
@@ -1,1 +1,0 @@
-Fix gift card flow showing false-positive confetti when the LSP payment fails, and re-opening unexpectedly after an app language change.

--- a/changelog.d/next/931.fixed.md
+++ b/changelog.d/next/931.fixed.md
@@ -1,1 +1,0 @@
-Improved public contact payment flows for manual Pubky entry, add-contact payments, and RBF activity display.

--- a/changelog.d/next/935.fixed.md
+++ b/changelog.d/next/935.fixed.md
@@ -1,1 +1,0 @@
-Fix several OS widget issues including an intermittent crash when removing or cancelling a home screen widget, ordering of widget options, and the color of disabled checkboxes in widget configuration screens.

--- a/changelog.d/next/936.added.md
+++ b/changelog.d/next/936.added.md
@@ -1,1 +1,0 @@
-Added private Paykit contact payments with dedicated contact endpoints, rotation, cleanup, and restore-safe address reservations.

--- a/changelog.d/next/942.changed.md
+++ b/changelog.d/next/942.changed.md
@@ -1,1 +1,0 @@
-Redesigned the Bitcoin Calculator widget to v61 design and replaced the OS keyboard with a dark-themed in-app numpad

--- a/changelog.d/next/945.added.md
+++ b/changelog.d/next/945.added.md
@@ -1,1 +1,0 @@
-Added contact payment flows, activity contact attribution, and payment preference controls for private payments.

--- a/changelog.d/next/952.fixed.md
+++ b/changelog.d/next/952.fixed.md
@@ -1,1 +1,0 @@
-Improved OS widgets so previews, settings, currency display, and OS-home interactions match v61 design iteration.

--- a/changelog.d/next/954.changed.md
+++ b/changelog.d/next/954.changed.md
@@ -1,1 +1,0 @@
-Hide experimental Paykit profile, contacts, and contact payment controls behind a developer setting.

--- a/changelog.d/next/961.added.md
+++ b/changelog.d/next/961.added.md
@@ -1,1 +1,0 @@
-Added BTCPay wallet connection support for sharing Bitcoin receive descriptors.

--- a/changelog.d/next/969.fixed.md
+++ b/changelog.d/next/969.fixed.md
@@ -1,1 +1,0 @@
-Improved logs, support diagnostics and channel peer recovery after wallet restore.

--- a/changelog.d/next/971.fixed.md
+++ b/changelog.d/next/971.fixed.md
@@ -1,1 +1,0 @@
-The Support page now shows the current copyright year automatically.

--- a/changelog.d/next/972.changed.md
+++ b/changelog.d/next/972.changed.md
@@ -1,1 +1,0 @@
-The add widget experience now opens as a bottom-sheet flow with in-sheet previews instead of full-screen picker pages.

--- a/changelog.d/next/974.added.md
+++ b/changelog.d/next/974.added.md
@@ -1,1 +1,0 @@
-Added a Legacy Recovery option in developer settings to help recover funds from affected legacy channel closes.

--- a/changelog.d/next/978.fixed.md
+++ b/changelog.d/next/978.fixed.md
@@ -1,1 +1,0 @@
-Android home-screen widgets now refresh after unlocking and keep retrying with backoff while connectivity is still coming back.

--- a/changelog.d/next/979.fixed.md
+++ b/changelog.d/next/979.fixed.md
@@ -1,1 +1,0 @@
-Improved BTCPay setup link handling so Bitkit opens supported connection links reliably and shows clearer setup errors.

--- a/changelog.d/next/985.added.md
+++ b/changelog.d/next/985.added.md
@@ -1,1 +1,0 @@
-Home widgets can now be resized between compact and wide from the preview sheet, with a redesigned two-column grid, inline edit mode, and an interactive compact calculator.

--- a/changelog.d/next/987.fixed.md
+++ b/changelog.d/next/987.fixed.md
@@ -1,1 +1,0 @@
-Bitkit no longer crashes when Android stops the background Lightning node service.

--- a/changelog.d/next/989.fixed.md
+++ b/changelog.d/next/989.fixed.md
@@ -1,1 +1,0 @@
-Bitkit now handles unexpected native on-chain lookup failures without crashing.

--- a/changelog.d/next/990.fixed.md
+++ b/changelog.d/next/990.fixed.md
@@ -1,1 +1,0 @@
-New widgets now open on compact size in the preview carousel, matching iOS, and the add-widgets list keeps its scroll position when navigating back.


### PR DESCRIPTION
Bump version to 2.3.0 (build 182) for release.

### Description

- `versionCode`: 181 → 182
- `versionName`: 2.2.0 → 2.3.0
- Collected changelog fragments and finalized `CHANGELOG.md` for 2.3.0

### Preview

N/A

### QA Notes

N/A

Made with [Cursor](https://cursor.com)