### PR TITLE
fix: guard coroutine scopes against crashes

### DIFF
--- a/app/src/main/java/to/bitkit/App.kt
+++ b/app/src/main/java/to/bitkit/App.kt
@@ -14,6 +14,7 @@ import to.bitkit.appwidget.AppWidgetRefreshReason
 import to.bitkit.appwidget.AppWidgetRefreshScheduler
 import to.bitkit.env.Env
 import to.bitkit.services.BluetoothInit
+import to.bitkit.utils.Logger
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -34,6 +35,7 @@ internal open class App : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        installUncaughtExceptionLogger()
         Env.initAppStoragePath(filesDir.absolutePath)
         SingletonImageLoader.setSafe { imageLoader }
         currentActivity = CurrentActivity().also { registerActivityLifecycleCallbacks(it) }
@@ -42,7 +44,17 @@ internal open class App : Application(), Configuration.Provider {
         BluetoothInit.ensureInitialized()
     }
 
+    private fun installUncaughtExceptionLogger() {
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            Logger.error("Uncaught exception on thread '${thread.name}'", throwable, context = TAG)
+            previous?.uncaughtException(thread, throwable)
+        }
+    }
+
     companion object {
+        private const val TAG = "App"
+
         @SuppressLint("StaticFieldLeak") // Should be safe given its manual memory management
         internal var currentActivity: CurrentActivity? = null
     }

--- a/app/src/main/java/to/bitkit/App.kt
+++ b/app/src/main/java/to/bitkit/App.kt
@@ -35,8 +35,8 @@ internal open class App : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-        installUncaughtExceptionLogger()
         Env.initAppStoragePath(filesDir.absolutePath)
+        installUncaughtExceptionLogger()
         SingletonImageLoader.setSafe { imageLoader }
         currentActivity = CurrentActivity().also { registerActivityLifecycleCallbacks(it) }
         appWidgetRefreshScheduler.ensureScheduled(AppWidgetRefreshReason.APP_START)

--- a/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
+++ b/app/src/main/java/to/bitkit/androidServices/LightningNodeService.kt
@@ -14,14 +14,13 @@ import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.lightningdevkit.ldknode.Event
 import to.bitkit.App
 import to.bitkit.R
 import to.bitkit.appwidget.AppWidgetRefreshReason
 import to.bitkit.appwidget.AppWidgetRefreshScheduler
+import to.bitkit.async.appScope
 import to.bitkit.data.CacheStore
 import to.bitkit.di.UiDispatcher
 import to.bitkit.domain.commands.NotifyChannelReady
