### PR TITLE
chore: update fx rates endpoint

### DIFF
--- a/app/src/main/java/to/bitkit/env/Env.kt
+++ b/app/src/main/java/to/bitkit/env/Env.kt
@@ -121,7 +121,7 @@ internal object Env {
 
     val btcRatesServer
         get() = when (network) {
-            Network.BITCOIN -> "https://blocktank.synonym.to/fx/rates/btc"
+            Network.BITCOIN -> "https://api1.blocktank.to/api/fx/rates/btc"
             else -> "https://bitkit.stag0.blocktank.to/fx/rates/btc"
         }
 

--- a/changelog.d/next/1072.changed.md
+++ b/changelog.d/next/1072.changed.md
@@ -1,0 +1,1 @@
+Update FX rates endpoint to no longer use old Blocktank service.


### PR DESCRIPTION
### Description

Update FX rates endpoint to no longer use old Blocktank service.

See https://synonymworkspace.slack.com/archives/C07BJ7DNPCG/p1784012810894369
