### PR TITLE
chore: bump version 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-07-15
+
+### Added
+- Added a dedicated detail screen for paired hardware wallets, showing balances, transaction history, and a remove action. #1022
+- Added a Hardware Wallets settings screen to view and remove paired devices, reachable from Settings under General › Payments. #1032
+- Connect a Trezor hardware wallet from the home suggestion card or Hardware Wallets settings to watch its balance. #1033
+- Transfer funds from a paired Trezor hardware wallet to your spending balance, with safer fee handling and confirmation tracking for device-signed funding transactions. #1039
+- Background payments now include a "Keep Bitkit active in background" option for more reliable payments, and payment notifications always show the amount received. #1053
+- Added the ability to rename saved hardware wallets from Settings. #1057
+- Trezor hardware wallet support with improved connection reliability, native SegWit balance tracking, and transfer to spending. #1062
+- Show paired Trezor hardware wallet balances and activity on the home screen, with sheets to enter pairing code and notify incoming hardware wallet transactions. #999
+
+### Changed
+- Update FX rates endpoint to no longer use old Blocktank service. #1072
+
+### Fixed
+- Connection Details now shows the short channel ID for Lightning connections instead of the long internal channel ID. #1002
+- The system notification permission dialog is now only requested when you tap Enable on the background payments prompt, instead of appearing automatically on every app open. #1004
+- Transfer to Spending now fills in the maximum transferable amount when you enter a value above the limit, instead of only showing an error. #1013
+- Bitkit now handles more unexpected native on-chain wallet sync failures without crashing. #1015
+- Re-adding the Suggestions widget now restores the default suggestion cards when all of them had been dismissed. #1016
+- Transferring to your spending balance now reliably shows the "Spending Balance Ready" confirmation instead of sometimes being mistaken for an incoming payment when an unused instant-payment invoice is still pending. #1017
+- Recovery mode now has a Reset Network Graph option that re-downloads the Lightning network graph to fix "route not found" errors. #1020
+- Error toasts now use the brand orange color to match the design prototype. #1023
+- Channel close and transfer activities, including force closes, now offer an Explore button so the on-chain transaction ID and block explorer details are accessible. #1037
+- Spending balances no longer briefly include cooperatively closed channel funds after opening a new channel. #1043
+- Tapping an NFC tag now opens the gift claim and other deep links instead of being ignored, and the NFC intent filter no longer declares the unused BROWSABLE category that triggered a Play Console deep link warning. #1054
+- Pending transfer funds now stay reflected in the total balance without temporarily inflating it while moving between savings and spending. #1058
+- Fixed a raw technical error appearing when a locked Trezor blocks connecting or signing; Bitkit now asks you to unlock the device and retries automatically. #1065
+- Improved Trezor pairing, Bluetooth recovery, connection and unlock guidance, transfer cancellation, and signed-broadcast retries. #1067
+- Hardware wallet transfer sign screens now show the on-chain mining fee and total outflow that matches Trezor confirmation. #1071
+- Tapping Connect on the Electrum server settings screen no longer freezes the app when the host field contains a long or malformed value. #1077
+- Fixed a crash that could occur when showing the backup-failure notification in some languages. #1080
+- Instant-channel payment notifications now appear once with a correctly formatted amount, and opening a regular channel no longer shows a misleading "payment received" notification. #787
+- The amount number pad now caps entry at the available maximum on the send, LNURL, transfer, and channel-funding screens, stays usable at a zero balance, and lets you delete down from an over-cap amount. #908
+- Home-screen widgets no longer render too tall on Android 10 and 11, matching the size shown on newer Android versions. #994
+- Fixed private contact payment preferences so they only show confirmed endpoint publication or removal state. #997
+
+
+
+
+
 ## [2.3.2] - 2026-07-14
 
 ### Fixed
@@ -105,7 +147,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - About screen (content merged into Support) #857
 - Standalone General, Security, and Advanced settings screens (merged into tabs) #857
 
