### PR TITLE
fix: narrow LNURL-pay error mapping

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -1732,8 +1732,7 @@ private fun Throwable.toLnurlPayInvoiceError(): Throwable {
 
 private fun Throwable.isLnurlPayValidationError(): Boolean = when (this) {
     is LnurlException.InvalidAmount,
-    is LnurlException.AmountMismatch,
-    is LnurlException.MetadataMismatch -> true
+    is LnurlException.AmountMismatch -> true
 
     else -> false
 }


### PR DESCRIPTION
### Description

This PR narrows Android's LNURL-pay invoice error mapping to the amount-related validation errors returned by the pinned bitkit-core package.

It removes the stale metadata branch from the app mapper while keeping the current bitkit-core package version unchanged, basically mirroring the late changes to the iOS release PR (synonymdev/bitkit-ios#608), it's still effectively part of post-merge hygiene for the 2.3.1 hotfix.

### Preview

N/A

### QA Notes

#### Manual Tests
N/A

#### Automated Checks
- `just test file LightningRepoTest`
- `just compile`
- `just test`
- `just lint`
