### PR TITLE
feat: add resetScores devtools command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ suspend fun getData(): Result<Data> = withContext(Dispatchers.IO) {
 - ALWAYS check existing code patterns before implementing new features
 - USE existing extensions and utilities rather than creating new ones
 - ALWAYS use or create `Context` extension properties in `ext/Context.kt` instead of raw `context.getSystemService()` casts
+- NEVER use `System.currentTimeMillis()`, use time helpers from `ext/DateTime.kt` instead (e.g. `nowMillis()`, `Clock.nowMs()`) — they accept a `Clock` and are unit-testable
 - ALWAYS apply the YAGNI (You Ain't Gonna Need It) principle for new code
 - ALWAYS reuse existing constants
 - ALWAYS ensure a method exist before calling it

--- a/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
+++ b/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
@@ -64,6 +64,7 @@ private sealed interface DevCommand {
             ProbeInvoice.METHOD -> ProbeInvoice.parse(arg)
             ProbeNode.METHOD -> ProbeNode.parse(arg)
             ProbeReadiness.METHOD -> ProbeReadiness
+            ResetScores.METHOD -> ResetScores
             else -> null
         }
     }
@@ -172,6 +173,21 @@ private sealed interface DevCommand {
         override suspend fun execute(deps: DevToolsProvider.Dependencies): DevResult =
             DevResult.ProbeReadiness.from(deps.lightningRepo().probeReadiness())
     }
+
+    data object ResetScores : DevCommand {
+        const val METHOD = "resetScores"
+
+        override suspend fun execute(deps: DevToolsProvider.Dependencies): DevResult {
+            Logger.info("Resetting pathfinding scores via devtools", context = TAG)
+            return deps.lightningRepo().resetPathfindingScores().fold(
+                onSuccess = { DevResult.Ack() },
+                onFailure = {
+                    Logger.error("Failed to reset pathfinding scores", it, context = TAG)
+                    DevResult.Error(it.message)
+                },
+            )
+        }
+    }
 }
 
 @Serializable
@@ -182,6 +198,8 @@ private sealed interface DevResult {
     }
 
     @Serializable data class Invoice(val bolt11: String) : DevResult