-[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.3.2...HEAD
+[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/synonymdev/bitkit-android/compare/v2.3.2...v2.4.0
 [2.3.2]: https://github.com/synonymdev/bitkit-android/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/synonymdev/bitkit-android/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/synonymdev/bitkit-android/compare/v2.2.0...v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update FX rates endpoint to no longer use old Blocktank service. #1072
 
 ### Fixed
+- Hardware wallet transfers to spending now use a faster on-chain fee rate so funding confirms more reliably. #1089
 - Connection Details now shows the short channel ID for Lightning connections instead of the long internal channel ID. #1002
 - The system notification permission dialog is now only requested when you tap Enable on the background payments prompt, instead of appearing automatically on every app open. #1004
 - Transfer to Spending now fills in the maximum transferable amount when you enter a value above the limit, instead of only showing an error. #1013

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,7 +169,7 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 186
+        versionCode = 187
         versionName = "2.4.0"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         bitkitAndroidTestAnnotation?.let {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,8 +169,8 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 185
-        versionName = "2.3.2"
+        versionCode = 186
+        versionName = "2.4.0"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         bitkitAndroidTestAnnotation?.let {
             testInstrumentationRunnerArguments["annotation"] = it

--- a/changelog.d/next/1002.fixed.md
+++ b/changelog.d/next/1002.fixed.md
@@ -1,1 +1,0 @@
-Connection Details now shows the short channel ID for Lightning connections instead of the long internal channel ID.

--- a/changelog.d/next/1004.fixed.md
+++ b/changelog.d/next/1004.fixed.md
@@ -1,1 +1,0 @@
-The system notification permission dialog is now only requested when you tap Enable on the background payments prompt, instead of appearing automatically on every app open.

--- a/changelog.d/next/1013.fixed.md
+++ b/changelog.d/next/1013.fixed.md
@@ -1,1 +1,0 @@
-Transfer to Spending now fills in the maximum transferable amount when you enter a value above the limit, instead of only showing an error.

--- a/changelog.d/next/1015.fixed.md
+++ b/changelog.d/next/1015.fixed.md
@@ -1,1 +1,0 @@
-Bitkit now handles more unexpected native on-chain wallet sync failures without crashing.

--- a/changelog.d/next/1016.fixed.md
+++ b/changelog.d/next/1016.fixed.md
@@ -1,1 +1,0 @@
-Re-adding the Suggestions widget now restores the default suggestion cards when all of them had been dismissed.

--- a/changelog.d/next/1017.fixed.md
+++ b/changelog.d/next/1017.fixed.md
@@ -1,1 +1,0 @@
-Transferring to your spending balance now reliably shows the "Spending Balance Ready" confirmation instead of sometimes being mistaken for an incoming payment when an unused instant-payment invoice is still pending.

--- a/changelog.d/next/1020.fixed.md
+++ b/changelog.d/next/1020.fixed.md
@@ -1,1 +1,0 @@
-Recovery mode now has a Reset Network Graph option that re-downloads the Lightning network graph to fix "route not found" errors.

--- a/changelog.d/next/1022.added.md
+++ b/changelog.d/next/1022.added.md
@@ -1,1 +1,0 @@
-Added a dedicated detail screen for paired hardware wallets, showing balances, transaction history, and a remove action.

--- a/changelog.d/next/1023.fixed.md
+++ b/changelog.d/next/1023.fixed.md
@@ -1,1 +1,0 @@
-Error toasts now use the brand orange color to match the design prototype.

--- a/changelog.d/next/1032.added.md
+++ b/changelog.d/next/1032.added.md
@@ -1,1 +1,0 @@
-Added a Hardware Wallets settings screen to view and remove paired devices, reachable from Settings under General › Payments.

--- a/changelog.d/next/1033.added.md
+++ b/changelog.d/next/1033.added.md
@@ -1,1 +1,0 @@
-Connect a Trezor hardware wallet from the home suggestion card or Hardware Wallets settings to watch its balance.

--- a/changelog.d/next/1037.fixed.md
+++ b/changelog.d/next/1037.fixed.md
@@ -1,1 +1,0 @@
-Channel close and transfer activities, including force closes, now offer an Explore button so the on-chain transaction ID and block explorer details are accessible.

--- a/changelog.d/next/1039.added.md
+++ b/changelog.d/next/1039.added.md
@@ -1,1 +1,0 @@
-Transfer funds from a paired Trezor hardware wallet to your spending balance, with safer fee handling and confirmation tracking for device-signed funding transactions.

--- a/changelog.d/next/1043.fixed.md
+++ b/changelog.d/next/1043.fixed.md
@@ -1,1 +1,0 @@
-Spending balances no longer briefly include cooperatively closed channel funds after opening a new channel.

--- a/changelog.d/next/1053.added.md
+++ b/changelog.d/next/1053.added.md
@@ -1,1 +1,0 @@
-Background payments now include a "Keep Bitkit active in background" option for more reliable payments, and payment notifications always show the amount received.

--- a/changelog.d/next/1054.fixed.md
+++ b/changelog.d/next/1054.fixed.md
@@ -1,1 +1,0 @@
-Tapping an NFC tag now opens the gift claim and other deep links instead of being ignored, and the NFC intent filter no longer declares the unused BROWSABLE category that triggered a Play Console deep link warning.

--- a/changelog.d/next/1057.added.md
+++ b/changelog.d/next/1057.added.md
@@ -1,1 +1,0 @@
-Added the ability to rename saved hardware wallets from Settings.

--- a/changelog.d/next/1058.fixed.md
+++ b/changelog.d/next/1058.fixed.md
@@ -1,1 +1,0 @@
-Pending transfer funds now stay reflected in the total balance without temporarily inflating it while moving between savings and spending.

--- a/changelog.d/next/1062.added.md
+++ b/changelog.d/next/1062.added.md
@@ -1,1 +1,0 @@
-Trezor hardware wallet support with improved connection reliability, native SegWit balance tracking, and transfer to spending.

--- a/changelog.d/next/1065.fixed.md
+++ b/changelog.d/next/1065.fixed.md
@@ -1,1 +1,0 @@
-Fixed a raw technical error appearing when a locked Trezor blocks connecting or signing; Bitkit now asks you to unlock the device and retries automatically.

--- a/changelog.d/next/1067.fixed.md
+++ b/changelog.d/next/1067.fixed.md
@@ -1,1 +1,0 @@
-Improved Trezor pairing, Bluetooth recovery, connection and unlock guidance, transfer cancellation, and signed-broadcast retries.

--- a/changelog.d/next/1071.fixed.md
+++ b/changelog.d/next/1071.fixed.md
@@ -1,1 +1,0 @@
-Hardware wallet transfer sign screens now show the on-chain mining fee and total outflow that matches Trezor confirmation.

--- a/changelog.d/next/1072.changed.md
+++ b/changelog.d/next/1072.changed.md
@@ -1,1 +1,0 @@
-Update FX rates endpoint to no longer use old Blocktank service.

--- a/changelog.d/next/1077.fixed.md
+++ b/changelog.d/next/1077.fixed.md
@@ -1,1 +1,0 @@
-Tapping Connect on the Electrum server settings screen no longer freezes the app when the host field contains a long or malformed value.

--- a/changelog.d/next/1080.fixed.md
+++ b/changelog.d/next/1080.fixed.md
@@ -1,1 +1,0 @@
-Fixed a crash that could occur when showing the backup-failure notification in some languages.

--- a/changelog.d/next/1089.fixed.md
+++ b/changelog.d/next/1089.fixed.md
@@ -1,1 +1,0 @@
-Hardware wallet transfers to spending now use a faster on-chain fee rate so funding confirms more reliably.

--- a/changelog.d/next/787.fixed.md
+++ b/changelog.d/next/787.fixed.md
@@ -1,1 +1,0 @@
-Instant-channel payment notifications now appear once with a correctly formatted amount, and opening a regular channel no longer shows a misleading "payment received" notification.

--- a/changelog.d/next/908.fixed.md
+++ b/changelog.d/next/908.fixed.md
@@ -1,1 +1,0 @@
-The amount number pad now caps entry at the available maximum on the send, LNURL, transfer, and channel-funding screens, stays usable at a zero balance, and lets you delete down from an over-cap amount.

--- a/changelog.d/next/994.fixed.md
+++ b/changelog.d/next/994.fixed.md
@@ -1,1 +1,0 @@
-Home-screen widgets no longer render too tall on Android 10 and 11, matching the size shown on newer Android versions.

--- a/changelog.d/next/997.fixed.md
+++ b/changelog.d/next/997.fixed.md
@@ -1,1 +1,0 @@
-Fixed private contact payment preferences so they only show confirmed endpoint publication or removal state.

--- a/changelog.d/next/999.added.md
+++ b/changelog.d/next/999.added.md
@@ -1,1 +1,0 @@
-Show paired Trezor hardware wallet balances and activity on the home screen, with sheets to enter pairing code and notify incoming hardware wallet transactions.


### PR DESCRIPTION
Bump version to 2.4.0 (build 186) for release.

### Description

- `versionCode`: 185 → ~186~ → 187
- `versionName`: 2.3.2 → 2.4.0

### Preview

N/A

### QA Notes

N/A

Made with [Cursor](https://cursor.com)