### PR TITLE
test: add probeNode devtools command

### DIFF
--- a/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
+++ b/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
@@ -62,6 +62,7 @@ private sealed interface DevCommand {
         fun parse(method: String, arg: String?): DevCommand? = when (method) {
             CreateInvoice.METHOD -> CreateInvoice.parse(arg)
             ProbeInvoice.METHOD -> ProbeInvoice.parse(arg)
+            ProbeNode.METHOD -> ProbeNode.parse(arg)
             ProbeReadiness.METHOD -> ProbeReadiness
             else -> null
         }
@@ -113,6 +114,45 @@ private sealed interface DevCommand {
             )
 
             return deps.lightningRepo().sendProbeForInvoice(args.bolt11, amountSats)
+                .fold(
+                    onSuccess = {
+                        deps.lightningRepo().waitForProbeOutcome(it.paymentIds, timeout)
+                            .fold(
+                                onSuccess = { outcome -> outcome.toDevResult(it.paymentIds) },
+                                onFailure = { error -> DevResult.ProbeFailure.from(error, it.paymentIds) },
+                            )
+                    },
+                    onFailure = { DevResult.ProbeFailure.from(it) },
+                )
+        }
+    }
+
+    data class ProbeNode(val args: Args) : DevCommand {
+        companion object {
+            const val METHOD = "probeNode"
+            fun parse(arg: String?) = ProbeNode(arg.deserialize<Args>())
+        }
+
+        @Serializable
+        data class Args(
+            val targetName: String? = null,
+            val nodeId: String,
+            val amountMsat: ULong? = null,
+            val amountSats: ULong? = null,
+            val timeoutSeconds: Long = 90,
+        )
+
+        override suspend fun execute(deps: DevToolsProvider.Dependencies): DevResult {
+            val amountSats = args.amountSats ?: args.amountMsat?.let { msatCeilOf(it) }
+                ?: return DevResult.Error("Probe node requires amountSats or amountMsat")
+            val timeout = args.timeoutSeconds.coerceAtLeast(1).seconds
+
+            Logger.info(
+                "Sending keysend probe for target '${args.targetName ?: "unknown"}' nodeId='${args.nodeId}' amountSats='$amountSats'",
+                context = TAG,
+            )
+
+            return deps.lightningRepo().sendProbeForNode(args.nodeId, amountSats)
                 .fold(
                     onSuccess = {
                         deps.lightningRepo().waitForProbeOutcome(it.paymentIds, timeout)


### PR DESCRIPTION
Closes #1000

This PR adds a `probeNode` devtools command for mainnet keysend probe targets used by nightly Lightning monitoring.

### Description

- Adds `ProbeNode` to the debug devtools ContentProvider, mirroring the existing invoice probe flow
- Accepts `nodeId`, `amountSats`/`amountMsat`, `targetName`, and `timeoutSeconds` over adb
- Delegates to `LightningRepo.sendProbeForNode()` and returns the same success/failure JSON shape as `probeInvoice`

Pairs with:
- synonymdev/bitkit-e2e-tests#177
- synonymdev/bitkit-nightly#22

### Preview

<!-- N/A — devtools-only change, no UI -->

### QA Notes

#### Manual Tests

- [x] **1.** Build mainnet debug E2E APK → install on emulator/device with probe wallet.
- [x] **2.** With node running, adb shell content call to `probeNode` with a known pubkey and 1000 sats → JSON success response.
- [x] **3.** `regression:` adb shell content call to `probeInvoice` with a test BOLT11 → still returns expected success/failure JSON.

#### Automated Checks

- `just compile` passed locally.
- Existing `LightningRepoTest.sendProbeForNode` covers repo delegation; no new unit tests for devtools (same precedent as `probeInvoice`).
- CI: standard compile, unit test, and detekt checks run by the PR bot.

Made with [Cursor](https://cursor.com)