@@ -53,7 +52,7 @@ class LightningNodeService : Service() {
     @UiDispatcher
     lateinit var uiDispatcher: CoroutineDispatcher
 
-    private val serviceScope by lazy { CoroutineScope(SupervisorJob() + uiDispatcher) }
+    private val serviceScope by lazy { appScope(uiDispatcher, TAG) }
 
     @Inject
     lateinit var lightningRepo: LightningRepo

--- a/app/src/main/java/to/bitkit/async/BaseCoroutineScope.kt
+++ b/app/src/main/java/to/bitkit/async/BaseCoroutineScope.kt
@@ -7,7 +7,8 @@ import kotlin.coroutines.CoroutineContext
 
 open class BaseCoroutineScope(
     private val dispatcher: CoroutineDispatcher,
-) : CoroutineScope by CoroutineScope(SupervisorJob() + dispatcher) {
+    tag: String,
+) : CoroutineScope by CoroutineScope(SupervisorJob() + dispatcher + loggingExceptionHandler(tag)) {
 
     @Throws(InterruptedException::class)
     protected fun <T> runBlocking(

--- a/app/src/main/java/to/bitkit/async/CoroutineScopes.kt
+++ b/app/src/main/java/to/bitkit/async/CoroutineScopes.kt
@@ -1,0 +1,15 @@
+package to.bitkit.async
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import to.bitkit.utils.Logger
+
+fun loggingExceptionHandler(tag: String): CoroutineExceptionHandler =
+    CoroutineExceptionHandler { _, throwable ->
+        Logger.error("Uncaught coroutine exception", throwable, context = tag)
+    }
+
+fun appScope(dispatcher: CoroutineDispatcher, tag: String): CoroutineScope =
+    CoroutineScope(dispatcher + SupervisorJob() + loggingExceptionHandler(tag))

--- a/app/src/main/java/to/bitkit/async/ServiceQueue.kt
+++ b/app/src/main/java/to/bitkit/async/ServiceQueue.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import to.bitkit.ext.runSuspendCatching
 import to.bitkit.utils.AppError
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
@@ -20,14 +21,14 @@ enum class ServiceQueue {
         coroutineContext: CoroutineContext = scope.coroutineContext,
         block: suspend CoroutineScope.() -> T,
     ): T = runBlocking(coroutineContext) {
-        runCatching { block() }.getOrElse { throw AppError(it) }
+        runSuspendCatching { block() }.getOrElse { throw AppError(it) }
     }
 
     suspend fun <T> background(
         coroutineContext: CoroutineContext = scope.coroutineContext,
         block: suspend CoroutineScope.() -> T,
     ): T = withContext(coroutineContext) {
-        runCatching { block() }.getOrElse { throw AppError(it) }
+        runSuspendCatching { block() }.getOrElse { throw AppError(it) }
     }
 }
 

--- a/app/src/main/java/to/bitkit/data/keychain/Keychain.kt
+++ b/app/src/main/java/to/bitkit/data/keychain/Keychain.kt
@@ -34,7 +34,7 @@ class Keychain @Inject constructor(
     private val db: AppDb,
     @ApplicationContext private val context: Context,
     @IoDispatcher private val dispatcher: CoroutineDispatcher,
-) : BaseCoroutineScope(dispatcher) {
+) : BaseCoroutineScope(dispatcher, TAG) {
     companion object {
         private const val TAG = "Keychain"
         private const val CAUSE_CHAIN_DEPTH = 4

--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -6,10 +6,8 @@ import com.synonym.bitkitcore.migrateBackupActivityTagsJson
 import com.synonym.bitkitcore.migrateBackupPreActivityMetadataJson
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
@@ -33,6 +31,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import to.bitkit.R
+import to.bitkit.async.appScope
 import to.bitkit.data.AppDb
 import to.bitkit.data.CacheStore
 import to.bitkit.data.SettingsStore
@@ -102,7 +101,7 @@ class BackupRepo @Inject constructor(
     private val clock: Clock,
     private val db: AppDb,
 ) {
-    private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val scope = appScope(ioDispatcher, TAG)
 
     private val backupJobs = mutableMapOf<BackupCategory, Job>()
     private val statusObserverJobs = mutableListOf<Job>()

--- a/app/src/main/java/to/bitkit/repositories/BlocktankRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BlocktankRepo.kt
@@ -21,9 +21,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -50,6 +48,7 @@ import org.lightningdevkit.ldknode.Bolt11Invoice
 import org.lightningdevkit.ldknode.ChannelDetails
 import org.lightningdevkit.ldknode.Event
 import to.bitkit.async.ServiceQueue
+import to.bitkit.async.appScope
 import to.bitkit.data.CacheStore
 import to.bitkit.di.BgDispatcher
 import to.bitkit.env.Env
@@ -82,7 +81,7 @@ class BlocktankRepo @Inject constructor(
     @Named("enablePolling") private val enablePolling: Boolean,
     private val lightningRepo: LightningRepo,
 ) {
-    private val repoScope = CoroutineScope(bgDispatcher + SupervisorJob())
+    private val repoScope = appScope(bgDispatcher, TAG)
 
     private val _blocktankState = MutableStateFlow(BlocktankState())
     val blocktankState: StateFlow<BlocktankState> = _blocktankState.asStateFlow()

--- a/app/src/main/java/to/bitkit/repositories/ConnectivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ConnectivityRepo.kt
@@ -9,8 +9,6 @@ import android.os.Handler
 import android.os.Looper
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -19,6 +17,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import to.bitkit.async.appScope
 import to.bitkit.di.BgDispatcher
 import to.bitkit.utils.Logger
 import javax.inject.Inject
@@ -29,11 +28,12 @@ class ConnectivityRepo @Inject constructor(
     @ApplicationContext private val context: Context,
     @BgDispatcher private val bgDispatcher: CoroutineDispatcher,
 ) {
-    private val repoScope = CoroutineScope(bgDispatcher + SupervisorJob())
+    private val repoScope = appScope(bgDispatcher, TAG)
     private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     private val mainHandler = Handler(Looper.getMainLooper())
 
     companion object {
+        private const val TAG = "ConnectivityRepo"
         private const val DELAY_MS = 250L
     }
 

--- a/app/src/main/java/to/bitkit/repositories/CurrencyRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/CurrencyRepo.kt
@@ -5,8 +5,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -22,6 +20,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import to.bitkit.async.appScope
 import to.bitkit.data.CacheStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.di.BgDispatcher
@@ -58,7 +57,7 @@ class CurrencyRepo @Inject constructor(
     private val clock: Clock,
     @Named("enablePolling") private val enablePolling: Boolean,
 ) : AmountInputHandler {
-    private val repoScope = CoroutineScope(bgDispatcher + SupervisorJob())
+    private val repoScope = appScope(bgDispatcher, TAG)
     private val _currencyState = MutableStateFlow(CurrencyState())
     val currencyState: StateFlow<CurrencyState> = _currencyState.asStateFlow()
 

--- a/app/src/main/java/to/bitkit/repositories/HealthRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/HealthRepo.kt
@@ -1,8 +1,6 @@
 package to.bitkit.repositories
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,6 +10,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.lightningdevkit.ldknode.ChannelDetails
+import to.bitkit.async.appScope
 import to.bitkit.data.CacheStore
 import to.bitkit.di.BgDispatcher
 import to.bitkit.models.BackupCategory
@@ -33,7 +32,11 @@ class HealthRepo @Inject constructor(
     private val cacheStore: CacheStore,
     private val clock: Clock,
 ) {
-    private val repoScope = CoroutineScope(bgDispatcher + SupervisorJob())
+    companion object {
+        private const val TAG = "HealthRepo"
+    }
+
+    private val repoScope = appScope(bgDispatcher, TAG)
 
     private val _healthState = MutableStateFlow(AppHealthState())
     val healthState: StateFlow<AppHealthState> = _healthState.asStateFlow()

--- a/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
@@ -13,8 +13,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,6 +28,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import to.bitkit.async.appScope
 import to.bitkit.data.HwWalletStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.di.IoDispatcher
@@ -90,7 +89,7 @@ class HwWalletRepo @Inject constructor(
         private val SUPPORTED_WATCHER_ADDRESS_TYPES = setOf(HwFundingAddressType.NATIVE_SEGWIT.settingsKey)
     }
 
-    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val scope = appScope(ioDispatcher, TAG)
 
     private val activeWatchers = mutableSetOf<String>()
     private val activeWatcherElectrumUrls = mutableMapOf<String, String>()

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -17,9 +17,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -54,6 +52,7 @@ import org.lightningdevkit.ldknode.PaymentId
 import org.lightningdevkit.ldknode.PeerDetails
 import org.lightningdevkit.ldknode.SpendableUtxo
 import org.lightningdevkit.ldknode.Txid
+import to.bitkit.async.appScope
 import to.bitkit.data.CacheStore
 import to.bitkit.data.SettingsData
 import to.bitkit.data.SettingsStore
@@ -73,6 +72,7 @@ import to.bitkit.models.NATIVE_WITNESS_TYPES
 import to.bitkit.models.NodeLifecycleState
 import to.bitkit.models.OpenChannelResult
 import to.bitkit.models.TransactionSpeed
+import to.bitkit.models.WalletScope
 import to.bitkit.models.safe
 import to.bitkit.models.satsToMsat
 import to.bitkit.models.toAddressType
@@ -88,7 +88,6 @@ import to.bitkit.services.LnurlWithdrawResponse
 import to.bitkit.services.LspNotificationsService
 import to.bitkit.services.NodeEventHandler
 import to.bitkit.utils.AppError
-import to.bitkit.models.WalletScope
 import to.bitkit.utils.Logger
 import to.bitkit.utils.ServiceError
 import to.bitkit.utils.UrlValidator
@@ -128,7 +127,7 @@ class LightningRepo @Inject constructor(
     private val _nodeEvents = MutableSharedFlow<Event>(extraBufferCapacity = 64)
     val nodeEvents = _nodeEvents.asSharedFlow()
 
-    private val scope = CoroutineScope(bgDispatcher + SupervisorJob())
+    private val scope = appScope(bgDispatcher, TAG)
 
     private val _eventHandlers = ConcurrentHashMap.newKeySet<NodeEventHandler>()
     private val _isRecoveryMode = MutableStateFlow(false)

--- a/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
@@ -9,10 +9,8 @@ import com.synonym.paykit.PrivatePaymentListDeliveryReport
 import com.synonym.paykit.PrivatePaymentListReservationUpdateInput
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +25,7 @@ import org.lightningdevkit.ldknode.PaymentDirection
 import org.lightningdevkit.ldknode.PaymentKind
 import org.lightningdevkit.ldknode.PaymentStatus
 import to.bitkit.App
+import to.bitkit.async.appScope
 import to.bitkit.data.PrivatePaykitCacheStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.di.IoDispatcher
@@ -86,7 +85,7 @@ class PrivatePaykitRepo @Inject constructor(
 
     private val publicationMutex = Mutex()
     private val serializedDispatcher = ioDispatcher.limitedParallelism(1)
-    private val retryScope = CoroutineScope(serializedDispatcher + SupervisorJob())
+    private val retryScope = appScope(serializedDispatcher, TAG)
     private val knownSavedContactKeys = mutableSetOf<String>()
     private var state: PrivatePaykitState? = null
     private val pendingMessageDrainRetryLock = Any()

--- a/app/src/main/java/to/bitkit/repositories/PubkyRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PubkyRepo.kt
@@ -11,9 +11,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.post
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -33,6 +31,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import to.bitkit.async.appScope
 import to.bitkit.data.PubkyStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.data.hasPublicPaykitPublicationState
@@ -94,7 +93,7 @@ class PubkyRepo @Inject constructor(
         private const val AVATAR_QUALITY = 80
     }
 
-    private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private val scope = appScope(ioDispatcher, TAG)
     private val serviceInitializeMutex = Mutex()
     private val initializeMutex = Mutex()
     private val loadProfileMutex = Mutex()

--- a/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
@@ -33,10 +33,8 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -53,6 +51,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import to.bitkit.async.appScope
 import to.bitkit.data.HwWalletStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.di.IoDispatcher
@@ -126,7 +125,7 @@ class TrezorRepo @Inject constructor(
     private val _state = MutableStateFlow(TrezorState())
     val state = _state.asStateFlow()
 
-    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val scope = appScope(ioDispatcher, TAG)
     private var isSetup = CompletableDeferred<Unit>()
     private val setupMutex = Mutex()
 

--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
@@ -10,9 +10,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +21,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.lightningdevkit.ldknode.Event
 import org.lightningdevkit.ldknode.WordCount
+import to.bitkit.async.appScope
 import to.bitkit.data.CacheStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.data.keychain.Keychain
@@ -36,6 +35,7 @@ import to.bitkit.models.ALL_ADDRESS_TYPE_STRINGS
 import to.bitkit.models.AddressModel
 import to.bitkit.models.BalanceState
 import to.bitkit.models.DEFAULT_ADDRESS_TYPE_STRING
+import to.bitkit.models.WalletScope
 import to.bitkit.models.msatFloorOf
 import to.bitkit.models.toAccountDerivationPath
 import to.bitkit.models.toBalance
@@ -45,7 +45,6 @@ import to.bitkit.services.CoreService
 import to.bitkit.usecases.DeriveBalanceStateUseCase
 import to.bitkit.usecases.WipeWalletUseCase
 import to.bitkit.utils.Bip21Utils
-import to.bitkit.models.WalletScope
 import to.bitkit.utils.Logger
 import to.bitkit.utils.ServiceError
 import to.bitkit.utils.measured
@@ -71,7 +70,7 @@ class WalletRepo @Inject constructor(
     private val activityRepo: ActivityRepo,
     private val hwWalletRepo: HwWalletRepo,
 ) {
-    private val repoScope = CoroutineScope(bgDispatcher + SupervisorJob())
+    private val repoScope = appScope(bgDispatcher, TAG)
 
     private val _walletState = MutableStateFlow(WalletState(walletExists = walletExists()))
     val walletState = _walletState.asStateFlow()

--- a/app/src/main/java/to/bitkit/repositories/WidgetsRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WidgetsRepo.kt
@@ -1,9 +1,7 @@
 package to.bitkit.repositories
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +16,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import to.bitkit.async.appScope
 import to.bitkit.data.WidgetsData
 import to.bitkit.data.WidgetsStore
 import to.bitkit.data.dto.ArticleDTO
@@ -57,7 +56,7 @@ class WidgetsRepo @Inject constructor(
     private val priceService: PriceService,
     private val widgetsStore: WidgetsStore,
 ) {
-    private val repoScope = CoroutineScope(bgDispatcher + SupervisorJob())
+    private val repoScope = appScope(bgDispatcher, TAG)
     private val widgetJobs = ConcurrentHashMap<WidgetType, Job>()
 
     val widgetsDataFlow: StateFlow<WidgetsData> = widgetsStore.data

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -85,7 +85,7 @@ class LightningService @Inject constructor(
     private val vssStoreIdProvider: VssStoreIdProvider,
     private val settingsStore: SettingsStore,
     private val loggerLdk: LoggerLdk,
-) : BaseCoroutineScope(bgDispatcher) {
+) : BaseCoroutineScope(bgDispatcher, TAG) {
 
     companion object {
         private const val TAG = "LightningService"
@@ -886,7 +886,7 @@ class LightningService @Inject constructor(
         liquidityPenaltyMultiplierMsat = SCORING_LIQUIDITY_PENALTY_MULTIPLIER_MSAT,
         liquidityPenaltyAmountMultiplierMsat = SCORING_LIQUIDITY_PENALTY_AMOUNT_MULTIPLIER_MSAT,
         historicalLiquidityPenaltyAmountMultiplierMsat =
-            SCORING_HISTORICAL_LIQUIDITY_PENALTY_AMOUNT_MULTIPLIER_MSAT,
+        SCORING_HISTORICAL_LIQUIDITY_PENALTY_AMOUNT_MULTIPLIER_MSAT,
         consideredImpossiblePenaltyMsat = SCORING_CONSIDERED_IMPOSSIBLE_PENALTY_MSAT,
         probingDiversityPenaltyMsat = SCORING_PROBING_DIVERSITY_PENALTY_MSAT,
     )

--- a/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/trezor/TrezorViewModel.kt
@@ -21,14 +21,13 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import to.bitkit.async.appScope
 import to.bitkit.di.BgDispatcher
 import to.bitkit.env.Env
 import to.bitkit.models.HwWalletId
@@ -51,10 +50,14 @@ class TrezorViewModel @Inject constructor(
     private val trezorRepo: TrezorRepo,
 ) : ViewModel() {
 
+    companion object {
+        private const val TAG = "TrezorViewModel"
+    }
+
     @Volatile
     private var isCleared = false
 
-    private val watcherStartScope = CoroutineScope(SupervisorJob() + bgDispatcher)
+    private val watcherStartScope = appScope(bgDispatcher, TAG)
 
     init {
         observeWatcherEvents()

--- a/app/src/test/java/to/bitkit/async/CoroutineScopesTest.kt
+++ b/app/src/test/java/to/bitkit/async/CoroutineScopesTest.kt
@@ -1,0 +1,31 @@
+package to.bitkit.async
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import org.junit.Test
+import to.bitkit.test.BaseUnitTest
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoroutineScopesTest : BaseUnitTest() {
+
+    @Test
+    fun `appScope stays active after an uncaught exception in a child`() = test {
+        val scope = appScope(testDispatcher, "Test")
+
+        scope.launch { throw IllegalStateException("boom") }
+        runCurrent()
+
+        assertTrue(scope.isActive)
+
+        var secondChildRan = false
+        scope.launch { secondChildRan = true }
+        runCurrent()
+
+        assertTrue(secondChildRan)
+        scope.cancel()
+    }
+}

--- a/app/src/test/java/to/bitkit/async/ServiceQueueTest.kt
+++ b/app/src/test/java/to/bitkit/async/ServiceQueueTest.kt
@@ -1,0 +1,30 @@
+package to.bitkit.async
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import to.bitkit.test.BaseUnitTest
+import to.bitkit.utils.AppError
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServiceQueueTest : BaseUnitTest() {
+
+    @Test
+    fun `background rethrows CancellationException without wrapping it`() = test {
+        assertFailsWith<CancellationException> {
+            ServiceQueue.CORE.background(testDispatcher) {
+                throw CancellationException("cancelled")
+            }
+        }
+    }
+
+    @Test
+    fun `background wraps non-cancellation failures in AppError`() = test {
+        assertFailsWith<AppError> {
+            ServiceQueue.CORE.background(testDispatcher) {
+                throw IllegalStateException("boom")
+            }
+        }
+    }
+}

--- a/changelog.d/next/1094.fixed.md
+++ b/changelog.d/next/1094.fixed.md
@@ -1,0 +1,1 @@
+Hardened background task error handling to prevent rare crashes.


### PR DESCRIPTION
Relates to #1093 , #986

This PR:
1. Adds a shared exception-handling convention so every long-lived background scope logs uncaught errors instead of crashing the app
2. Fixes background task cancellation being reclassified as a generic error
3. Adds a process-level uncaught-exception logger as a last-resort backstop

### Description

A recent crash came from an uncaught error escaping a background coroutine. None of the app's long-lived scopes had an exception handler, so any unhandled throw in a background task reached the system's default handler and killed the process — often in a restart loop.

This introduces a single helper used across the repositories, services, and background workers so that every long-lived scope shares the same behavior: an uncaught error is logged with its owning tag and the scope stays alive, rather than taking the app down. The same handler is applied to the shared base scope used by the Lightning service and the keychain.

Background queue work now preserves coroutine cancellation instead of wrapping it into a generic error, so structured cancellation keeps working as intended.

Finally, a global uncaught-exception logger is installed at startup that records anything still slipping through before delegating to the platform's default handler, so normal crash behavior is preserved while we gain a log trail.

This is the safety net for the broader hardening tracked in #1093. Guarding the specific background bodies so a failure is handled meaningfully instead of only logged remains a follow-up.

### Preview

N/A — no UI changes.

### QA Notes

#### Manual Tests
- [x] **1.** `regression:` Cold start with an existing wallet → let startup finish: node starts, balances and widgets load, app does not crash.
- [x] **2.** `regression:` Background the app during sync, then foreground: sync resumes, no crash.

#### Automated Checks
- Unit tests added: `CoroutineScopesTest.kt` asserts a scope keeps running after an uncaught child exception (verified failing without the handler, passing with it).
- Unit tests added: `ServiceQueueTest.kt` asserts background work rethrows cancellation unchanged and wraps other failures in AppError.
- CI: standard compile, unit test, and detekt checks run by the PR bot.


---

## Runtime demonstration (crash simulation)

Verified the two runtime guards on a device (`to.bitkit.dev`, dev/regtest) by
temporarily injecting uncaught crashes (**not committed** — reverted after each
run), building & installing the dev build, and driving the app with the journeys
below via the `android` CLI. Each case shows the injected diff, the journey, and
the resulting logcat + persisted device log (`files/logs/…`).

### Case A — background coroutine crash is contained (scope handler)

A child launched in a long-lived `appScope` throws; the app must **stay alive**
and the throw must be logged with the owning tag.

Injected diff (reverted):
```diff
--- a/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/WalletRepo.kt
     init {
+        // CRASH-SIM (do not commit): proves appScope loggingExceptionHandler contains uncaught throws
+        repoScope.launch { error("CRASH-SIM: uncaught exception in WalletRepo background scope") }
         repoScope.launch {
             lightningRepo.nodeEvents.collect { event ->
```

Journey:
```xml
<journey name="scope handler contains background crash">
  <description>Precondition: onboarded dev wallet; WalletRepo background scope throws on startup.</description>
  <actions>
    <action>Launch the Bitkit dev app</action>
    <action>Verify the wallet home screen is visible with the total balance and the activity list</action>
    <action>Verify the app process is still running (it did not crash)</action>
  </actions>
</journey>
```

Result: **PASSED** — home screen rendered fully, process stayed alive (pid 9270).

logcat + persisted log (`files/logs/bitkit_2026-07-20_17-56-47.log`):
```
2026-07-20 17:56:47.533 ERROR [CoroutineExceptionHandler.kt:50]  Uncaught coroutine exception [IllegalStateException='CRASH-SIM: uncaught exception in WalletRepo background scope'] - WalletRepo
java.lang.IllegalStateException: CRASH-SIM: uncaught exception in WalletRepo background scope
    at to.bitkit.repositories.WalletRepo$1.invokeSuspend(WalletRepo.kt:85)
```
The throw is logged under the owning tag (`WalletRepo`); startup proceeds and the
UI loads — the scope survives instead of crashing the process.

### Case B — startup uncaught crash is recorded then delegated (backstop / P2)

An uncaught throw on a background thread during early startup must be **written to
the log file** (the P2 fix) and then follow normal crash behavior.

Injected diff (reverted), on top of the `5949a023c` reorder:
```diff
--- a/app/src/main/java/to/bitkit/App.kt
+++ b/app/src/main/java/to/bitkit/App.kt
         Env.initAppStoragePath(filesDir.absolutePath)
         installUncaughtExceptionLogger()
+        // CRASH-SIM (do not commit): P2 — genuine uncaught crash during early startup. Because the
+        // handler is installed after initAppStoragePath, the Logger delegate has a valid session
+        // log-file path, so the backstop records this crash before delegating to the default handler.
+        Thread({ throw RuntimeException("CRASH-SIM: uncaught startup crash on background thread") }, "crash-sim").start()
         SingletonImageLoader.setSafe { imageLoader }
```

Journey:
```xml
<journey name="startup backstop records uncaught crash">
  <description>Precondition: dev build; a background thread throws during App.onCreate.</description>
  <actions>
    <action>Launch the Bitkit dev app</action>
    <action>Verify the process crashes (normal crash behavior is preserved)</action>
    <action>Verify the session log file recorded an "Uncaught exception on thread" entry</action>
  </actions>
</journey>
```

Result: **PASSED** — backstop logged the crash, then the default handler killed
the process; the entry is present in the session log file.

logcat:
```
E AndroidRuntime: FATAL EXCEPTION: crash-sim
E AndroidRuntime: Process: to.bitkit.dev, PID: 9664
E AndroidRuntime: java.lang.RuntimeException: CRASH-SIM: uncaught startup crash on background thread
E AndroidRuntime:     at to.bitkit.App.onCreate$lambda$0(App.kt:43)
E APP:            Uncaught exception on thread 'crash-sim' [RuntimeException='CRASH-SIM: uncaught startup crash on background thread'] - App
I ActivityManager: Process to.bitkit.dev (pid 9664) has died: fg  TOP
```

Persisted log (`files/logs/bitkit_2026-07-20_18-00-48.log`) — the P2 proof:
```
2026-07-20 18:00:48.478 INFO  [Env.kt:199]  App storage path: /data/user/0/to.bitkit.dev/files
2026-07-20 18:00:48.480 ERROR [App.kt:54]   Uncaught exception on thread 'crash-sim' [RuntimeException='CRASH-SIM: uncaught startup crash on background thread'] - App
```
The `App storage path: …` line (from `initAppStoragePath`) is written **before**
the crash entry, confirming the reorder: the storage path — and therefore the
Logger delegate's session file — is initialized before the backstop fires, so the
early-startup crash is captured on disk instead of dropped.

> Out of scope (P1, tracked in #1093): the failed child coroutine itself still
> terminates — a long-lived collector that throws stops observing until restart.
> This PR contains and logs the failure; per-body recovery/relaunch is the
> follow-up.
