### PR TITLE
fix: request notification permission on enable

### DIFF
--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -1382,10 +1382,18 @@ private fun NavGraphBuilder.generalSettingsSubScreens(
     }
 
     composableWithDefaultTransitions<Routes.BackgroundPaymentsIntro> {
+        val notificationPermissionLauncher = rememberLauncherForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { granted ->
+            settingsViewModel.setNotificationPreference(granted)
+        }
         BackgroundPaymentsIntroScreen(
             onBack = { navController.popBackStack() },
             onLater = { navController.popBackStack() },
             onEnable = {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
                 navController.navigateTo(Routes.BackgroundPaymentsSettings)
             },
         )

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -200,6 +200,7 @@ import to.bitkit.ui.utils.AutoReadClipboardHandler
 import to.bitkit.ui.utils.RequestNotificationPermissions
 import to.bitkit.ui.utils.composableWithDefaultTransitions
 import to.bitkit.ui.utils.navigationWithDefaultTransitions
+import to.bitkit.ui.utils.rememberRequestNotificationPermission
 import to.bitkit.utils.Logger
 import to.bitkit.viewmodels.ActivityListViewModel
 import to.bitkit.viewmodels.AppViewModel
@@ -241,11 +242,10 @@ fun ContentView(
     val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
     val walletExists = walletUiState.walletExists
 
-    val notificationPermissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { granted ->
-        settingsViewModel.setNotificationPreference(granted)
-    }
+    val requestNotificationPermission = rememberRequestNotificationPermission(
+        onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
+        onPreTiramisu = { navController.navigateTo(Routes.BackgroundPaymentsSettings) },
+    )
 
     // Effects on app entering fg (ON_START) / bg (ON_STOP)
     DisposableEffect(lifecycle) {
@@ -512,15 +512,7 @@ fun ContentView(
                                         onEnable = {
                                             appViewModel.dismissTimedSheet()
                                             settingsViewModel.setBgPaymentsIntroSeen(true)
-                                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                                notificationPermissionLauncher.launch(
-                                                    Manifest.permission.POST_NOTIFICATIONS
-                                                )
-                                            } else {
-                                                // Pre-13 has no runtime permission dialog; open the
-                                                // in-app background payments settings instead.
-                                                navController.navigateTo(Routes.BackgroundPaymentsSettings)
-                                            }
+                                            requestNotificationPermission()
                                         },
                                     )
                                 }

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -2,7 +2,11 @@
 
 package to.bitkit.ui
 
+import android.Manifest
 import android.content.Intent
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.DrawerState
@@ -236,6 +240,12 @@ fun ContentView(
     val isRecoveryMode by walletViewModel.isRecoveryMode.collectAsStateWithLifecycle()
     val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
     val walletExists = walletUiState.walletExists
+
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        settingsViewModel.setNotificationPreference(granted)
+    }
 
     // Effects on app entering fg (ON_START) / bg (ON_STOP)
     DisposableEffect(lifecycle) {
@@ -501,8 +511,12 @@ fun ContentView(
                                         },
                                         onEnable = {
                                             appViewModel.dismissTimedSheet()
-                                            navController.navigateTo(Routes.BackgroundPaymentsSettings)
                                             settingsViewModel.setBgPaymentsIntroSeen(true)
+                                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                                notificationPermissionLauncher.launch(
+                                                    Manifest.permission.POST_NOTIFICATIONS
+                                                )
+                                            }
                                         },
                                     )
                                 }
