### PR TITLE
fix: update hw activity explorer

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityExploreScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityExploreScreen.kt
@@ -327,7 +327,7 @@ private fun ColumnScope.OnchainDetails(
                 }
             },
         )
-    } else if (!isHardware) {
+    } else if (!isHardware && !onchain.v1.isTransfer) {
         CircularProgressIndicator(
             strokeWidth = 2.dp,
             modifier = Modifier

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityExploreScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityExploreScreen.kt
@@ -221,6 +221,7 @@ private fun ActivityExploreContent(
             is Activity.Onchain -> {
                 OnchainDetails(
                     onchain = item,
+                    isHardware = isHardware,
                     onCopy = onCopy,
                     txDetails = txDetails,
                     boostTxDoesExist = boostTxDoesExist,
@@ -283,6 +284,7 @@ private fun LightningDetails(
 @Composable
 private fun ColumnScope.OnchainDetails(
     onchain: Activity.Onchain,
+    isHardware: Boolean,
     onCopy: (String) -> Unit,
     txDetails: TransactionDetails?,
     boostTxDoesExist: Map<String, Boolean> = emptyMap(),
@@ -324,6 +326,14 @@ private fun ColumnScope.OnchainDetails(
                     }
                 }
             },
+        )
+    } else if (!isHardware) {
+        CircularProgressIndicator(
+            strokeWidth = 2.dp,
+            modifier = Modifier
+                .padding(vertical = 16.dp)
+                .size(16.dp)
+                .align(Alignment.CenterHorizontally)
         )
     }
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityExploreScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/activity/ActivityExploreScreen.kt
@@ -164,6 +164,7 @@ fun ActivityExploreScreen(
                 val toastMessage = stringResource(R.string.common__copied)
                 ActivityExploreContent(
                     item = item,
+                    isHardware = uiState.isHardwareActivity,
                     txDetails = txDetails,
                     boostTxDoesExist = boostTxDoesExist,
                     onCopy = { text ->
@@ -187,6 +188,7 @@ fun ActivityExploreScreen(
 @Composable
 private fun ActivityExploreContent(
     item: Activity,
+    isHardware: Boolean = false,
     txDetails: TransactionDetails? = null,
     boostTxDoesExist: Map<String, Boolean> = emptyMap(),
     onCopy: (String) -> Unit = {},
@@ -210,7 +212,7 @@ private fun ActivityExploreContent(
                 showBitcoinSymbol = false,
                 modifier = Modifier.weight(1f),
             )
-            ActivityIcon(activity = item, size = 48.dp)
+            ActivityIcon(activity = item, size = 48.dp, isHardware = isHardware)
         }
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -322,14 +324,6 @@ private fun ColumnScope.OnchainDetails(
                     }
                 }
             },
-        )
-    } else {
-        CircularProgressIndicator(
-            strokeWidth = 2.dp,
-            modifier = Modifier
-                .padding(vertical = 16.dp)
-                .size(16.dp)
-                .align(Alignment.CenterHorizontally)
         )
     }
 


### PR DESCRIPTION
### Description

This PR fixes the hardware wallet activity explorer so it matches the hardware activity detail state.

The explorer now passes the hardware-wallet activity flag through to the shared activity icon, keeping hardware receive/send icons blue. It also stops showing an indefinite loading spinner when transaction inputs/outputs are unavailable, so hardware wallet activity exploration can still show the transaction id and block explorer action without implying details are still loading.

The loading spinner is kept for regular on-chain activities while tx details load, but hidden for hardware wallet activities and for transfers. Transfers are excluded so hardware wallet transfers do not show an indefinite spinner when inputs/outputs are unavailable; savings-to-spending transfers still load details normally, just without the spinner.

### Preview

| Before | After |
| --- | --- |
| <img width="198" height="422" alt="Screenshot 2026-07-03 at 15 46 23" src="https://github.com/user-attachments/assets/ef38666f-176e-46cc-9c15-768bdfe62ce0" /> | <img width="202" height="425" alt="Screenshot 2026-07-03 at 15 38 59" src="https://github.com/user-attachments/assets/5cfc6ff5-532e-4e7a-aab6-ad3c285329f8" /> |
| <img width="194" height="420" alt="Screenshot 2026-07-03 at 16 13 00" src="https://github.com/user-attachments/assets/230ced77-2ce6-41fb-afc0-a6d70df4aa2c" /> | <img width="199" height="427" alt="Screenshot 2026-07-03 at 16 24 38" src="https://github.com/user-attachments/assets/6fc45f19-c00c-48cd-90dc-b3e72454ff97" /> |





### QA Notes

#### Manual Tests
- [x] **1.** Hardware wallet received Bitcoin activity → Activity Detail → Explore: icon is blue and the transaction id is shown without an indefinite spinner.
- [x] **2.** Hardware wallet received Bitcoin activity → Activity Detail → Explore → Open Block Explorer: external block explorer opens for the txid.
- [x] **3.** Hardware wallet → Spending transfer → Activity Detail → Explore: transaction id is shown without an indefinite spinner when inputs/outputs are unavailable.
- [x] **4.** `regression:` Normal on-chain activity → Activity Detail → Explore: transaction id, inputs/outputs when available, loading spinner while details load, and Open Block Explorer still work.

#### Automated Checks
- Local verification: `just compile` passed.