### PR TITLE
fix: set transfer amount to max on cap error

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAdvancedScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAdvancedScreen.kt
@@ -112,13 +112,16 @@ fun SpendingAdvancedScreen(
     LaunchedEffect(Unit) {
         amountInputViewModel.effect.collect {
             when (it) {
-                AmountInputEffect.MaxExceeded -> app.toast(
-                    type = Toast.ToastType.WARNING,
-                    title = context.getString(R.string.lightning__spending_advanced__error_max__title),
-                    description = context.getString(R.string.lightning__spending_advanced__error_max__description)
-                        .replace("{amount}", currentMaxLspBalance.formatToModernDisplay()),
-                    visibilityTime = Toast.VISIBILITY_TIME_SHORT,
-                )
+                AmountInputEffect.MaxExceeded -> {
+                    amountInputViewModel.setSats(currentMaxLspBalance.toLong(), currencies)
+                    app.toast(
+                        type = Toast.ToastType.WARNING,
+                        title = context.getString(R.string.lightning__spending_advanced__error_max__title),
+                        description = context.getString(R.string.lightning__spending_advanced__error_max__description)
+                            .replace("{amount}", currentMaxLspBalance.formatToModernDisplay()),
+                        visibilityTime = Toast.VISIBILITY_TIME_SHORT,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAdvancedScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAdvancedScreen.kt
@@ -75,6 +75,7 @@ fun SpendingAdvancedScreen(
 
     val transferValues by viewModel.transferValues.collectAsStateWithLifecycle()
     val currentMaxLspBalance by rememberUpdatedState(transferValues.maxLspBalance)
+    val currentCurrencies by rememberUpdatedState(currencies)
 
     LaunchedEffect(order.clientBalanceSat) {
         viewModel.updateTransferValues(order.clientBalanceSat)
@@ -113,7 +114,7 @@ fun SpendingAdvancedScreen(
         amountInputViewModel.effect.collect {
             when (it) {
                 AmountInputEffect.MaxExceeded -> {
-                    amountInputViewModel.setSats(currentMaxLspBalance.toLong(), currencies)
+                    amountInputViewModel.setSats(currentMaxLspBalance.toLong(), currentCurrencies)
                     app.toast(
                         type = Toast.ToastType.WARNING,
                         title = context.getString(R.string.lightning__spending_advanced__error_max__title),

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
@@ -55,7 +55,6 @@ import to.bitkit.viewmodels.TransferEffect
 import to.bitkit.viewmodels.TransferToSpendingUiState
 import to.bitkit.viewmodels.TransferViewModel
 import to.bitkit.viewmodels.previewAmountInputViewModel
-import kotlin.math.min
 
 @Suppress("ViewModelForwarding")
 @Composable
@@ -112,23 +111,10 @@ fun SpendingAmountScreen(
             currencies = currencies,
             onBackClick = onBackClick,
             onClickQuarter = {
-                val quarter = uiState.balanceAfterFeeQuarter()
-                val max = uiState.maxAllowedToSend
-                if (quarter > max) {
-                    toast(
-                        context.getString(R.string.lightning__spending_amount__error_max__title),
-                        context.getString(R.string.lightning__spending_amount__error_max__description)
-                            .replace("{amount}", max.formatToModernDisplay()),
-                    )
-                }
-                val cappedQuarter = min(quarter, max)
-                viewModel.updateLimits(cappedQuarter)
-                amountInputViewModel.setSats(cappedQuarter, currencies)
+                amountInputViewModel.setSats(uiState.quarterAmount, currencies)
             },
             onClickMaxAmount = {
-                val newAmountSats = uiState.maxAllowedToSend
-                viewModel.updateLimits(newAmountSats)
-                amountInputViewModel.setSats(newAmountSats, currencies)
+                amountInputViewModel.setSats(uiState.maxAllowedToSend, currencies)
             },
             onConfirmAmount = { viewModel.onConfirmAmount(amountUiState.sats) },
         )

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
@@ -73,6 +73,7 @@ fun SpendingAmountScreen(
     val amountUiState by amountInputViewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val currentMaxAllowedToSend by rememberUpdatedState(uiState.maxAllowedToSend)
+    val currentCurrencies by rememberUpdatedState(currencies)
 
     LaunchedEffect(isOffline) {
         viewModel.updateLimits()
@@ -92,7 +93,7 @@ fun SpendingAmountScreen(
         amountInputViewModel.effect.collect {
             when (it) {
                 AmountInputEffect.MaxExceeded -> {
-                    amountInputViewModel.setSats(currentMaxAllowedToSend, currencies)
+                    amountInputViewModel.setSats(currentMaxAllowedToSend, currentCurrencies)
                     toast(
                         context.getString(R.string.lightning__spending_amount__error_max__title),
                         context.getString(R.string.lightning__spending_amount__error_max__description)

--- a/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/transfer/SpendingAmountScreen.kt
@@ -92,11 +92,14 @@ fun SpendingAmountScreen(
     LaunchedEffect(Unit) {
         amountInputViewModel.effect.collect {
             when (it) {
-                AmountInputEffect.MaxExceeded -> toast(
-                    context.getString(R.string.lightning__spending_amount__error_max__title),
-                    context.getString(R.string.lightning__spending_amount__error_max__description)
-                        .replace("{amount}", currentMaxAllowedToSend.formatToModernDisplay()),
-                )
+                AmountInputEffect.MaxExceeded -> {
+                    amountInputViewModel.setSats(currentMaxAllowedToSend, currencies)
+                    toast(
+                        context.getString(R.string.lightning__spending_amount__error_max__title),
+                        context.getString(R.string.lightning__spending_amount__error_max__description)
+                            .replace("{amount}", currentMaxAllowedToSend.formatToModernDisplay()),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
@@ -405,12 +405,14 @@ class TransferViewModel @Inject constructor(
                 liquidity.maxClientBalanceSat.toLong(),
                 maxClientBalance.toLong()
             )
+            val quarterAmount = min((maxSend.toDouble() * 0.25).roundToLong(), maxSend)
 
             _spendingUiState.update {
                 it.copy(
                     maxAllowedToSend = maxSend,
                     isLoading = false,
                     balanceAfterFee = maxSend,
+                    quarterAmount = quarterAmount,
                 )
             }
         }.onFailure {
@@ -650,12 +652,11 @@ data class TransferToSpendingUiState(
     val isAdvanced: Boolean = false,
     val maxAllowedToSend: Long = 0,
     val balanceAfterFee: Long = 0,
+    val quarterAmount: Long = 0,
     val isLoading: Boolean = false,
     val receivingAmount: Long = 0,
     val feeEstimate: Long? = null,
-) {
-    fun balanceAfterFeeQuarter() = (balanceAfterFee.toDouble() * 0.25).roundToLong()
-}
+)
 
 data class TransferValues(
     val defaultLspBalance: ULong = 0u,

--- a/app/src/test/java/to/bitkit/viewmodels/TransferViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/viewmodels/TransferViewModelTest.kt
@@ -27,6 +27,7 @@ import to.bitkit.repositories.LightningState
 import to.bitkit.repositories.TransferRepo
 import to.bitkit.repositories.WalletRepo
 import to.bitkit.test.BaseUnitTest
+import kotlin.math.roundToLong
 import kotlin.test.assertEquals
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -89,6 +90,7 @@ class TransferViewModelTest : BaseUnitTest() {
         val state = sut.spendingUiState.value
         assertEquals(OPTION_MAX_CLIENT_BALANCE.toLong(), state.maxAllowedToSend)
         assertEquals(OPTION_MAX_CLIENT_BALANCE.toLong(), state.balanceAfterFee)
+        assertEquals((OPTION_MAX_CLIENT_BALANCE.toDouble() * 0.25).roundToLong(), state.quarterAmount)
 
         // The order fee must be estimated against the clamped client balance, not the full balance.
         verify(blocktankRepo).estimateOrderFee(eq(LSP_MAX_CLIENT_BALANCE), any(), any())

--- a/changelog.d/next/1013.fixed.md
+++ b/changelog.d/next/1013.fixed.md
@@ -1,0 +1,1 @@
+Transfer to Spending now fills in the maximum transferable amount when you enter a value above the limit, instead of only showing an error.


### PR DESCRIPTION
This PR makes the Transfer to Spending amount screen fill in the maximum transferable amount when you try to enter a value above the cap, instead of only flashing an error toast.

### Description

Previously, entering an amount above the spending maximum on the Transfer to Spending screen blocked the input and showed the "Spending Balance Maximum" toast while leaving the field unchanged. Now, when the cap is exceeded, the amount snaps to the current maximum allowed to send and the toast still appears, so it is a single step to continue with the largest possible transfer.

This ports the max-exceeded behavior from the iOS fix in synonymdev/bitkit-ios#595. The two-pass LSP max-client-balance clamping that the iOS PR also introduced already exists on Android in the transfer view model, so this change is limited to the input-snapping behavior.

### Preview


[Screen_recording_20260615_082049.webm](https://github.com/user-attachments/assets/4c7de922-4abd-4d77-99a7-982917a78583)

### QA Notes

#### Manual Tests
- [ ] **1.** On-chain balance above the spending cap → Transfer → Spending Amount → type an amount above the maximum: input snaps to the maximum and the "Spending Balance Maximum" toast appears.
- [ ] **2.** `regression:` Spending Amount → tap MAX: amount fills to the maximum.
- [ ] **3.** `regression:` Spending Amount → tap 25%: amount is the quarter capped to the maximum.
- [ ] **4.** Spending Amount → amount at maximum → Continue: proceeds to the next step.

#### Automated Checks
- Local: `just compile` passes.
- CI: standard compile, unit test, and detekt checks run by the PR bot.