@@ -896,8 +910,10 @@ private fun NavGraphBuilder.home(
         val isRecoveryMode by walletViewModel.isRecoveryMode.collectAsStateWithLifecycle()
         val hazeState = rememberHazeState()
 
+        // Only keep notification permission state in sync; the system dialog is requested
+        // from the background payments intro sheet, not automatically on the home screen.
         RequestNotificationPermissions(
-            showPermissionDialog = !isRecoveryMode,
+            showPermissionDialog = false,
             onPermissionChange = { granted ->
                 settingsViewModel.setNotificationPreference(granted)
             }

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -516,6 +516,10 @@ fun ContentView(
                                                 notificationPermissionLauncher.launch(
                                                     Manifest.permission.POST_NOTIFICATIONS
                                                 )
+                                            } else {
+                                                // Pre-13 has no runtime permission dialog; open the
+                                                // in-app background payments settings instead.
+                                                navController.navigateTo(Routes.BackgroundPaymentsSettings)
                                             }
                                         },
                                     )

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingConfirmScreen.kt
@@ -66,6 +66,7 @@ import to.bitkit.ui.theme.AppSwitchDefaults
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.utils.RequestNotificationPermissions
+import to.bitkit.ui.utils.rememberRequestNotificationPermission
 import to.bitkit.ui.utils.withAccent
 import to.bitkit.viewmodels.SettingsViewModel
 import to.bitkit.viewmodels.TransferViewModel
@@ -100,6 +101,11 @@ fun SpendingConfirmScreen(
         showPermissionDialog = false,
     )
 
