### PR TITLE
ci: add hardware wallet e2e shard

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,6 +126,8 @@ jobs:
           E2E: true
           E2E_BACKEND: network
           GEO: false
+          TREZOR_BRIDGE: true
+          TREZOR_BRIDGE_URL: http://10.0.2.2:21325
         run: ./gradlew assembleDevDebug
 
       - name: Rename APK
@@ -320,6 +322,7 @@ jobs:
         shard:
           - { name: multi_address_2_regtest, grep: "@multi_address_2" }
           - { name: pubky_paykit, grep: "@pubky" }
+          - { name: hardware_wallet, grep: "@hardware_wallet" }
 
     name: e2e-tests-staging - ${{ matrix.shard.name }}
 
@@ -389,6 +392,13 @@ jobs:
       - name: Install dependencies
         working-directory: bitkit-e2e-tests
         run: npm ci
+
+      - name: Pull Trezor emulator image
+        if: matrix.shard.name == 'hardware_wallet'
+        working-directory: bitkit-e2e-tests
+        run: |
+          cd docker
+          docker compose --profile trezor pull --quiet trezor-user-env
 
       - name: Run E2E Tests 1 (${{ matrix.shard.name }})
         continue-on-error: true


### PR DESCRIPTION
Refs #1038
Companion PR: synonymdev/bitkit-e2e-tests#184

This PR adds the Android CI wiring for hardware-wallet emulator E2E coverage.

### Description

- Enables Trezor Bridge support in the existing staging/regtest E2E APK build so the hardware-wallet tests can talk to the emulator Bridge.
- Adds a dedicated `hardware_wallet` staging shard that runs the `@hardware_wallet` E2E tests from the companion E2E test branch.
- Pulls the pinned Trezor User Env image before the shard runs so test setup does not spend its first attempt downloading the large emulator image.

### Preview

N/A - CI workflow change only.

### QA Notes

#### Manual Tests

N/A

#### Automated Checks

- E2E coverage added in `hardware-wallet.e2e.ts` by companion PR synonymdev/bitkit-e2e-tests#184: connects the Trezor emulator, verifies settings/home visibility and removal, receives on-chain hardware funds, and transfers hardware funds to Spending.
- Workflow behavior validation after merge: the `hardware_wallet` staging shard should build the regtest APK with `TREZOR_BRIDGE=true`, pull the Trezor User Env image, and run `@hardware_wallet` with `BACKEND=regtest`.