+
+    @Serializable data class Ack(val success: Boolean = true) : DevResult
 
     @Serializable
     data class ProbeSuccess(
@@ -224,6 +242,7 @@ private sealed interface DevResult {
         val graphNodeCount: Int? = null,
         val graphChannelCount: Int? = null,
         val latestRgsSyncTimestamp: ULong? = null,
+        val latestPathfindingScoresSyncTimestamp: ULong? = null,
     ) : DevResult {
         companion object {
             fun from(readiness: NodeProbeReadiness) = ProbeReadiness(
@@ -241,6 +260,7 @@ private sealed interface DevResult {
                 graphNodeCount = readiness.graphNodeCount,
                 graphChannelCount = readiness.graphChannelCount,
                 latestRgsSyncTimestamp = readiness.latestRgsSyncTimestamp,
+                latestPathfindingScoresSyncTimestamp = readiness.latestPathfindingScoresSyncTimestamp,
             )
         }
     }

--- a/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
+++ b/app/src/debug/java/to/bitkit/dev/DevToolsProvider.kt
@@ -180,7 +180,7 @@ private sealed interface DevCommand {
         override suspend fun execute(deps: DevToolsProvider.Dependencies): DevResult {
             Logger.info("Resetting pathfinding scores via devtools", context = TAG)
             return deps.lightningRepo().resetPathfindingScores().fold(
-                onSuccess = { DevResult.Ack() },
+                onSuccess = { DevResult.Ack(timestamp = it) },
                 onFailure = {
                     Logger.error("Failed to reset pathfinding scores", it, context = TAG)
                     DevResult.Error(it.message)
@@ -199,7 +199,7 @@ private sealed interface DevResult {
 
     @Serializable data class Invoice(val bolt11: String) : DevResult
 
-    @Serializable data class Ack(val success: Boolean = true) : DevResult
+    @Serializable data class Ack(val success: Boolean = true, val timestamp: Long? = null) : DevResult
 
     @Serializable
     data class ProbeSuccess(

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -61,6 +61,7 @@ import to.bitkit.di.BgDispatcher
 import to.bitkit.env.Defaults
 import to.bitkit.env.Env
 import to.bitkit.ext.getSatsPerVByteFor
+import to.bitkit.ext.nowMillis
 import to.bitkit.ext.nowTimestamp
 import to.bitkit.ext.toPeerDetailsList
 import to.bitkit.ext.totalNextOutboundHtlcLimitSats
@@ -99,6 +100,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
 
 @Singleton
 @Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
@@ -1629,6 +1631,7 @@ class LightningRepo @Inject constructor(
      * Returns the device epoch seconds captured after the VSS deletes and before the node restart,
      * so callers can require any scores sync timestamp to be strictly newer to prove a post-reset download.
      */
+    @OptIn(ExperimentalTime::class)
     suspend fun resetPathfindingScores(walletIndex: Int = 0): Result<Long> = withContext(bgDispatcher) {
         Logger.info("Resetting pathfinding scores", context = TAG)
 
@@ -1654,7 +1657,7 @@ class LightningRepo @Inject constructor(
             return@withContext Result.failure(it)
         }
 
-        val resetAtSecs = System.currentTimeMillis() / 1000
+        val resetAtSecs = nowMillis() / 1000
 
         start(walletIndex = walletIndex, shouldRetry = false)
             .map { resetAtSecs }

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -1635,12 +1635,18 @@ class LightningRepo @Inject constructor(
         }
 
         runCatching {
+            val lifecycleState = _lightningState.value.nodeLifecycleState
+            check(lifecycleState == NodeLifecycleState.Stopped) {
+                "Node lifecycle changed to '$lifecycleState' during pathfinding scores reset"
+            }
             vssBackupClientLdk.setup(walletIndex).getOrThrow()
             vssBackupClientLdk.deleteObject(VSS_KEY_SCORER).getOrThrow()
             vssBackupClientLdk.deleteObject(VSS_KEY_EXTERNAL_SCORES_CACHE).getOrThrow()
         }.onFailure {
             Logger.error("Failed to delete pathfinding scores from VSS", it, context = TAG)
-            start(walletIndex = walletIndex, shouldRetry = false)
+            start(walletIndex = walletIndex, shouldRetry = false).onFailure { startError ->
+                Logger.error("Failed to restart node after pathfinding scores reset failure", startError, context = TAG)
+            }
             return@withContext Result.failure(it)
         }
 

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -1625,7 +1625,11 @@ class LightningRepo @Inject constructor(
         )
     }
 
-    suspend fun resetPathfindingScores(walletIndex: Int = 0): Result<Unit> = withContext(bgDispatcher) {
+    /**
+     * Returns the device epoch seconds captured after the VSS deletes and before the node restart,
+     * so callers can require any scores sync timestamp to be strictly newer to prove a post-reset download.
+     */
+    suspend fun resetPathfindingScores(walletIndex: Int = 0): Result<Long> = withContext(bgDispatcher) {
         Logger.info("Resetting pathfinding scores", context = TAG)
 
         waitForNodeToStop().onFailure { return@withContext Result.failure(it) }
@@ -1650,9 +1654,13 @@ class LightningRepo @Inject constructor(
             return@withContext Result.failure(it)
         }
 
-        start(walletIndex = walletIndex, shouldRetry = false).onSuccess {
-            Logger.info("Pathfinding scores reset", context = TAG)
-        }
+        val resetAtSecs = System.currentTimeMillis() / 1000
+
+        start(walletIndex = walletIndex, shouldRetry = false)
+            .map { resetAtSecs }
+            .onSuccess {
+                Logger.info("Pathfinding scores reset at '$resetAtSecs'", context = TAG)
+            }
     }
     // endregion
 

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -1620,8 +1620,33 @@ class LightningRepo @Inject constructor(
             graphNodeCount = graph?.nodeCount,
             graphChannelCount = graph?.channelCount,
             latestRgsSyncTimestamp = graph?.latestRgsSyncTimestamp,
+            latestPathfindingScoresSyncTimestamp = state.nodeStatus?.latestPathfindingScoresSyncTimestamp,
             syncHealthy = state.isSyncHealthy,
         )
+    }
+
+    suspend fun resetPathfindingScores(walletIndex: Int = 0): Result<Unit> = withContext(bgDispatcher) {
+        Logger.info("Resetting pathfinding scores", context = TAG)
+
+        waitForNodeToStop().onFailure { return@withContext Result.failure(it) }
+        stop().onFailure {
+            Logger.error("Failed to stop node during pathfinding scores reset", it, context = TAG)
+            return@withContext Result.failure(it)
+        }
+
+        runCatching {
+            vssBackupClientLdk.setup(walletIndex).getOrThrow()
+            vssBackupClientLdk.deleteObject(VSS_KEY_SCORER).getOrThrow()
+            vssBackupClientLdk.deleteObject(VSS_KEY_EXTERNAL_SCORES_CACHE).getOrThrow()
+        }.onFailure {
+            Logger.error("Failed to delete pathfinding scores from VSS", it, context = TAG)
+            start(walletIndex = walletIndex, shouldRetry = false)
+            return@withContext Result.failure(it)
+        }
+
+        start(walletIndex = walletIndex, shouldRetry = false).onSuccess {
+            Logger.info("Pathfinding scores reset", context = TAG)
+        }
     }
     // endregion
 
@@ -1642,6 +1667,8 @@ class LightningRepo @Inject constructor(
     companion object {
         private const val TAG = "LightningRepo"
         private const val LENGTH_CHANNEL_ID_PREVIEW = 10
+        private const val VSS_KEY_SCORER = "scorer"
+        private const val VSS_KEY_EXTERNAL_SCORES_CACHE = "external_pathfinding_scores_cache"
         private const val MS_SYNC_LOOP_DEBOUNCE = 500L
         private const val SYNC_RETRY_DELAY_MS = 15_000L
         private val CHANNELS_USABLE_TIMEOUT = 15.seconds
@@ -1702,6 +1729,7 @@ data class ProbeReadiness(
     val graphNodeCount: Int?,
     val graphChannelCount: Int?,
     val latestRgsSyncTimestamp: ULong?,
+    val latestPathfindingScoresSyncTimestamp: ULong?,
     val syncHealthy: Boolean,
 ) {
     val ready: Boolean


### PR DESCRIPTION
This PR adds a `resetScores` devtools command that wipes the persisted pathfinding scores, so mainnet probe runs can start from a fresh scorer.

### Description

- Adds `ResetScores` to the debug devtools ContentProvider, callable over adb like the existing probe commands
- Delegates to `LightningRepo.resetPathfindingScores()`: stops the node, deletes the `scorer` and `external_pathfinding_scores_cache` VSS keys, then restarts the node (external scores are re-downloaded on startup)
- On VSS delete failure the node is restarted before returning the error, so the wallet is never left stopped
- Exposes `latestPathfindingScoresSyncTimestamp` in the `probeReadiness` response, so e2e can gate probing on a fresh post-reset scores sync

Without the reset, locally learned scores accumulate in VSS under the probe seed across nightly runs (probe results train the scorer), so consecutive scorer A/B runs are not comparable.

Pairs with:
- synonymdev/bitkit-e2e-tests#181
- synonymdev/bitkit-nightly#24

### Preview

<!-- N/A — devtools-only change, no UI -->

### QA Notes

#### Manual Tests

- [x] **1.** Build mainnet debug E2E APK → restore probe wallet → adb content call `resetScores`: returns `{"success":true}` in ~7s.
- [x] **2.** App logs confirm full sequence: node stop → `deleteObject` success for `scorer` and `external_pathfinding_scores_cache` → node rebuild without cache merge → fresh `External scores merged successfully` after restart.
- [x] **3.** `regression:` adb content call `probeReadiness`: still returns readiness JSON, now including `latestPathfindingScoresSyncTimestamp`.

#### Automated Checks

- Verified end-to-end locally via the companion e2e probe spec with `PROBE_RESET_SCORES=true`: readiness gated on a post-reset scores sync timestamp.
- CI: standard compile, unit test, and detekt checks run by the PR bot.

Made with [Cursor](https://cursor.com)
