### PR TITLE
fix: prevent crash during wallet backup

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.synonym.bitkitcore.migrateBackupActivitiesJson
 import com.synonym.bitkitcore.migrateBackupActivityTagsJson
 import com.synonym.bitkitcore.migrateBackupPreActivityMetadataJson
+import com.synonym.vssclient.VssItem
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
@@ -425,7 +426,7 @@ class BackupRepo @Inject constructor(
         }
     }
 
-    suspend fun triggerBackup(category: BackupCategory) = withContext(ioDispatcher) {
+    suspend fun triggerBackup(category: BackupCategory): Result<VssItem> = withContext(ioDispatcher) {
         Logger.debug("Backup starting for: '$category'", context = TAG)
 
         val backupRequired = currentTimeMillis()
@@ -437,7 +438,7 @@ class BackupRepo @Inject constructor(
 
         val data = runSuspendCatching { getBackupDataBytes(category) }
             .onFailure { markBackupFailed(category, backupRequired, it) }
-            .getOrNull() ?: return@withContext
+            .getOrElse { return@withContext Result.failure(it) }
 
         vssBackupClient.putObject(key = category.name, data = data)
             .onSuccess {

--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.synonym.bitkitcore.migrateBackupActivitiesJson
 import com.synonym.bitkitcore.migrateBackupActivityTagsJson
 import com.synonym.bitkitcore.migrateBackupPreActivityMetadataJson
-import com.synonym.vssclient.VssItem
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
@@ -426,7 +425,7 @@ class BackupRepo @Inject constructor(
         }
     }
 
-    suspend fun triggerBackup(category: BackupCategory): Result<VssItem> = withContext(ioDispatcher) {
+    suspend fun triggerBackup(category: BackupCategory): Result<Unit> = withContext(ioDispatcher) {
         Logger.debug("Backup starting for: '$category'", context = TAG)
 
         val backupRequired = currentTimeMillis()
@@ -437,8 +436,10 @@ class BackupRepo @Inject constructor(
         }
 
         val data = runSuspendCatching { getBackupDataBytes(category) }
-            .onFailure { markBackupFailed(category, backupRequired, it) }
-            .getOrElse { return@withContext Result.failure(it) }
+            .getOrElse {
+                markBackupFailed(category, backupRequired, it)
+                return@withContext Result.failure(it)
+            }
 
         vssBackupClient.putObject(key = category.name, data = data)
             .onSuccess {
@@ -453,6 +454,7 @@ class BackupRepo @Inject constructor(
                 Logger.info("Backup succeeded for: '$category'", context = TAG)
             }
             .onFailure { markBackupFailed(category, backupRequired, it) }
+            .map {}
     }
 
     private suspend fun markBackupFailed(category: BackupCategory, backupRequired: Long, e: Throwable) {
@@ -541,16 +543,8 @@ class BackupRepo @Inject constructor(
 
     private suspend fun getWalletBackupDataBytes(): ByteArray {
         val transfers = db.transferDao().getAll()
-        val privateReservations = privatePaykitAddressReservationRepo.get().backupSnapshot()
-            .onFailure {
-                Logger.warn("Failed to snapshot private Paykit reservations", it, context = TAG)
-            }
-            .getOrThrow()
-        val paykitSdkBackupState = privatePaykitRepo.get().backupSnapshot()
-            .onFailure {
-                Logger.warn("Failed to snapshot Paykit SDK state", it, context = TAG)
-            }
-            .getOrThrow()
+        val privateReservations = privatePaykitAddressReservationRepo.get().backupSnapshot().getOrThrow()
+        val paykitSdkBackupState = privatePaykitRepo.get().backupSnapshot().getOrThrow()
 
         val payload = WalletBackupV1(
             createdAt = currentTimeMillis(),

--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -44,6 +44,7 @@ import to.bitkit.di.IoDispatcher
 import to.bitkit.di.json
 import to.bitkit.ext.formatPlural
 import to.bitkit.ext.nowMillis
+import to.bitkit.ext.runSuspendCatching
 import to.bitkit.models.ActivityBackupV1
 import to.bitkit.models.BackupCategory
 import to.bitkit.models.BackupItemStatus
@@ -435,7 +436,11 @@ class BackupRepo @Inject constructor(
             it.copy(running = true, required = backupRequired)
         }
 
-        vssBackupClient.putObject(key = category.name, data = getBackupDataBytes(category))
+        val data = runSuspendCatching { getBackupDataBytes(category) }
+            .onFailure { markBackupFailed(category, backupRequired, it) }
+            .getOrNull() ?: return@withContext
+
+        vssBackupClient.putObject(key = category.name, data = data)
             .onSuccess {
                 runningBackups -= category
                 failedBackupRequired -= category
@@ -447,18 +452,20 @@ class BackupRepo @Inject constructor(
                 }
                 Logger.info("Backup succeeded for: '$category'", context = TAG)
             }
-            .onFailure { e ->
-                runningBackups -= category
-                cacheStore.updateBackupStatus(category) {
-                    if (it.required == backupRequired) {
-                        failedBackupRequired[category] = backupRequired
-                    } else {
-                        failedBackupRequired -= category
-                    }
-                    it.copy(running = false)
-                }
-                Logger.error("Backup failed for: '$category'", e, context = TAG)
+            .onFailure { markBackupFailed(category, backupRequired, it) }
+    }
+
+    private suspend fun markBackupFailed(category: BackupCategory, backupRequired: Long, e: Throwable) {
+        runningBackups -= category
+        cacheStore.updateBackupStatus(category) {
+            if (it.required == backupRequired) {
+                failedBackupRequired[category] = backupRequired
+            } else {
+                failedBackupRequired -= category
             }
+            it.copy(running = false)
+        }
+        Logger.error("Backup failed for: '$category'", e, context = TAG)
     }
 
     private suspend fun getBackupDataBytes(category: BackupCategory): ByteArray = when (category) {

--- a/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
@@ -40,6 +40,7 @@ import to.bitkit.services.PaykitSdkService
 import to.bitkit.test.BaseUnitTest
 import to.bitkit.utils.AppError
 import javax.inject.Provider
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -109,6 +110,35 @@ class BackupRepoTest : BaseUnitTest() {
         assertTrue(result.isFailure)
         verify(privatePaykitRepo, never()).restoreBackup(any())
         verify(settingsStore, never()).update(any())
+    }
+
+    @Test
+    fun `automatic wallet backup marks failure when Paykit snapshot fails`() = test {
+        whenever { privatePaykitRepo.backupSnapshot() }
+            .thenReturn(Result.failure(BackupRepoTestError("paykit session missing capabilities")))
+        val backupStatuses = MutableStateFlow(
+            mapOf(
+                BackupCategory.WALLET to BackupItemStatus(
+                    synced = 1_000,
+                    required = 2_000,
+                ),
+            )
+        )
+        val allowWalletClear = CompletableDeferred<Unit>().apply { complete(Unit) }
+        stubBackupStatuses(backupStatuses, allowWalletClear) {}
+        stubBackupObservers()
+
+        try {
+            sut.startObservingBackups()
+            runCurrent()
+            advanceTimeBy(5_000)
+            runCurrent()
+
+            verify(vssBackupClient, never()).putObject(eq(BackupCategory.WALLET.name), any())
+            assertFalse(backupStatuses.value.getValue(BackupCategory.WALLET).running)
+        } finally {
+            sut.stopObservingBackups()
+        }
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
@@ -114,6 +114,7 @@ class BackupRepoTest : BaseUnitTest() {
 
     @Test
     fun `automatic wallet backup marks failure when Paykit snapshot fails`() = test {
+        whenever(clock.now()).thenReturn(Instant.fromEpochMilliseconds(3_000))
         whenever { privatePaykitRepo.backupSnapshot() }
             .thenReturn(Result.failure(BackupRepoTestError("paykit session missing capabilities")))
         val backupStatuses = MutableStateFlow(
@@ -134,8 +135,17 @@ class BackupRepoTest : BaseUnitTest() {
             advanceTimeBy(5_000)
             runCurrent()
 
+            verify(privatePaykitRepo).backupSnapshot()
             verify(vssBackupClient, never()).putObject(eq(BackupCategory.WALLET.name), any())
-            assertFalse(backupStatuses.value.getValue(BackupCategory.WALLET).running)
+            val status = backupStatuses.value.getValue(BackupCategory.WALLET)
+            assertTrue(status.isRequired)
+            assertFalse(status.running)
+
+            advanceTimeBy(5_000)
+            runCurrent()
+
+            verify(privatePaykitRepo).backupSnapshot()
+            verify(vssBackupClient, never()).putObject(eq(BackupCategory.WALLET.name), any())
         } finally {
             sut.stopObservingBackups()
         }

--- a/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
@@ -144,7 +144,8 @@ class BackupRepoTest : BaseUnitTest() {
             advanceTimeBy(5_000)
             runCurrent()
 
-            verify(privatePaykitRepo).backupSnapshot()
+            // still one attempt: the failed timestamp suppresses a retry until data changes again
+            verify(privatePaykitRepo, times(1)).backupSnapshot()
             verify(vssBackupClient, never()).putObject(eq(BackupCategory.WALLET.name), any())
         } finally {
             sut.stopObservingBackups()

--- a/changelog.d/next/1092.fixed.md
+++ b/changelog.d/next/1092.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash during automatic wallet backup when Paykit state could not be read.

--- a/changelog.d/next/1092.fixed.md
+++ b/changelog.d/next/1092.fixed.md
@@ -1,1 +1,1 @@
-Fixed a crash during automatic wallet backup when Paykit state could not be read.
+Fixed the wallet backup failing repeatedly when Paykit state could not be read.


### PR DESCRIPTION
This PR fixes a crash that could put the app into a restart loop shortly after launch.

### Description

The wallet backup payload was assembled outside of any error handling, so a failure while reading Paykit state escaped the backup coroutine and brought the whole app down. The automatic backup runs shortly after every launch, so an affected wallet crash-looped on startup with no way for the user to recover.

The payload is now built inside the existing failure handling. A failed read marks the backup as failed and retries later, the same way an upload failure already did. This also covers the retry action on the Backup settings screen, which previously crashed when tapped for a failed wallet backup.

The trigger seen in the wild was a stored Paykit session missing capabilities the SDK now requires, which is only reachable if Paykit was turned on from dev settings. The backup path itself is not gated, so any Paykit initialisation failure could take down the app the same way for any user.

#### Relationship to #1094

This branch was cut before #1094 merged, which is why the crash above was reachable at all: the backup scope had no exception handler, so the throw reached the system default handler and killed the process. #1094 has since been merged into this branch and now contains that throw.

The two fixes are complementary rather than overlapping. #1094 stops the process dying, but on its own it leaves the failure only logged, and the backup then retries every five seconds indefinitely because the category is never marked as failed. This PR is the concrete instance of the follow-up #1094 called out: guarding the specific background body so the failure is handled meaningfully instead of only logged.

The retry action on the Backup settings screen runs on the screen's view-model scope, which #1094 does not cover, so that path was fatal before #1094 and stays fatal without this PR.

Recovering a stale session and broader coroutine error handling are follow-ups (#1093). That includes the Paykit dependencies resolved when backup observation starts, which also run on a view-model scope and are still unguarded. This PR only stops the crash, so an affected wallet will report a failed wallet backup instead of crashing.

### Preview

N/A — no user-facing UI changes.

### QA Notes

#### Manual Tests
- [x] **1.** `regression:` Fresh launch with wallet activity → wait for automatic backup: Settings → Backup shows wallet backup synced, no crash.
- [x] **2.** `regression:` Settings → Backup → tap retry on a failed wallet backup: retries without crashing.
- [x] **3.** Dev settings → Paykit enabled with a stale session → launch and wait for automatic backup: app stays up, wallet backup reports a failure once, and does not retry in a loop. With #1094 merged in, an unfixed build no longer crashes here, so check the session log for a backup attempt repeating every five seconds rather than for a process death.

#### Automated Checks
- Unit tests added: cover the wallet backup marking a failure instead of crashing when the Paykit snapshot fails, in `BackupRepoTest.kt`. Verified failing before the fix and passing after.
- CI: standard compile, unit test, and detekt checks run by the PR bot.
