### PR TITLE
chore: version 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2] - 2026-07-14
+
+### Fixed
+- Improved Lightning payment route selection reliability. #1052
+
 ## [2.3.1] - 2026-06-26
 
 ### Fixed
@@ -100,7 +105,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - About screen (content merged into Support) #857
 - Standalone General, Security, and Advanced settings screens (merged into tabs) #857
 
-[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.3.1...HEAD
+[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.3.2...HEAD
+[2.3.2]: https://github.com/synonymdev/bitkit-android/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/synonymdev/bitkit-android/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/synonymdev/bitkit-android/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/synonymdev/bitkit-android/compare/v2.1.2...v2.2.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,8 +169,8 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 184
-        versionName = "2.3.1"
+        versionCode = 185
+        versionName = "2.3.2"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         bitkitAndroidTestAnnotation?.let {
             testInstrumentationRunnerArguments["annotation"] = it

--- a/changelog.d/next/1052.fixed.md
+++ b/changelog.d/next/1052.fixed.md
@@ -1,1 +1,0 @@
-Improved Lightning payment route selection reliability.


### PR DESCRIPTION
### Description

Backfills the 2.3.2 release version bump onto master.

- Bumps `versionCode` from `184` to `185`
- Bumps `versionName` from `2.3.1` to `2.3.2`
- Adds the 2.3.2 changelog section for #1052
- Removes the consumed #1052 changelog fragment from `changelog.d/next`

### Preview

N/A

### QA Notes

- Verified the changelog preview no longer includes the consumed #1052 fragment in `next`