### PR TITLE
ci: update workflows for temurin and node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: ./gradlew testDevDebugUnitTest
 
       - name: Upload test report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: unit_test_report_${{ github.run_number }}
           path: app/build/reports/tests/testDevDebugUnitTest/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
       code: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -83,7 +83,7 @@ jobs:
           mv "$apk" app/build/outputs/apk/dev/debug/bitkit_e2e.apk
 
       - name: Upload APK (local)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bitkit-e2e-apk_${{ github.run_number }}
           path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
@@ -136,7 +136,7 @@ jobs:
           mv "$apk" app/build/outputs/apk/dev/debug/bitkit_e2e.apk
 
       - name: Upload APK (regtest)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bitkit-e2e-apk-regtest_${{ github.run_number }}
           path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
@@ -210,7 +210,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Download APK
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: bitkit-e2e-apk_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -302,7 +302,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts_${{ matrix.shard.name }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/
@@ -368,7 +368,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Download APK (regtest)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: bitkit-e2e-apk-regtest_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -454,7 +454,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.shard.name }})
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts-regtest_${{ matrix.shard.name }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -101,7 +101,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/e2e_migration.yml
+++ b/.github/workflows/e2e_migration.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/e2e_migration.yml
+++ b/.github/workflows/e2e_migration.yml
@@ -64,7 +64,7 @@ jobs:
           mv "$apk" app/build/outputs/apk/dev/debug/bitkit_e2e.apk
 
       - name: Upload APK
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bitkit-e2e-apk_${{ github.run_number }}
           path: app/build/outputs/apk/dev/debug/bitkit_e2e.apk
@@ -138,7 +138,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Download APK
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: bitkit-e2e-apk_${{ github.run_number }}
           path: bitkit-e2e-tests/aut
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload E2E Artifacts (${{ matrix.scenario.name }})
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts_${{ matrix.scenario.name }}_${{ matrix.rn_version }}_${{ github.run_number }}
           path: bitkit-e2e-tests/artifacts/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload lint report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: lint_report_${{ github.run_number }}
           path: app/build/reports/detekt/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -149,7 +149,7 @@ jobs:
           echo "artifact_dir=$artifact_dir" >> "$GITHUB_OUTPUT"
 
       - name: Upload internal artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifacts.outputs.artifact_name }}
           path: ${{ steps.artifacts.outputs.artifact_dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
           echo "artifact_dir=$artifact_dir" >> "$GITHUB_OUTPUT"
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifacts.outputs.artifact_name }}
           path: ${{ steps.artifacts.outputs.artifact_dir }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload UI test report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: compose_test_report
           path: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Cache gradle
         uses: actions/cache@v5


### PR DESCRIPTION
Fixes #1021

### Description

CI cleanup for GitHub Actions deprecations on `ubuntu-latest`:

1. **setup-java:** replace deprecated `distribution: 'adopt'` with `'temurin'` in all workflows.
2. **Node 24 actions:** bump third-party and artifact actions that still target Node.js 20:
   - `dorny/paths-filter@v3` → `@v4`
   - `actions/upload-artifact@v6` → `@v7`
   - `actions/download-artifact@v6` → `@v7`

This addresses warnings seen in [E2E run #3629](https://github.com/synonymdev/bitkit-android/actions/runs/28790783860) and [E2E Migration run #185](https://github.com/synonymdev/bitkit-android/actions/runs/28838296504).

Updated workflows: `ci.yml`, `lint.yml`, `ui-tests.yml`, `e2e.yml`, `e2e_migration.yml`, `release.yml`, `release-internal.yml`.

### QA Notes

- CI should pass without AdoptOpenJDK or Node.js 20 deprecation warnings in affected jobs.
- No app or build logic changes; Java and Node versions used by test steps are unchanged.