### PR TITLE
feat: make foreground service opt-in

### DIFF
--- a/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
+++ b/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
@@ -35,6 +35,7 @@ import to.bitkit.models.NewTransactionSheetDetails
 import to.bitkit.models.NotificationDetails
 import to.bitkit.repositories.LightningRepo
 import to.bitkit.repositories.WalletRepo
+import to.bitkit.services.NodeEventHandler
 import to.bitkit.services.NodeServiceFgState
 import to.bitkit.ui.ID_NOTIFICATION_NODE
 import to.bitkit.ui.MainActivity
@@ -80,18 +81,20 @@ class LightningNodeService : Service() {
 
     private var hasStartedNode = false
 
+    private val nodeEventHandler: NodeEventHandler = { event ->
+        Logger.debug("LDK-node event received in $TAG: ${jsonLogOf(event)}", context = TAG)
+        handlePaymentReceived(event)
+        if (event is Event.ChannelReady) handleChannelReady(event)
+        handlePendingPaymentResolved(event)
+    }
+
     private fun setupService() {
         if (hasStartedNode) return
         hasStartedNode = true
 
         serviceScope.launch {
             lightningRepo.start(
-                eventHandler = { event ->
-                    Logger.debug("LDK-node event received in $TAG: ${jsonLogOf(event)}", context = TAG)
-                    handlePaymentReceived(event)
-                    if (event is Event.ChannelReady) handleChannelReady(event)
-                    handlePendingPaymentResolved(event)
-                }
+                eventHandler = nodeEventHandler,
             ).onSuccess {
                 walletRepo.setWalletExistsState()
                 walletRepo.refreshBip21()
@@ -238,6 +241,8 @@ class LightningNodeService : Service() {
     override fun onDestroy() {
         Logger.debug("onDestroy", context = TAG)
         nodeServiceFgState.setForegroundServiceRunning(false)
+        // Drop our event handler so it isn't retained by the repo singleton across service restarts.
+        lightningRepo.removeEventHandler(nodeEventHandler)
         // Only stop the node when no activity is active; in the foreground WalletViewModel owns the
         // node lifecycle, so toggling off the foreground service must leave the node running.
         // Safe to call even if already stopped — guarded by lifecycleMutex + isStoppedOrStopping()

--- a/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
+++ b/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
@@ -238,8 +238,14 @@ class LightningNodeService : Service() {
     override fun onDestroy() {
         Logger.debug("onDestroy", context = TAG)
         nodeServiceFgState.setForegroundServiceRunning(false)
+        // Only stop the node when no activity is active; in the foreground WalletViewModel owns the
+        // node lifecycle, so toggling off the foreground service must leave the node running.
         // Safe to call even if already stopped — guarded by lifecycleMutex + isStoppedOrStopping()
-        serviceScope.launch { lightningRepo.stop() }
+        if (App.currentActivity?.value == null) {
+            serviceScope.launch { lightningRepo.stop() }
+        } else {
+            Logger.debug("Skipping node stop on foreground service destroy: activity is active", context = TAG)
+        }
         super.onDestroy()
     }
 

--- a/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
+++ b/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
@@ -243,14 +243,7 @@ class LightningNodeService : Service() {
         nodeServiceFgState.setForegroundServiceRunning(false)
         // Drop our event handler so it isn't retained by the repo singleton across service restarts.
         lightningRepo.removeEventHandler(nodeEventHandler)
-        // Only stop the node when no activity is active; in the foreground WalletViewModel owns the
-        // node lifecycle, so toggling off the foreground service must leave the node running.
-        // Safe to call even if already stopped — guarded by lifecycleMutex + isStoppedOrStopping()
-        if (App.currentActivity?.value == null) {
-            serviceScope.launch { lightningRepo.stop() }
-        } else {
-            Logger.debug("Skipping node stop on foreground service destroy: activity is active", context = TAG)
-        }
+        stopNodeIfBackgrounded()
         super.onDestroy()
     }
 
@@ -258,8 +251,16 @@ class LightningNodeService : Service() {
     override fun onTimeout(startId: Int, fgsType: Int) {
         Logger.warn("Reached foreground service timeout for type '$fgsType'", context = TAG)
         stopForegroundService(startId)
-        serviceScope.launch { lightningRepo.stop() }
+        stopNodeIfBackgrounded()
         super.onTimeout(startId, fgsType)
+    }
+
+    private fun stopNodeIfBackgrounded() {
+        if (App.currentActivity?.value == null) {
+            serviceScope.launch { lightningRepo.stop() }
+        } else {
+            Logger.debug("Skipping node stop: activity is active", context = TAG)
+        }
     }
 
     override fun onBind(intent: Intent?): IBinder? = null

--- a/app/src/main/java/to/bitkit/data/SettingsStore.kt
+++ b/app/src/main/java/to/bitkit/data/SettingsStore.kt
@@ -142,7 +142,6 @@ data class SettingsData(
     val enableSendAmountWarning: Boolean = false,
     val backupVerified: Boolean = false,
     val notificationsGranted: Boolean = false,
-    val showNotificationDetails: Boolean = true,
     val keepBitkitActiveInBackground: Boolean = false,
     val dismissedSuggestions: List<String> = emptyList(),
     val balanceWarningIgnoredMillis: Long = 0,

--- a/app/src/main/java/to/bitkit/data/SettingsStore.kt
+++ b/app/src/main/java/to/bitkit/data/SettingsStore.kt
@@ -143,6 +143,7 @@ data class SettingsData(
     val backupVerified: Boolean = false,
     val notificationsGranted: Boolean = false,
     val showNotificationDetails: Boolean = true,
+    val keepBitkitActiveInBackground: Boolean = false,
     val dismissedSuggestions: List<String> = emptyList(),
     val balanceWarningIgnoredMillis: Long = 0,
     val backupWarningIgnoredMillis: Long = 0,

--- a/app/src/main/java/to/bitkit/domain/commands/ReceivedNotificationContent.kt
+++ b/app/src/main/java/to/bitkit/domain/commands/ReceivedNotificationContent.kt
@@ -28,11 +28,7 @@ class ReceivedNotificationContent @Inject constructor(
     suspend fun build(sats: Long): NotificationDetails {
         val settings = settingsStore.data.first()
         val title = context.getString(R.string.notification__received__title)
-        val body = if (settings.showNotificationDetails) {
-            formatAmount(sats, settings)
-        } else {
-            context.getString(R.string.notification__received__body_hidden)
-        }
+        val body = formatAmount(sats, settings)
         return NotificationDetails(title, body)
     }
 

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -429,6 +429,8 @@ class LightningRepo @Inject constructor(
         result
     }
 
+    fun removeEventHandler(handler: NodeEventHandler) = run { _eventHandlers.remove(handler) }
+
     private suspend fun onEvent(event: Event) {
         handleLdkEvent(event)
         recordProbeOutcome(event)

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -429,7 +429,9 @@ class LightningRepo @Inject constructor(
         result
     }
 
-    fun removeEventHandler(handler: NodeEventHandler) = run { _eventHandlers.remove(handler) }
+    fun removeEventHandler(handler: NodeEventHandler) {
+        _eventHandlers.remove(handler)
+    }
 
     private suspend fun onEvent(event: Event) {
         handleLdkEvent(event)

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -246,6 +246,7 @@ fun ContentView(
 
     val isRecoveryMode by walletViewModel.isRecoveryMode.collectAsStateWithLifecycle()
     val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
+    val keepActiveInBackground by settingsViewModel.keepBitkitActiveInBackground.collectAsStateWithLifecycle()
     val walletExists = walletUiState.walletExists
 
     val requestNotificationPermission = rememberRequestNotificationPermission(
@@ -273,11 +274,10 @@ fun ContentView(
                 }
 
                 Lifecycle.Event.ON_STOP -> {
-                    if (walletExists && !isRecoveryMode && !notificationsGranted) {
-                        // App backgrounded without notification permission - stop node
+                    val keptAliveByService = notificationsGranted && keepActiveInBackground
+                    if (walletExists && !isRecoveryMode && !keptAliveByService) {
                         walletViewModel.stop()
                     }
-                    // If notificationsGranted=true, service keeps node running
                 }
 
                 else -> Unit

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -274,7 +274,9 @@ fun ContentView(
                 }
 
                 Lifecycle.Event.ON_STOP -> {
-                    val keptAliveByService = notificationsGranted && keepActiveInBackground
+                    val keptAliveByService = notificationsGranted &&
+                        keepActiveInBackground &&
+                        appViewModel.isForegroundServiceRunning()
                     if (walletExists && !isRecoveryMode && !keptAliveByService) {
                         walletViewModel.stop()
                     }

--- a/app/src/main/java/to/bitkit/ui/MainActivity.kt
+++ b/app/src/main/java/to/bitkit/ui/MainActivity.kt
@@ -31,7 +31,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import to.bitkit.R
@@ -118,9 +117,7 @@ class MainActivity : FragmentActivity() {
                 val isRecoveryMode by walletViewModel.isRecoveryMode.collectAsStateWithLifecycle()
                 val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
                 val keepActive by settingsViewModel.keepBitkitActiveInBackground.collectAsStateWithLifecycle()
-                val walletExists by walletViewModel.walletState
-                    .map { it.walletExists }
-                    .collectAsStateWithLifecycle(initialValue = walletViewModel.walletExists)
+                val walletExists = walletViewModel.walletExists
                 val isShowingMigrationLoading by walletViewModel.isShowingMigrationLoading.collectAsStateWithLifecycle()
                 val restoreState by walletViewModel.restoreState.collectAsStateWithLifecycle()
                 val hazeState = rememberHazeState(blurEnabled = true)

--- a/app/src/main/java/to/bitkit/ui/MainActivity.kt
+++ b/app/src/main/java/to/bitkit/ui/MainActivity.kt
@@ -117,6 +117,7 @@ class MainActivity : FragmentActivity() {
                 val scope = rememberCoroutineScope()
                 val isRecoveryMode by walletViewModel.isRecoveryMode.collectAsStateWithLifecycle()
                 val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
+                val keepActive by settingsViewModel.keepBitkitActiveInBackground.collectAsStateWithLifecycle()
                 val walletExists by walletViewModel.walletState
                     .map { it.walletExists }
                     .collectAsStateWithLifecycle(initialValue = walletViewModel.walletExists)
@@ -128,11 +129,14 @@ class MainActivity : FragmentActivity() {
                     walletExists,
                     isRecoveryMode,
                     notificationsGranted,
+                    keepActive,
                     restoreState,
                 ) {
-                    val canStartService = walletExists && notificationsGranted && restoreState.isIdle()
+                    val canStartService = walletExists && notificationsGranted && keepActive && restoreState.isIdle()
                     if (canStartService && !isRecoveryMode) {
                         tryStartForegroundService()
+                    } else if (!keepActive) {
+                        stopForegroundService()
                     }
                 }
 
@@ -264,9 +268,7 @@ class MainActivity : FragmentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         if (!settingsViewModel.notificationsGranted.value) {
-            runCatching {
-                stopService(Intent(this, LightningNodeService::class.java))
-            }
+            stopForegroundService()
         }
     }
 
@@ -283,6 +285,14 @@ class MainActivity : FragmentActivity() {
             )
         }.onFailure { error ->
             Logger.error("Failed to start LightningNodeService", error, context = "MainActivity")
+        }
+    }
+
+    private fun stopForegroundService() {
+        runCatching {
+            stopService(Intent(this, LightningNodeService::class.java))
+        }.onFailure { error ->
+            Logger.error("Failed to stop LightningNodeService", error, context = "MainActivity")
         }
     }
 }

--- a/app/src/main/java/to/bitkit/ui/MainActivity.kt
+++ b/app/src/main/java/to/bitkit/ui/MainActivity.kt
@@ -135,7 +135,7 @@ class MainActivity : FragmentActivity() {
                     val canStartService = walletExists && notificationsGranted && keepActive && restoreState.isIdle()
                     if (canStartService && !isRecoveryMode) {
                         tryStartForegroundService()
-                    } else if (!keepActive) {
+                    } else {
                         stopForegroundService()
                     }
                 }

--- a/app/src/main/java/to/bitkit/ui/components/NotificationPreview.kt
+++ b/app/src/main/java/to/bitkit/ui/components/NotificationPreview.kt
@@ -1,6 +1,5 @@
 package to.bitkit.ui.components
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -18,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import to.bitkit.R
@@ -34,7 +32,6 @@ fun NotificationPreview(
     enabled: Boolean,
     title: String,
     description: String,
-    showDetails: Boolean,
     modifier: Modifier = Modifier,
     time: String = "5m",
 ) {
@@ -66,13 +63,7 @@ fun NotificationPreview(
                     Caption(text = time, color = Colors.White64)
                 }
 
-                val bodyText = when (showDetails) {
-                    true -> description
-                    else -> stringResource(R.string.notification__received__body_hidden)
-                }
-                AnimatedContent(targetState = bodyText) { text ->
-                    BodyS(text = text, color = Colors.White80)
-                }
+                BodyS(text = description, color = Colors.White80)
             }
 
             Icon(
@@ -110,14 +101,12 @@ private fun Preview() {
                 enabled = true,
                 title = "Payment Received",
                 description = "₿ 21 000 ($21.00)",
-                showDetails = true,
                 modifier = Modifier.fillMaxWidth()
             )
             NotificationPreview(
                 enabled = false,
                 title = "Payment Received",
                 description = "₿ 21 000 ($21.00)",
-                showDetails = false,
                 modifier = Modifier.fillMaxWidth()
             )
         }

--- a/app/src/main/java/to/bitkit/ui/components/NotificationPreview.kt
+++ b/app/src/main/java/to/bitkit/ui/components/NotificationPreview.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,6 +26,9 @@ import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
 import to.bitkit.ui.theme.Shapes
 
+/** Degrees to rotate the right chevron so it points downward (expand-more) in the preview. */
+private const val CHEVRON_EXPAND_ROTATION_DEGREES = 90f
+
 @Composable
 fun NotificationPreview(
     enabled: Boolean,
@@ -30,44 +36,60 @@ fun NotificationPreview(
     description: String,
     showDetails: Boolean,
     modifier: Modifier = Modifier,
+    time: String = "5m",
 ) {
     Box(modifier = modifier) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .clip(Shapes.medium)
-                .background(Colors.White80)
-                .padding(9.dp)
+                .clip(Shapes.extraSmall)
+                .background(Colors.White16)
+                .padding(16.dp)
         ) {
             Image(
                 painter = painterResource(R.drawable.ic_notification),
                 contentDescription = null,
-                modifier = Modifier
-                    .size(38.dp)
+                modifier = Modifier.size(24.dp)
             )
 
             Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.SpaceBetween
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier.weight(1f)
             ) {
-                BodySSB(text = title, color = Colors.Black)
-                val textDescription = when (showDetails) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    BodySSB(text = title, color = Colors.White)
+                    Caption(text = "•", color = Colors.White64)
+                    Caption(text = time, color = Colors.White64)
+                }
+
+                val bodyText = when (showDetails) {
                     true -> description
                     else -> stringResource(R.string.notification__received__body_hidden)
                 }
-                AnimatedContent(targetState = textDescription) { text ->
-                    Footnote(text = text, color = Colors.Gray3)
+                AnimatedContent(targetState = bodyText) { text ->
+                    BodyS(text = text, color = Colors.White80)
                 }
             }
 
-            Caption("3m ago", color = Colors.Gray2)
+            Icon(
+                painter = painterResource(R.drawable.ic_chevron_right),
+                contentDescription = null,
+                tint = Colors.White64,
+                modifier = Modifier
+                    .size(16.dp)
+                    .rotate(CHEVRON_EXPAND_ROTATION_DEGREES)
+            )
         }
 
         if (!enabled) {
             Box(
                 modifier = Modifier
                     .matchParentSize()
-                    .clip(Shapes.medium)
+                    .clip(Shapes.extraSmall)
                     .background(Colors.Black70)
             )
         }
@@ -79,23 +101,22 @@ fun NotificationPreview(
 private fun Preview() {
     AppThemeSurface {
         Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
                 .fillMaxSize()
-                .padding(8.dp),
-            verticalArrangement = Arrangement.Center
+                .padding(16.dp)
         ) {
             NotificationPreview(
                 enabled = true,
                 title = "Payment Received",
-                description = "₿ 21 000",
+                description = "₿ 21 000 ($21.00)",
                 showDetails = true,
                 modifier = Modifier.fillMaxWidth()
             )
-            VerticalSpacer(16.dp)
             NotificationPreview(
                 enabled = false,
                 title = "Payment Received",
-                description = "₿ 21 000",
+                description = "₿ 21 000 ($21.00)",
                 showDetails = false,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/to/bitkit/ui/settings/backgroundPayments/BackgroundPaymentsSettings.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backgroundPayments/BackgroundPaymentsSettings.kt
@@ -22,8 +22,6 @@ import to.bitkit.ui.components.NotificationPreview
 import to.bitkit.ui.components.SecondaryButton
 import to.bitkit.ui.components.Text13Up
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.components.settings.SettingsButtonRow
-import to.bitkit.ui.components.settings.SettingsButtonValue
 import to.bitkit.ui.components.settings.SettingsSwitchRow
 import to.bitkit.ui.openNotificationSettings
 import to.bitkit.ui.scaffold.AppTopBar
@@ -55,7 +53,6 @@ fun BackgroundPaymentsSettings(
         keepActive = keepActive,
         onBack = onBack,
         onSystemSettingsClick = context::openNotificationSettings,
-        toggleNotificationDetails = settingsViewModel::toggleNotificationDetails,
         onKeepActiveClick = { settingsViewModel.setKeepBitkitActiveInBackground(!keepActive) },
     )
 }
@@ -67,7 +64,6 @@ private fun Content(
     keepActive: Boolean,
     onBack: () -> Unit,
     onSystemSettingsClick: () -> Unit,
-    toggleNotificationDetails: () -> Unit,
     onKeepActiveClick: () -> Unit,
 ) {
     Column(
@@ -123,27 +119,6 @@ private fun Content(
                 modifier = Modifier.padding(vertical = 16.dp),
             )
 
-            NotificationPreview(
-                enabled = hasPermission,
-                title = stringResource(R.string.notification__received__title),
-                description = "₿ 21 000",
-                showDetails = showDetails,
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            VerticalSpacer(32.dp)
-
-            Text13Up(
-                text = stringResource(R.string.settings__bg__privacy_header),
-                color = Colors.White64
-            )
-
-            SettingsButtonRow(
-                stringResource(R.string.settings__bg__include_amount),
-                value = SettingsButtonValue.BooleanValue(showDetails),
-                onClick = toggleNotificationDetails,
-            )
-
             VerticalSpacer(32.dp)
 
             Text13Up(
@@ -157,6 +132,23 @@ private fun Content(
                 stringResource(R.string.settings__bg__customize),
                 icon = { Image(painter = painterResource(R.drawable.ic_bell), contentDescription = null) },
                 onClick = onSystemSettingsClick,
+            )
+
+            VerticalSpacer(32.dp)
+
+            Text13Up(
+                text = stringResource(R.string.common__preview),
+                color = Colors.White64
+            )
+
+            VerticalSpacer(16.dp)
+
+            NotificationPreview(
+                enabled = hasPermission,
+                title = stringResource(R.string.notification__received__title),
+                description = "₿ 21 000 ($21.00)",
+                showDetails = showDetails,
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }
@@ -172,7 +164,6 @@ private fun Preview1() {
             keepActive = true,
             onBack = {},
             onSystemSettingsClick = {},
-            toggleNotificationDetails = {},
             onKeepActiveClick = {},
         )
     }
@@ -188,7 +179,6 @@ private fun Preview2() {
             keepActive = false,
             onBack = {},
             onSystemSettingsClick = {},
-            toggleNotificationDetails = {},
             onKeepActiveClick = {},
         )
     }

--- a/app/src/main/java/to/bitkit/ui/settings/backgroundPayments/BackgroundPaymentsSettings.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backgroundPayments/BackgroundPaymentsSettings.kt
@@ -42,6 +42,7 @@ fun BackgroundPaymentsSettings(
     val context = LocalContext.current
     val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
     val showNotificationDetails by settingsViewModel.showNotificationDetails.collectAsStateWithLifecycle()
+    val keepActive by settingsViewModel.keepBitkitActiveInBackground.collectAsStateWithLifecycle()
 
     RequestNotificationPermissions(
         onPermissionChange = settingsViewModel::setNotificationPreference,
@@ -51,9 +52,11 @@ fun BackgroundPaymentsSettings(
     Content(
         hasPermission = notificationsGranted,
         showDetails = showNotificationDetails,
+        keepActive = keepActive,
         onBack = onBack,
         onSystemSettingsClick = context::openNotificationSettings,
         toggleNotificationDetails = settingsViewModel::toggleNotificationDetails,
+        onKeepActiveClick = { settingsViewModel.setKeepBitkitActiveInBackground(!keepActive) },
     )
 }
 
@@ -61,9 +64,11 @@ fun BackgroundPaymentsSettings(
 private fun Content(
     hasPermission: Boolean,
     showDetails: Boolean,
+    keepActive: Boolean,
     onBack: () -> Unit,
     onSystemSettingsClick: () -> Unit,
     toggleNotificationDetails: () -> Unit,
+    onKeepActiveClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier.screen()
@@ -104,6 +109,19 @@ private fun Content(
                     color = Colors.Red,
                 )
             }
+
+            SettingsSwitchRow(
+                title = stringResource(R.string.settings__bg__keep_active_title),
+                isChecked = keepActive,
+                onClick = onKeepActiveClick,
+                enabled = hasPermission,
+            )
+
+            BodyM(
+                text = stringResource(R.string.settings__bg__keep_active_desc),
+                color = Colors.White64,
+                modifier = Modifier.padding(vertical = 16.dp),
+            )
 
             NotificationPreview(
                 enabled = hasPermission,
@@ -151,9 +169,11 @@ private fun Preview1() {
         Content(
             hasPermission = true,
             showDetails = true,
+            keepActive = true,
             onBack = {},
             onSystemSettingsClick = {},
             toggleNotificationDetails = {},
+            onKeepActiveClick = {},
         )
     }
 }
@@ -165,9 +185,11 @@ private fun Preview2() {
         Content(
             hasPermission = false,
             showDetails = false,
+            keepActive = false,
             onBack = {},
             onSystemSettingsClick = {},
             toggleNotificationDetails = {},
+            onKeepActiveClick = {},
         )
     }
 }

--- a/app/src/main/java/to/bitkit/ui/settings/backgroundPayments/BackgroundPaymentsSettings.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/backgroundPayments/BackgroundPaymentsSettings.kt
@@ -39,7 +39,6 @@ fun BackgroundPaymentsSettings(
 ) {
     val context = LocalContext.current
     val notificationsGranted by settingsViewModel.notificationsGranted.collectAsStateWithLifecycle()
-    val showNotificationDetails by settingsViewModel.showNotificationDetails.collectAsStateWithLifecycle()
     val keepActive by settingsViewModel.keepBitkitActiveInBackground.collectAsStateWithLifecycle()
 
     RequestNotificationPermissions(
@@ -49,7 +48,6 @@ fun BackgroundPaymentsSettings(
 
     Content(
         hasPermission = notificationsGranted,
-        showDetails = showNotificationDetails,
         keepActive = keepActive,
         onBack = onBack,
         onSystemSettingsClick = context::openNotificationSettings,
@@ -60,7 +58,6 @@ fun BackgroundPaymentsSettings(
 @Composable
 private fun Content(
     hasPermission: Boolean,
-    showDetails: Boolean,
     keepActive: Boolean,
     onBack: () -> Unit,
     onSystemSettingsClick: () -> Unit,
@@ -147,7 +144,6 @@ private fun Content(
                 enabled = hasPermission,
                 title = stringResource(R.string.notification__received__title),
                 description = "₿ 21 000 ($21.00)",
-                showDetails = showDetails,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -160,7 +156,6 @@ private fun Preview1() {
     AppThemeSurface {
         Content(
             hasPermission = true,
-            showDetails = true,
             keepActive = true,
             onBack = {},
             onSystemSettingsClick = {},
@@ -175,7 +170,6 @@ private fun Preview2() {
     AppThemeSurface {
         Content(
             hasPermission = false,
-            showDetails = false,
             keepActive = false,
             onBack = {},
             onSystemSettingsClick = {},

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -143,6 +143,7 @@ import to.bitkit.repositories.WidgetsRepo
 import to.bitkit.services.AppUpdaterService
 import to.bitkit.services.CoreService
 import to.bitkit.services.MigrationService
+import to.bitkit.services.NodeServiceFgState
 import to.bitkit.ui.Routes
 import to.bitkit.ui.components.Sheet
 import to.bitkit.ui.shared.toast.ToastEventBus
@@ -200,6 +201,7 @@ class AppViewModel @Inject constructor(
     private val transferRepo: TransferRepo,
     private val migrationService: MigrationService,
     private val coreService: CoreService,
+    private val nodeServiceFgState: NodeServiceFgState,
     private val pubkyRepo: PubkyRepo,
     private val publicPaykitRepo: PublicPaykitRepo,
     private val privatePaykitRepo: PrivatePaykitRepo,
@@ -2734,6 +2736,8 @@ class AppViewModel @Inject constructor(
         cacheStore.clearBackgroundReceive()
         showTransactionSheet(details)
     }
+
+    fun isForegroundServiceRunning(): Boolean = nodeServiceFgState.isForegroundServiceRunning
     // endregion
 
     // region Sheets

--- a/app/src/main/java/to/bitkit/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/SettingsViewModel.kt
@@ -64,15 +64,6 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    val showNotificationDetails = settingsStore.data.map { it.showNotificationDetails }
-        .asStateFlow(initialValue = false)
-
-    fun toggleNotificationDetails() {
-        viewModelScope.launch {
-            settingsStore.update { it.copy(showNotificationDetails = !it.showNotificationDetails) }
-        }
-    }
-
     val keepBitkitActiveInBackground = settingsStore.data.map { it.keepBitkitActiveInBackground }
         .asStateFlow(initialValue = false)
 

--- a/app/src/main/java/to/bitkit/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/SettingsViewModel.kt
@@ -73,6 +73,15 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    val keepBitkitActiveInBackground = settingsStore.data.map { it.keepBitkitActiveInBackground }
+        .asStateFlow(initialValue = false)
+
+    fun setKeepBitkitActiveInBackground(value: Boolean) {
+        viewModelScope.launch {
+            settingsStore.update { it.copy(keepBitkitActiveInBackground = value) }
+        }
+    }
+
     fun setHasSeenSpendingIntro(value: Boolean) {
         viewModelScope.launch {
             settingsStore.update { it.copy(hasSeenSpendingIntro = value) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -817,6 +817,8 @@
     <string name="settings__bg__intro_button">Enable</string>
     <string name="settings__bg__intro_desc">Turn on notifications to get paid, even when your Bitkit app is closed.</string>
     <string name="settings__bg__intro_title">GET PAID\n&lt;accent&gt;PASSIVELY&lt;/accent&gt;</string>
+    <string name="settings__bg__keep_active_desc">Keeping Bitkit active results in more reliable payments. Android may show a persistent notification while this is enabled.</string>
+    <string name="settings__bg__keep_active_title">Keep Bitkit active in background</string>
     <string name="settings__bg__notifications_header">Notifications</string>
     <string name="settings__bg__off">Off</string>
     <string name="settings__bg__on">On</string>

--- a/app/src/test/java/to/bitkit/domain/commands/NotifyChannelReadyHandlerTest.kt
+++ b/app/src/test/java/to/bitkit/domain/commands/NotifyChannelReadyHandlerTest.kt
@@ -46,7 +46,7 @@ class NotifyChannelReadyHandlerTest : BaseUnitTest() {
     fun setUp() {
         whenever(context.getString(R.string.notification__received__title)).thenReturn("Payment Received")
         whenever(context.getString(any(), any())).thenReturn("Received amount")
-        whenever(settingsStore.data).thenReturn(flowOf(SettingsData(showNotificationDetails = true)))
+        whenever(settingsStore.data).thenReturn(flowOf(SettingsData()))
         whenever(currencyRepo.convertSatsToFiat(any(), anyOrNull())).thenReturn(
             Result.success(
                 ConvertedAmount(
@@ -154,30 +154,6 @@ class NotifyChannelReadyHandlerTest : BaseUnitTest() {
         assertNotNull(showNotification.notification)
         assertEquals("Payment Received", showNotification.notification.title)
         verify(activityRepo).insertActivityFromCjit(cjitEntry, channel)
-    }
-
-    @Test
-    fun `notification hides details when showNotificationDetails is false`() = test {
-        val event = mock<Event.ChannelReady> {
-            on { channelId } doReturn "channel-1"
-        }
-        val channel = createChannelDetails().copy(
-            channelId = "channel-1",
-            outboundCapacityMsat = 3000_000u,
-        )
-        val cjitEntry = IcJitEntry.mock()
-        whenever(lightningRepo.getChannels()).thenReturn(listOf(channel))
-        whenever(blocktankRepo.getCjitEntry(channel)).thenReturn(cjitEntry)
-        whenever(activityRepo.insertActivityFromCjit(any(), any())).thenReturn(Result.success(true))
-        whenever(settingsStore.data).thenReturn(flowOf(SettingsData(showNotificationDetails = false)))
-        whenever(context.getString(R.string.notification__received__body_hidden)).thenReturn("Hidden")
-
-        val result = sut(NotifyChannelReady.Command(event = event, includeNotification = true))
-
-        assertTrue(result.isSuccess)
-        val showNotification = result.getOrThrow()
-        assertTrue(showNotification is NotifyChannelReady.Result.ShowNotification)
-        assertEquals("Hidden", showNotification.notification.body)
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/domain/commands/NotifyPaymentReceivedHandlerTest.kt
+++ b/app/src/test/java/to/bitkit/domain/commands/NotifyPaymentReceivedHandlerTest.kt
@@ -41,7 +41,7 @@ class NotifyPaymentReceivedHandlerTest : BaseUnitTest() {
     fun setUp() {
         whenever(context.getString(R.string.notification__received__title)).thenReturn("Payment Received")
         whenever(context.getString(any(), any())).thenReturn("Received amount")
-        whenever(settingsStore.data).thenReturn(flowOf(SettingsData(showNotificationDetails = true)))
+        whenever(settingsStore.data).thenReturn(flowOf(SettingsData()))
         whenever(currencyRepo.convertSatsToFiat(any(), anyOrNull())).thenReturn(
             Result.success(
                 ConvertedAmount(

--- a/app/src/test/java/to/bitkit/domain/commands/ReceivedNotificationContentTest.kt
+++ b/app/src/test/java/to/bitkit/domain/commands/ReceivedNotificationContentTest.kt
@@ -89,18 +89,9 @@ class ReceivedNotificationContentTest : BaseUnitTest() {
         assertEquals(expected, result.body)
     }
 
-    @Test
-    fun `hides the amount when notification details are disabled`() = test {
-        whenever(settingsStore.data).thenReturn(flowOf(SettingsData(showNotificationDetails = false)))
-
-        val result = sut.build(48_064L)
-
-        assertEquals(context.getString(R.string.notification__received__body_hidden), result.body)
-    }
-
     private fun stubSettings(primaryDisplay: PrimaryDisplay) {
         whenever(settingsStore.data).thenReturn(
-            flowOf(SettingsData(showNotificationDetails = true, primaryDisplay = primaryDisplay)),
+            flowOf(SettingsData(primaryDisplay = primaryDisplay)),
         )
     }
 }

--- a/app/src/test/java/to/bitkit/viewmodels/AppViewModelSendFlowTest.kt
+++ b/app/src/test/java/to/bitkit/viewmodels/AppViewModelSendFlowTest.kt
@@ -72,6 +72,7 @@ import to.bitkit.services.ActivityService
 import to.bitkit.services.AppUpdaterService
 import to.bitkit.services.CoreService
 import to.bitkit.services.MigrationService
+import to.bitkit.services.NodeServiceFgState
 import to.bitkit.test.BaseUnitTest
 import to.bitkit.ui.Routes
 import to.bitkit.ui.components.Sheet
@@ -116,6 +117,7 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
     private val transferRepo = mock<TransferRepo>()
     private val migrationService = mock<MigrationService>()
     private val coreService = mock<CoreService>()
+    private val nodeServiceFgState = NodeServiceFgState()
     private val activityService = mock<ActivityService>()
     private val keychain = mock<Keychain>()
     private val pubkyRepo = mock<PubkyRepo>()
@@ -246,6 +248,7 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
         transferRepo = transferRepo,
         migrationService = migrationService,
         coreService = coreService,
+        nodeServiceFgState = nodeServiceFgState,
         publicPaykitRepo = publicPaykitRepo,
         privatePaykitRepo = privatePaykitRepo,
         samRockRepo = samRockRepo,

--- a/app/src/test/java/to/bitkit/viewmodels/SettingsViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/viewmodels/SettingsViewModelTest.kt
@@ -159,6 +159,24 @@ class SettingsViewModelTest : BaseUnitTest() {
         verify(privatePaykitRepo).disableSharingAndPruneUnsavedContactState(contacts.value.map { it.publicKey })
     }
 
+    @Test
+    fun `keepBitkitActiveInBackground defaults to false`() = test {
+        assertFalse(sut.keepBitkitActiveInBackground.value)
+    }
+
+    @Test
+    fun `setKeepBitkitActiveInBackground persists the new value`() = test {
+        sut.setKeepBitkitActiveInBackground(true)
+        advanceUntilIdle()
+
+        assertTrue(settingsData.value.keepBitkitActiveInBackground)
+
+        sut.setKeepBitkitActiveInBackground(false)
+        advanceUntilIdle()
+
+        assertFalse(settingsData.value.keepBitkitActiveInBackground)
+    }
+
     private fun createViewModel() = SettingsViewModel(
         settingsStore = settingsStore,
         pubkyRepo = pubkyRepo,

--- a/changelog.d/next/1053.added.md
+++ b/changelog.d/next/1053.added.md
@@ -1,0 +1,1 @@
+Background payments now include a "Keep Bitkit active in background" option for more reliable payments, and payment notifications always show the amount received.

--- a/changelog.d/next/fg-service-optional.added.md
+++ b/changelog.d/next/fg-service-optional.added.md
@@ -1,0 +1,1 @@
+Background payments now include a "Keep Bitkit active in background" option for more reliable payments.

--- a/changelog.d/next/fg-service-optional.added.md
+++ b/changelog.d/next/fg-service-optional.added.md
@@ -1,1 +1,0 @@
-Background payments now include a "Keep Bitkit active in background" option for more reliable payments.


### PR DESCRIPTION
Fixes #1007

This PR:
1. Adds a "Keep Bitkit active in background" toggle to the Background Payments screen that makes the persistent foreground service opt-in and disabled by default. The Lightning node still runs while the app is open, and background payments still arrive via push notifications; enabling the toggle keeps Bitkit active in the background for more reliable payments, at the cost of a persistent notification.
2. Updates the Background Payments screen and the notification preview to match the latest design.
3. Always shows the amount in payment notifications and removes the "Include amount in notifications" option.
4. Fixes a Lightning event-handler leak so toggling the service on and off no longer accumulates stale handlers.

### Description

- New persisted setting, off by default. The foreground service start gate now also requires it, and turning it off stops a running service immediately so the persistent notification disappears at once.
- Stopping the foreground service no longer stops the in-app node when an activity is active; in the foreground the node lifecycle is owned by the wallet view model, so toggling the service off leaves the node running. When the app is backgrounded, the node still stops as before.
- The Background Payments screen is reordered to match the design: "Get paid when Bitkit is closed", "Keep Bitkit active in background", a Notifications section with the Customize button, and a Preview of the payment notification. The "Keep Bitkit active in background" switch is disabled while notifications are denied.
- The notification preview is redesigned to the Android notification card style, with the app icon, title, time, amount, and an expand chevron.
- Removed the show-notification-details setting and its privacy toggle. Payment notifications now always include the amount across the foreground service, in-app handler, and the background push path.
- Added a remove-event-handler API and de-register the foreground service handler when the service is destroyed, preventing stale handlers from accumulating across service restarts.

### Preview


[disable-fg-switch.webm](https://github.com/user-attachments/assets/e6c6f016-50fe-44e6-aa60-7e144018ecc8)

[disable-notifications.webm](https://github.com/user-attachments/assets/abaec2c7-47da-4601-8ef8-da151c36848f)

[running-from-master.webm](https://github.com/user-attachments/assets/a8c1d999-603f-4b4f-9c44-337e13f59a55)

[wake-to-pay.webm](https://github.com/user-attachments/assets/96616815-3b17-4761-94dd-f58e47eb6228)

[enable-fg-service.webm](https://github.com/user-attachments/assets/5bb03978-9d9a-4ca5-87ce-69c7a9f37131)


### QA Notes

[FIGMA](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=40364-135743&m=dev)

#### Manual Tests

- [x] **1.** Settings → Background Payments: "Keep Bitkit active in background" is off by default and no persistent Bitkit notification is shown in the status bar.
- [x] **2.** Background Payments → toggle Keep active on: persistent Bitkit notification appears → background the app: node stays alive.
- [x] **3.** Background Payments → toggle Keep active off: persistent notification disappears immediately → with the app still open, receive a payment: still works (node keeps running).
- [x] **4.** Revoke notification permission in Android settings → Background Payments: "Get paid when Bitkit is closed" reads off and "Keep Bitkit active in background" is disabled.
- [x] **5.** `regression:` Keep active off, app closed → receive a payment: push notification arrives and shows the amount.
- [x] **6.** Background Payments: layout matches the design (two switches with explanations, Notifications/Customize, Preview card).

#### Automated Checks

- Unit tests added: default value and setter for the new toggle in `SettingsViewModelTest.kt`.
- Test coverage removed: hidden-amount assertions deleted from `ReceivedNotificationContentTest.kt` and `NotifyChannelReadyHandlerTest.kt` because the show-notification-details option no longer exists; `SettingsData` stubs updated in `NotifyPaymentReceivedHandlerTest.kt`.
- Ran locally: `just compile`, the affected unit tests, and `just lint`.
- CI: standard compile, unit test, and detekt checks run by the PR bot.