+    val requestNotificationPermission = rememberRequestNotificationPermission(
+        onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
+        onPreTiramisu = { context.openNotificationSettings() },
+    )
+
     Box {
         Content(
             onBackClick = onBackClick,
@@ -110,7 +116,7 @@ fun SpendingConfirmScreen(
             onTransferToSpendingConfirm = viewModel::onTransferToSpendingConfirm,
             order = order,
             hasNotificationPermission = notificationsGranted,
-            onSwitchClick = { context.openNotificationSettings() },
+            onSwitchClick = requestNotificationPermission,
             isAdvanced = isAdvanced,
         )
         AnimatedVisibility(
@@ -224,6 +230,7 @@ private fun Content(
                     isChecked = hasNotificationPermission,
                     colors = AppSwitchDefaults.colorsPurple,
                     onClick = onSwitchClick,
+                    switchTestTag = "SpendingConfirmNotificationSwitch",
                     modifier = Modifier.fillMaxWidth()
                 )
 

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingConfirmScreen.kt
@@ -66,7 +66,7 @@ import to.bitkit.ui.theme.AppSwitchDefaults
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.utils.RequestNotificationPermissions
-import to.bitkit.ui.utils.rememberRequestNotificationPermission
+import to.bitkit.ui.utils.rememberNotificationToggleClick
 import to.bitkit.ui.utils.withAccent
 import to.bitkit.viewmodels.SettingsViewModel
 import to.bitkit.viewmodels.TransferViewModel
@@ -101,9 +101,10 @@ fun SpendingConfirmScreen(
         showPermissionDialog = false,
     )
 
-    val requestNotificationPermission = rememberRequestNotificationPermission(
+    val onNotificationSwitchClick = rememberNotificationToggleClick(
+        isGranted = notificationsGranted,
         onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
-        onPreTiramisu = { context.openNotificationSettings() },
+        onOpenSystemSettings = { context.openNotificationSettings() },
     )
 
     Box {
@@ -116,7 +117,7 @@ fun SpendingConfirmScreen(
             onTransferToSpendingConfirm = viewModel::onTransferToSpendingConfirm,
             order = order,
             hasNotificationPermission = notificationsGranted,
-            onSwitchClick = requestNotificationPermission,
+            onSwitchClick = onNotificationSwitchClick,
             isAdvanced = isAdvanced,
         )
         AnimatedVisibility(

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveConfirmScreen.kt
@@ -43,6 +43,7 @@ import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppSwitchDefaults
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.utils.rememberRequestNotificationPermission
 import to.bitkit.ui.utils.withAccent
 import to.bitkit.viewmodels.SettingsViewModel
 
@@ -89,6 +90,11 @@ fun ReceiveConfirmScreen(
         } ?: sats.toString()
     }
 
+    val requestNotificationPermission = rememberRequestNotificationPermission(
+        onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
+        onPreTiramisu = { context.openNotificationSettings() },
+    )
+
     Content(
         receiveSats = entry.receiveAmountSats,
         networkFeeFormatted = networkFeeFormatted,
@@ -96,7 +102,7 @@ fun ReceiveConfirmScreen(
         receiveAmountFormatted = receiveAmountFormatted,
         onLearnMoreClick = onLearnMore,
         isAdditional = isAdditional,
-        onSystemSettingsClick = { context.openNotificationSettings() },
+        onSystemSettingsClick = requestNotificationPermission,
         hasNotificationPermission = notificationsGranted,
         onContinueClick = { onContinue(entry.invoice) },
         onBackClick = onBack,
@@ -162,6 +168,7 @@ private fun Content(
                 isChecked = hasNotificationPermission,
                 colors = AppSwitchDefaults.colorsPurple,
                 onClick = onSystemSettingsClick,
+                switchTestTag = "ReceiveConfirmNotificationSwitch",
                 modifier = Modifier.fillMaxWidth()
             )
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveConfirmScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveConfirmScreen.kt
@@ -43,7 +43,7 @@ import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppSwitchDefaults
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
-import to.bitkit.ui.utils.rememberRequestNotificationPermission
+import to.bitkit.ui.utils.rememberNotificationToggleClick
 import to.bitkit.ui.utils.withAccent
 import to.bitkit.viewmodels.SettingsViewModel
 
@@ -90,9 +90,10 @@ fun ReceiveConfirmScreen(
         } ?: sats.toString()
     }
 
-    val requestNotificationPermission = rememberRequestNotificationPermission(
+    val onNotificationSwitchClick = rememberNotificationToggleClick(
+        isGranted = notificationsGranted,
         onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
-        onPreTiramisu = { context.openNotificationSettings() },
+        onOpenSystemSettings = { context.openNotificationSettings() },
     )
 
     Content(
@@ -102,7 +103,7 @@ fun ReceiveConfirmScreen(
         receiveAmountFormatted = receiveAmountFormatted,
         onLearnMoreClick = onLearnMore,
         isAdditional = isAdditional,
-        onSystemSettingsClick = requestNotificationPermission,
+        onSystemSettingsClick = onNotificationSwitchClick,
         hasNotificationPermission = notificationsGranted,
         onContinueClick = { onContinue(entry.invoice) },
         onBackClick = onBack,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveLiquidityScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveLiquidityScreen.kt
@@ -154,6 +154,7 @@ private fun Content(
                 isChecked = hasNotificationPermission,
                 colors = AppSwitchDefaults.colorsPurple,
                 onClick = onSwitchClick,
+                switchTestTag = "ReceiveLiquidityNotificationSwitch",
                 modifier = Modifier.fillMaxWidth()
             )
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
@@ -31,6 +31,7 @@ import to.bitkit.ui.openNotificationSettings
 import to.bitkit.ui.screens.wallets.send.AddTagScreen
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.utils.composableWithDefaultTransitions
+import to.bitkit.ui.utils.rememberRequestNotificationPermission
 import to.bitkit.ui.walletViewModel
 import to.bitkit.viewmodels.AmountInputViewModel
 import to.bitkit.viewmodels.SettingsViewModel
@@ -150,13 +151,17 @@ fun ReceiveSheet(
                     cjitEntryDetails.value?.let { entryDetails ->
                         val context = LocalContext.current
                         val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
+                        val requestNotificationPermission = rememberRequestNotificationPermission(
+                            onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
+                            onPreTiramisu = { context.openNotificationSettings() },
+                        )
 
                         ReceiveLiquidityScreen(
                             entry = entryDetails,
                             onContinue = { navController.popBackStack() },
                             onBack = { navController.popBackStack() },
                             hasNotificationPermission = notificationsGranted,
-                            onSwitchClick = { context.openNotificationSettings() },
+                            onSwitchClick = requestNotificationPermission,
                         )
                     }
                 }
@@ -164,6 +169,10 @@ fun ReceiveSheet(
                     cjitEntryDetails.value?.let { entryDetails ->
                         val context = LocalContext.current
                         val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
+                        val requestNotificationPermission = rememberRequestNotificationPermission(
+                            onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
+                            onPreTiramisu = { context.openNotificationSettings() },
+                        )
 
                         ReceiveLiquidityScreen(
                             entry = entryDetails,
@@ -171,7 +180,7 @@ fun ReceiveSheet(
                             isAdditional = true,
                             onBack = { navController.popBackStack() },
                             hasNotificationPermission = notificationsGranted,
-                            onSwitchClick = { context.openNotificationSettings() },
+                            onSwitchClick = requestNotificationPermission,
                         )
                     }
                 }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/receive/ReceiveSheet.kt
@@ -31,7 +31,7 @@ import to.bitkit.ui.openNotificationSettings
 import to.bitkit.ui.screens.wallets.send.AddTagScreen
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.utils.composableWithDefaultTransitions
-import to.bitkit.ui.utils.rememberRequestNotificationPermission
+import to.bitkit.ui.utils.rememberNotificationToggleClick
 import to.bitkit.ui.walletViewModel
 import to.bitkit.viewmodels.AmountInputViewModel
 import to.bitkit.viewmodels.SettingsViewModel
@@ -151,9 +151,10 @@ fun ReceiveSheet(
                     cjitEntryDetails.value?.let { entryDetails ->
                         val context = LocalContext.current
                         val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
-                        val requestNotificationPermission = rememberRequestNotificationPermission(
+                        val onNotificationSwitchClick = rememberNotificationToggleClick(
+                            isGranted = notificationsGranted,
                             onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
-                            onPreTiramisu = { context.openNotificationSettings() },
+                            onOpenSystemSettings = { context.openNotificationSettings() },
                         )
 
                         ReceiveLiquidityScreen(
@@ -161,7 +162,7 @@ fun ReceiveSheet(
                             onContinue = { navController.popBackStack() },
                             onBack = { navController.popBackStack() },
                             hasNotificationPermission = notificationsGranted,
-                            onSwitchClick = requestNotificationPermission,
+                            onSwitchClick = onNotificationSwitchClick,
                         )
                     }
                 }
@@ -169,9 +170,10 @@ fun ReceiveSheet(
                     cjitEntryDetails.value?.let { entryDetails ->
                         val context = LocalContext.current
                         val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
-                        val requestNotificationPermission = rememberRequestNotificationPermission(
+                        val onNotificationSwitchClick = rememberNotificationToggleClick(
+                            isGranted = notificationsGranted,
                             onPermissionResult = { granted -> settingsViewModel.setNotificationPreference(granted) },
-                            onPreTiramisu = { context.openNotificationSettings() },
+                            onOpenSystemSettings = { context.openNotificationSettings() },
                         )
 
                         ReceiveLiquidityScreen(
@@ -180,7 +182,7 @@ fun ReceiveSheet(
                             isAdditional = true,
                             onBack = { navController.popBackStack() },
                             hasNotificationPermission = notificationsGranted,
-                            onSwitchClick = requestNotificationPermission,
+                            onSwitchClick = onNotificationSwitchClick,
                         )
                     }
                 }

--- a/app/src/main/java/to/bitkit/ui/utils/RequestNotificationPermissions.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/RequestNotificationPermissions.kt
@@ -98,3 +98,25 @@ fun rememberRequestNotificationPermission(
         }
     }
 }
+
+@Composable
+fun rememberNotificationToggleClick(
+    isGranted: Boolean,
+    onPermissionResult: (Boolean) -> Unit,
+    onOpenSystemSettings: () -> Unit,
+): () -> Unit {
+    val requestPermission = rememberRequestNotificationPermission(
+        onPermissionResult = onPermissionResult,
+        onPreTiramisu = onOpenSystemSettings,
+    )
+    val currentIsGranted by rememberUpdatedState(isGranted)
+    val currentOnOpenSystemSettings by rememberUpdatedState(onOpenSystemSettings)
+
+    return remember(requestPermission) {
+        {
+            // Already granted: the runtime request is a no-op, so send the user to system
+            // settings where they can actually turn notifications off.
+            if (currentIsGranted) currentOnOpenSystemSettings() else requestPermission()
+        }
+    }
+}

--- a/app/src/main/java/to/bitkit/ui/utils/RequestNotificationPermissions.kt
+++ b/app/src/main/java/to/bitkit/ui/utils/RequestNotificationPermissions.kt
@@ -72,3 +72,29 @@ fun RequestNotificationPermissions(
         }
     }
 }
+
+@Composable
+fun rememberRequestNotificationPermission(
+    onPermissionResult: (Boolean) -> Unit,
+    onPreTiramisu: () -> Unit,
+): () -> Unit {
+    val currentOnPermissionResult by rememberUpdatedState(onPermissionResult)
+    val currentOnPreTiramisu by rememberUpdatedState(onPreTiramisu)
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        currentOnPermissionResult(granted)
+    }
+
+    return remember(launcher) {
+        {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                // Pre-13 has no runtime permission dialog; defer to the caller-provided fallback.
+                currentOnPreTiramisu()
+            }
+        }
+    }
+}

--- a/changelog.d/next/1004.fixed.md
+++ b/changelog.d/next/1004.fixed.md
@@ -1,0 +1,1 @@
+The system notification permission dialog is now only requested when you tap Enable on the background payments prompt, instead of appearing automatically on every app open.

--- a/journeys/notification-permission/README.md
+++ b/journeys/notification-permission/README.md
@@ -1,0 +1,59 @@
+# Notification-permission journeys
+
+These journeys exercise the notification-permission request triggered by the
+"Set up in background" toggle that backs Bitkit's background-payments setup.
+
+The behaviour was changed on `fix/limit-system-notification-permission`: tapping the
+toggle now goes through the shared `rememberRequestNotificationPermission` helper
+(`ui/utils/RequestNotificationPermissions.kt`) instead of jumping straight to the
+system notification settings.
+
+## What the fix does
+- **Android 13+ (API 33, TIRAMISU)**: tapping the toggle launches the OS
+  `POST_NOTIFICATIONS` runtime permission dialog. Granting it flips the toggle to
+  checked; the result is persisted via `SettingsViewModel.setNotificationPreference`.
+- **Pre-13 (API < 33)**: there is no runtime dialog, so the toggle falls back to the
+  caller's `onPreTiramisu` action — the in-app background-payments settings on the
+  intro sheet, the system notification settings on the transfer/receive toggles.
+
+The same helper backs four entry points; these journeys cover the three the user can
+reach directly:
+- **Transfer → Spending confirm** (`SpendingConfirmScreen`)
+- **Receive → CJIT confirm** (`ReceiveConfirmScreen`)
+- **Receive → CJIT liquidity** (`ReceiveLiquidityScreen`, via "Learn more")
+
+## Mandatory setup
+1. **Use an API 33+ device** to verify the runtime-dialog path. On API < 33 the dialog
+   never appears — only the system-settings fallback is exercised.
+2. **Start from a fresh notification-permission state.** The OS only shows the
+   `POST_NOTIFICATIONS` dialog while the permission is in the "ask" state. Once granted
+   or denied it will not show again, and the journey will silently pass for the wrong
+   reason. Reset before each run:
+   `adb shell pm revoke to.bitkit.dev android.permission.POST_NOTIFICATIONS`
+   (or reinstall / clear app data).
+3. **Node must be connected to the LSP (Blocktank).** Both the Transfer→Spending and
+   Receive→CJIT confirm screens need a real order quoted by Blocktank before the toggle
+   screen renders. With the hosted staging backend this is `api.stag0.blocktank.to`.
+4. **Transfer→Spending also needs a positive on-chain Savings balance** so a real max can
+   be quoted. Fund + mine via the `blocktank-api:lsp` skill, then wait for the balance to
+   sync.
+
+## Gotchas
+- **The permission dialog is one-shot** — see setup #2. Always revoke/reset first.
+- **Blocktank must be reachable.** If `api.stag0.blocktank.to:443` is down, CJIT/order
+  creation hangs on a spinner at "Continue" and the confirm screen never appears, so the
+  toggle is unreachable. Verify the host first:
+  `curl -s -m 8 -o /dev/null -w '%{http_code}\n' https://api.stag0.blocktank.to/blocktank/api/v2/info`
+  (`000` = down). This is infra, not the toggle.
+- The system permission dialog is **OS UI**, not Compose — locate its buttons with
+  `android screen --annotate` (text "Allow" / "Don't allow"), not `android layout` tags.
+- On grant, the toggle reflects `notificationsGranted`; it only flips to checked once the
+  `ON_RESUME` re-check or the launcher callback fires.
+
+## Test tags
+- Transfer→Spending toggle switch: `SpendingConfirmNotificationSwitch`
+- Receive→CJIT confirm toggle switch: `ReceiveConfirmNotificationSwitch`
+- Receive→CJIT liquidity toggle switch: `ReceiveLiquidityNotificationSwitch`
+- Spending amount screen: `SpendingAmount`, continue `SpendingAmountContinue`,
+  available/max `SpendingAmountAvailable` / `SpendingAmountMax`.
+- The toggle label on all screens is "Set up in background".

--- a/journeys/notification-permission/README.md
+++ b/journeys/notification-permission/README.md
@@ -9,12 +9,15 @@ toggle now goes through the shared `rememberRequestNotificationPermission` helpe
 system notification settings.
 
 ## What the fix does
-- **Android 13+ (API 33, TIRAMISU)**: tapping the toggle launches the OS
+- **Toggle OFF (permission already granted)**: re-requesting a granted permission is a
+  no-op, so tapping opens the **system notification settings** (`openNotificationSettings`)
+  where the user can actually turn notifications off — the behaviour these toggles had
+  before the refactor.
+- **Toggle ON, Android 13+ (API 33, TIRAMISU)**: tapping launches the OS
   `POST_NOTIFICATIONS` runtime permission dialog. Granting it flips the toggle to
   checked; the result is persisted via `SettingsViewModel.setNotificationPreference`.
-- **Pre-13 (API < 33)**: there is no runtime dialog, so the toggle falls back to the
-  caller's `onPreTiramisu` action — the in-app background-payments settings on the
-  intro sheet, the system notification settings on the transfer/receive toggles.
+- **Toggle ON, pre-13 (API < 33)**: there is no runtime dialog, so it falls back to the
+  system notification settings.
 
 The same helper backs four entry points; these journeys cover the three the user can
 reach directly:

--- a/journeys/notification-permission/receive-cjit-confirm-notification-toggle.xml
+++ b/journeys/notification-permission/receive-cjit-confirm-notification-toggle.xml
@@ -1,0 +1,23 @@
+<journey name="receive cjit confirm toggle requests notification permission">
+  <description>
+    Verifies that the "Set up in background" toggle on the Receive → CJIT confirm screen
+    (ReceiveConfirmScreen) launches the Android POST_NOTIFICATIONS runtime permission
+    dialog on API 33+, and that granting it checks the toggle.
+
+    Precondition: API 33+ onboarded dev wallet with the node connected to the LSP so a
+    CJIT order can be quoted, and POST_NOTIFICATIONS in the "ask" state (revoke or
+    reinstall first — the dialog is one-shot). Start on the wallet home screen.
+  </description>
+  <actions>
+    <action>Tap the "Receive" button on the home screen</action>
+    <action>Tap the "Spending" tab in the Receive sheet</action>
+    <action>Tap "Receive Lightning funds"</action>
+    <action>On the amount screen, enter an amount above the CJIT minimum (e.g. 100 000 sats) using the number pad</action>
+    <action>Tap "Continue" and wait for the CJIT order to be created and the confirm screen ("To set up your spending balance...") to appear</action>
+    <action>Verify the "Set up in background" toggle (testTag "ReceiveConfirmNotificationSwitch") is visible and unchecked</action>
+    <action>Tap the "Set up in background" toggle</action>
+    <action>Verify the Android system notification permission dialog appears (text like "Allow Bitkit to send you notifications?")</action>
+    <action>Tap "Allow"</action>
+    <action>Verify the "Set up in background" toggle is now checked</action>
+  </actions>
+</journey>

--- a/journeys/notification-permission/receive-cjit-liquidity-notification-toggle.xml
+++ b/journeys/notification-permission/receive-cjit-liquidity-notification-toggle.xml
@@ -1,0 +1,25 @@
+<journey name="receive cjit liquidity toggle requests notification permission">
+  <description>
+    Verifies that the "Set up in background" toggle on the Receive → CJIT liquidity screen
+    (ReceiveLiquidityScreen, reached via "Learn more" from the confirm screen) launches the
+    Android POST_NOTIFICATIONS runtime permission dialog on API 33+, and that granting it
+    checks the toggle.
+
+    Precondition: API 33+ onboarded dev wallet with the node connected to the LSP so a CJIT
+    order can be quoted, and POST_NOTIFICATIONS in the "ask" state (revoke or reinstall
+    first — the dialog is one-shot). Start on the wallet home screen.
+  </description>
+  <actions>
+    <action>Tap the "Receive" button on the home screen</action>
+    <action>Tap the "Spending" tab in the Receive sheet</action>
+    <action>Tap "Receive Lightning funds"</action>
+    <action>On the amount screen, enter an amount above the CJIT minimum (e.g. 100 000 sats) using the number pad</action>
+    <action>Tap "Continue" and wait for the confirm screen to appear</action>
+    <action>Tap "Learn more" to open the liquidity screen</action>
+    <action>Verify the liquidity screen with the lightning channel and the "Set up in background" toggle (testTag "ReceiveLiquidityNotificationSwitch") is visible and unchecked</action>
+    <action>Tap the "Set up in background" toggle</action>
+    <action>Verify the Android system notification permission dialog appears (text like "Allow Bitkit to send you notifications?")</action>
+    <action>Tap "Allow"</action>
+    <action>Verify the "Set up in background" toggle is now checked</action>
+  </actions>
+</journey>

--- a/journeys/notification-permission/toggle-off-opens-system-settings.xml
+++ b/journeys/notification-permission/toggle-off-opens-system-settings.xml
@@ -1,0 +1,24 @@
+<journey name="notification toggle off opens system settings">
+  <description>
+    Verifies that when the "Set up in background" toggle is already ON (POST_NOTIFICATIONS
+    granted), tapping it opens the system notification settings instead of re-requesting the
+    permission (which would be a no-op). Uses the Receive → CJIT confirm screen, but the
+    behaviour is shared by the transfer and liquidity toggles.
+
+    Precondition: API 33+ onboarded dev wallet with the node connected to the LSP so a CJIT
+    order can be quoted, and POST_NOTIFICATIONS ALREADY GRANTED so the toggle starts checked
+    (grant via: adb shell pm grant to.bitkit.dev android.permission.POST_NOTIFICATIONS).
+    Start on the wallet home screen.
+  </description>
+  <actions>
+    <action>Tap the "Receive" button on the home screen</action>
+    <action>Tap the "Spending" tab in the Receive sheet</action>
+    <action>Tap "Receive Lightning funds"</action>
+    <action>On the amount screen, enter an amount above the CJIT minimum (e.g. 100 000 sats) using the number pad</action>
+    <action>Tap "Continue" and wait for the confirm screen to appear</action>
+    <action>Verify the "Set up in background" toggle (testTag "ReceiveConfirmNotificationSwitch") is visible and checked</action>
+    <action>Tap the "Set up in background" toggle</action>
+    <action>Verify the Android system notification settings screen for Bitkit opens (no in-app navigation, no permission dialog)</action>
+    <action>Press back to return to Bitkit and verify the confirm screen is still shown</action>
+  </actions>
+</journey>

--- a/journeys/notification-permission/transfer-spending-confirm-notification-toggle.xml
+++ b/journeys/notification-permission/transfer-spending-confirm-notification-toggle.xml
@@ -1,0 +1,25 @@
+<journey name="transfer spending confirm toggle requests notification permission">
+  <description>
+    Verifies that the "Set up in background" toggle on the Transfer → Spending confirm
+    screen (SpendingConfirmScreen) launches the Android POST_NOTIFICATIONS runtime
+    permission dialog on API 33+, and that granting it checks the toggle.
+
+    Precondition: API 33+ onboarded dev wallet with a POSITIVE on-chain Savings balance and
+    the node connected to the LSP (so a real max can be quoted), and POST_NOTIFICATIONS in
+    the "ask" state (revoke or reinstall first — the dialog is one-shot). The spending max
+    starts at 0 behind a spinner — wait for it to populate. Start on the wallet home screen.
+  </description>
+  <actions>
+    <action>Tap the Spending balance card on the home screen</action>
+    <action>Tap "Transfer from Savings"</action>
+    <action>If a transfer intro screen appears, tap "Get Started"</action>
+    <action>On the spending amount screen (testTag "SpendingAmount"), wait until the available/maximum amount (testTag "SpendingAmountAvailable") finishes loading and shows a positive value</action>
+    <action>Enter an amount within the maximum using the number pad</action>
+    <action>Tap continue (testTag "SpendingAmountContinue") and wait for the spending confirm screen to appear</action>
+    <action>Verify the "Set up in background" toggle (testTag "SpendingConfirmNotificationSwitch") is visible and unchecked</action>
+    <action>Tap the "Set up in background" toggle</action>
+    <action>Verify the Android system notification permission dialog appears (text like "Allow Bitkit to send you notifications?")</action>
+    <action>Tap "Allow"</action>
+    <action>Verify the "Set up in background" toggle is now checked</action>
+  </actions>
+</journey>


### PR DESCRIPTION
Closes #566

This PR stops the Android notification permission system dialog from appearing automatically on the home screen, requesting it only when the user taps "Enable" on the background payments prompt.

### Description

The home screen previously asked `RequestNotificationPermissions` to launch the `POST_NOTIFICATIONS` system dialog on every entry while notifications were ungranted, so a user who dismissed it kept getting re-prompted on each app open. Issue #566 asked to gate how often this appears; this aligns Android with the iOS flow, where the dialog is only triggered from the background payments intro sheet's "Enable" button (`NotificationsSheet` → `requestPermission()`).

- The home-screen `RequestNotificationPermissions` now runs with `showPermissionDialog = false`, so it only keeps the granted/denied state in sync (including when the user changes it in system settings); it no longer launches the dialog.
- Tapping "Enable" on the background payments prompt requests the OS notification permission in place and dismisses the sheet; "Later" just dismisses it. "Enable" no longer navigates to the Background Payments settings screen, matching iOS.
- The runtime request is guarded behind Android 13+ (`TIRAMISU`); on older versions, where there is no runtime notification permission, "Enable" simply dismisses.

The background payments prompt itself is unchanged: it still appears only when notifications are not yet granted and the wallet has a Lightning spending balance.

### Preview

[before.webm](https://github.com/user-attachments/assets/05ea790e-139e-4b99-930c-a14bd656f07a)

[allow-flow.webm](https://github.com/user-attachments/assets/8314d9e7-3013-4d7e-870d-477f484e6433)

[deny-flow.webm](https://github.com/user-attachments/assets/3b7de43b-b872-44dc-aeaa-0cebf65fa006)

[suggestion-intro.webm](https://github.com/user-attachments/assets/b642af20-39dd-4598-aadf-797994764653)


[android-11-enable-flow.webm](https://github.com/user-attachments/assets/f3b5d42f-e017-4ab0-9c09-8100e71e1fd4)

[cjit.webm](https://github.com/user-attachments/assets/5fea7cda-299f-436f-a784-d0658e157cdc)

[transfer.webm](https://github.com/user-attachments/assets/404183b2-5e54-41ec-a306-eb29c87c6d51)

### QA Notes

#### Manual Tests

- [x] **1.** LN spending balance + notifications not granted → open app to Home: no system permission dialog appears automatically.
- [x] **2.** Background payments prompt → tap Enable: OS permission dialog appears and the sheet dismisses with no navigation.
- [x] **3.** OS dialog → tap Allow: notifications enabled and the node keeps running in the background.
- [x] **4.** `regression:` Background payments prompt → tap Later: sheet dismisses, no OS dialog.
- [x] **5.** `regression:` Android 12 or below → tap Enable: navigate to payment settings (no runtime permission).

OBS: On Android 12 or bellow, the notifications are enabled by default

#### Automated Checks

- N/A — UI wiring change in `ContentView` only; no business logic added. `just compile` and `just lint` pass.
- CI: standard compile, unit test, and detekt checks run by the PR bot.
