### PR TITLE
fix: match hw wallets empty state to design

### DIFF
--- a/app/src/main/java/to/bitkit/ui/settings/general/HardwareWalletsSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/general/HardwareWalletsSettingsScreen.kt
@@ -75,6 +75,7 @@ import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.shared.util.gradientBackground
 import to.bitkit.ui.theme.AppThemeSurface
 import to.bitkit.ui.theme.Colors
+import to.bitkit.ui.utils.withAccent
 
 private const val ILLUSTRATIONS_HEIGHT_FRACTION = 0.8f
 
@@ -203,15 +204,15 @@ private fun Content(
 @Composable
 private fun EmptyState(modifier: Modifier = Modifier) {
     Column(
-        verticalArrangement = Arrangement.Center,
-        modifier = modifier.fillMaxWidth()
+        verticalArrangement = Arrangement.Bottom,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
     ) {
-        Display(text = stringResource(R.string.settings__hardware_wallets__nav_title))
+        Display(stringResource(R.string.hardware__intro_header).withAccent(accentColor = Colors.Blue))
         VerticalSpacer(8.dp)
-        BodyM(
-            text = stringResource(R.string.settings__hardware_wallets__empty_text),
-            color = Colors.White80,
-        )
+        BodyM(stringResource(R.string.hardware__intro_text), color = Colors.White64)
+        VerticalSpacer(32.dp)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -891,7 +891,6 @@
     <string name="settings__general__unit_title">Default Unit</string>
     <string name="settings__general_title">General</string>
     <string name="settings__hardware_wallets__add_button">Add Hardware Wallet</string>
-    <string name="settings__hardware_wallets__empty_text">Pair a hardware device to watch its balance and activity in Bitkit.</string>
     <string name="settings__hardware_wallets__name_label">Name</string>
     <string name="settings__hardware_wallets__nav_title">Hardware Wallets</string>
     <string name="settings__hardware_wallets__rename_title">Rename Hardware Wallet</string>


### PR DESCRIPTION
This PR updates the Hardware Wallets settings empty state to match the design, reusing the same content as the hardware wallet intro sheet.

[Figma](https://www.figma.com/design/ltqvnKiejWj0JQiqtDf2JJ/Bitkit-Wallet?node-id=45752-102869&m=dev)

### Description

The empty state previously showed a plain "Hardware Wallets" title with a generic pairing hint, vertically centered on the screen. It now shows the accented "Add your hardware wallet" headline and the intro copy, bottom-aligned just above the Add Hardware Wallet button so the device illustrations fill the space above it.

Because the copy is now shared with the intro sheet, the empty-state string it replaced was removed.

### Preview

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/2aed0c79-18f9-4388-a91d-039475ac2d01" />


### QA Notes

#### Manual Tests

- [x] **1.** No paired hardware wallets → Settings → General → Hardware Wallets: headline reads "Add your hardware wallet" with "hardware wallet" accented in blue, followed by "Connect your hardware device to watch or manage your long-term funds.", both sitting just above the Add Hardware Wallet button with the device illustrations above them.
- [x] **2.** Empty state → tap Add Hardware Wallet: the pairing flow opens as before.
- [x] **3.** `regression:` At least one paired hardware wallet → Settings → General → Hardware Wallets: device rows, balances, rename and remove are unchanged.

#### Automated Checks

- No automated coverage changed: the change is presentation-only, and no unit or E2E test asserted on the removed string or on this screen's test tags.
- `just compile` and `just lint` passed locally.
