### PR TITLE
refactor: batch paykit contact cleanup

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
@@ -107,6 +107,12 @@ class PrivatePaykitRepo @Inject constructor(
         val firstError: Throwable?,
     )
 
+    private data class PrivateEndpointCleanupPreparation(
+        val clearedRetryKeys: List<PrivateMessageDrainRetryKey>,
+        val failedPublicKeys: Set<String>,
+        val firstError: Throwable?,
+    )
+
     private data class PrivateMessageDrainRetryKey(
         val publicKey: String,
         val receiverPath: String,
@@ -683,6 +689,7 @@ class PrivatePaykitRepo @Inject constructor(
         var firstError: Throwable? = null
         val updates = mutableListOf<PrivatePaymentListReservationUpdateInput>()
         val linkRetryKeys = mutableListOf<PrivateMessageDrainRetryKey>()
+        val linkedReceiverPaths = linkedReceiverPathsByPublicKey()
 
         for (publicKey in publicKeys) {
             val receiverPaths = runSuspendCatching { receiverPathsForSavedContact(publicKey) }
@@ -699,15 +706,12 @@ class PrivatePaykitRepo @Inject constructor(
             val publicationReceiverPaths = receiverPathSelection.publishableReceiverPaths
             receiverPathSelection.error?.let {
                 firstError = firstError ?: it
-                Logger.warn(
-                    "Failed to inspect private Paykit receiver markers for '${redacted(publicKey)}' during '$reason'",
-                    it,
-                    context = TAG,
-                )
+                logPrivateReceiverPathSelectionFailure(publicKey, reason, it)
             }
             val cleanupReceiverPaths = receiverPathsForPrivateEndpointCleanup(
                 publicKey = publicKey,
                 excludedReceiverPaths = publicationReceiverPaths + receiverPathSelection.cleanupProtectedReceiverPaths,
+                linkedReceiverPaths = linkedReceiverPaths[publicKey].orEmpty(),
             )
 
             (linkableReceiverPaths + cleanupReceiverPaths).distinct().forEach { receiverPath ->
@@ -815,6 +819,18 @@ class PrivatePaykitRepo @Inject constructor(
                 context = TAG,
             )
         }
+    }
+
+    private fun logPrivateReceiverPathSelectionFailure(
+        publicKey: String,
+        reason: String,
+        error: Throwable,
+    ) {
+        Logger.warn(
+            "Failed to inspect private Paykit receiver markers for '${redacted(publicKey)}' during '$reason'",
+            error,
+            context = TAG,
+        )
     }
 
     private suspend fun applyPrivatePaymentListDeliveryReport(
@@ -1170,41 +1186,77 @@ class PrivatePaykitRepo @Inject constructor(
     }
 
     private suspend fun removePublishedEndpoints(): Result<Unit> = withContext(serializedDispatcher) {
-        runSuspendCatching {
-            val keys = (knownSavedContactKeys + ensureState().contacts.keys + pendingDeletedContactCleanupPublicKeys())
-                .distinct()
-            val firstError = keys.mapNotNull { publicKey ->
-                removePublishedEndpoints(publicKey).exceptionOrNull()
-            }.firstOrNull()
-            if (firstError != null) throw firstError
-        }
+        val keys = (knownSavedContactKeys + ensureState().contacts.keys + pendingDeletedContactCleanupPublicKeys())
+            .distinct()
+        removePublishedEndpoints(keys)
     }
 
-    private suspend fun removePublishedEndpoints(publicKey: String): Result<Unit> = withContext(serializedDispatcher) {
-        runSuspendCatching {
-            var firstError: Throwable? = null
-            receiverPathsForCleanup(publicKey).forEach { receiverPath ->
-                val result = runSuspendCatching {
-                    val report = paykitSdkService.clearPrivatePaymentList(
-                        counterparty = publicKey,
-                        receiverPath = receiverPath,
+    private suspend fun removePublishedEndpoints(publicKey: String): Result<Unit> =
+        removePublishedEndpoints(listOf(publicKey))
+
+    private suspend fun removePublishedEndpoints(publicKeys: Collection<String>): Result<Unit> =
+        withContext(serializedDispatcher) {
+            runSuspendCatching {
+                val publicKeys = publicKeys.mapNotNull(::normalizedPublicKey).distinct()
+                if (publicKeys.isEmpty()) return@runSuspendCatching Unit
+
+                val linkedReceiverPaths = linkedReceiverPathsByPublicKey()
+                val preparation = clearPrivatePaymentLists(publicKeys, linkedReceiverPaths)
+                val failedPublicKeys = preparation.failedPublicKeys.toMutableSet()
+                var firstError = preparation.firstError
+
+                if (preparation.clearedRetryKeys.isNotEmpty()) {
+                    drainPendingPrivateMessages(
+                        reason = "private endpoint cleanup",
+                        advancingLinksFor = preparation.clearedRetryKeys,
                     )
+                    val pendingRetryKeys = pendingPrivateMessageDrainKeys(preparation.clearedRetryKeys)
+                    if (pendingRetryKeys.isNotEmpty()) {
+                        failedPublicKeys += pendingRetryKeys.map { it.publicKey }
+                        firstError = firstError ?: PrivatePaykitError.PrivateUnavailable
+                    }
+                }
+
+                val successfulPublicKeys = publicKeys.filterNot { it in failedPublicKeys }
+                clearPublishedEndpointCache(successfulPublicKeys)
+
+                firstError?.let { throw it }
+                Unit
+            }
+        }
+
+    private suspend fun clearPrivatePaymentLists(
+        publicKeys: Collection<String>,
+        linkedReceiverPaths: Map<String, Set<String>>,
+    ): PrivateEndpointCleanupPreparation {
+        val failedPublicKeys = mutableSetOf<String>()
+        val clearedRetryKeys = mutableListOf<PrivateMessageDrainRetryKey>()
+        var firstError: Throwable? = null
+
+        publicKeys.forEach { publicKey ->
+            receiverPathsForCleanup(
+                publicKey = publicKey,
+                linkedReceiverPaths = linkedReceiverPaths[publicKey].orEmpty(),
+            ).forEach { receiverPath ->
+                runSuspendCatching {
+                    val report = paykitSdkService.clearPrivatePaymentList(publicKey, receiverPath)
                     if (report.failedToQueue.isNotEmpty() || report.failedToDeliver.isNotEmpty()) {
                         throw PrivatePaykitError.PrivateUnavailable
                     }
-                    val retryKey = PrivateMessageDrainRetryKey(publicKey, receiverPath)
-                    drainPendingPrivateMessages("private endpoint cleanup", advancingLinksFor = listOf(retryKey))
-                    if (retryKey in pendingPrivateMessageDrainKeys(listOf(retryKey))) {
-                        throw PrivatePaykitError.PrivateUnavailable
-                    }
-                }
-                if (result.isFailure) {
-                    firstError = firstError ?: result.exceptionOrNull()
+                }.onSuccess {
+                    clearedRetryKeys += PrivateMessageDrainRetryKey(publicKey, receiverPath)
+                }.onFailure {
+                    failedPublicKeys += publicKey
+                    firstError = firstError ?: it
                 }
             }
+        }
 
-            firstError?.let { throw it }
+        return PrivateEndpointCleanupPreparation(clearedRetryKeys, failedPublicKeys, firstError)
+    }
 
+    private suspend fun clearPublishedEndpointCache(publicKeys: Collection<String>) {
+        publicKeys.forEach { publicKey ->
             state?.contacts?.get(publicKey)?.let { contactState ->
                 contactState.remoteEndpoints = emptyList()
                 contactState.localInvoicesByReceiverPath = emptyMap()
@@ -1214,6 +1266,9 @@ class PrivatePaykitRepo @Inject constructor(
                 }
             }
             updateDeletedContactCleanupPending(publicKey, isPending = false)
+        }
+
+        if (publicKeys.isNotEmpty()) {
             persistState(markWalletBackup = true)
         }
     }
@@ -1226,42 +1281,38 @@ class PrivatePaykitRepo @Inject constructor(
         return paths.ifEmpty { listOf(PaykitReceiverPaths.WALLET) }
     }
 
-    private suspend fun receiverPathsForPrivateEndpointCleanup(
+    private fun receiverPathsForPrivateEndpointCleanup(
         publicKey: String,
         excludedReceiverPaths: List<String>,
+        linkedReceiverPaths: Collection<String>,
     ): List<String> {
         val publishedPaths = publishedPrivatePaymentReceiverPaths(publicKey)
-        val linkedPaths = linkedReceiverPaths(publicKey)
-        return (publishedPaths + linkedPaths)
+        return (publishedPaths + linkedReceiverPaths)
             .filter { it in PaykitReceiverPaths.supported }
             .filterNot { it in excludedReceiverPaths }
             .distinct()
             .sorted()
     }
 
-    private suspend fun receiverPathsForCleanup(publicKey: String): List<String> {
-        val paths = (
-            linkedReceiverPaths(publicKey) +
-                publishedPrivatePaymentReceiverPaths(publicKey)
-            )
+    private fun receiverPathsForCleanup(
+        publicKey: String,
+        linkedReceiverPaths: Collection<String>,
+    ): List<String> {
+        return (linkedReceiverPaths + publishedPrivatePaymentReceiverPaths(publicKey))
             .filter { it in PaykitReceiverPaths.supported }
             .distinct()
             .sorted()
-        return paths
     }
 
-    private suspend fun linkedReceiverPaths(publicKey: String): List<String> {
-        val normalizedKey = normalizedPublicKey(publicKey) ?: return emptyList()
-        val paths = paykitSdkService.linkedPeers()
-            .mapNotNull { peer ->
-                val peerKey = normalizedPublicKey(peer.counterparty)
-                peer.counterpartyReceiverPath.takeIf {
-                    peerKey == normalizedKey && it in PaykitReceiverPaths.supported
-                }
+    private suspend fun linkedReceiverPathsByPublicKey(): Map<String, Set<String>> {
+        val linkedPaths = mutableMapOf<String, MutableSet<String>>()
+        paykitSdkService.linkedPeers().forEach { peer ->
+            val publicKey = normalizedPublicKey(peer.counterparty) ?: return@forEach
+            if (peer.counterpartyReceiverPath in PaykitReceiverPaths.supported) {
+                linkedPaths.getOrPut(publicKey, ::mutableSetOf) += peer.counterpartyReceiverPath
             }
-            .distinct()
-            .sorted()
-        return paths
+        }
+        return linkedPaths
     }
 
     private fun publishedPrivatePaymentReceiverPaths(publicKey: String): List<String> {

--- a/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
@@ -113,6 +113,16 @@ class PrivatePaykitRepo @Inject constructor(
         val firstError: Throwable?,
     )
 
+    private data class NormalizedPublicKeyBatch(
+        val publicKeys: List<String>,
+        val hadInvalidKey: Boolean,
+    )
+
+    private data class LinkedReceiverPathInspection(
+        val receiverPaths: Set<String>,
+        val error: Throwable?,
+    )
+
     private data class PrivateMessageDrainRetryKey(
         val publicKey: String,
         val receiverPath: String,
@@ -689,7 +699,7 @@ class PrivatePaykitRepo @Inject constructor(
         var firstError: Throwable? = null
         val updates = mutableListOf<PrivatePaymentListReservationUpdateInput>()
         val linkRetryKeys = mutableListOf<PrivateMessageDrainRetryKey>()
-        val linkedReceiverPaths = linkedReceiverPathsByPublicKey()
+        val linkedReceiverPathsSnapshot = linkedReceiverPathsSnapshotOrNull(reason)
 
         for (publicKey in publicKeys) {
             val receiverPaths = runSuspendCatching { receiverPathsForSavedContact(publicKey) }
@@ -708,22 +718,19 @@ class PrivatePaykitRepo @Inject constructor(
                 firstError = firstError ?: it
                 logPrivateReceiverPathSelectionFailure(publicKey, reason, it)
             }
+            val linkedReceiverPathInspection = inspectLinkedReceiverPaths(
+                publicKey,
+                linkedReceiverPathsSnapshot,
+                reason,
+            )
+            firstError = firstError ?: linkedReceiverPathInspection.error
             val cleanupReceiverPaths = receiverPathsForPrivateEndpointCleanup(
                 publicKey = publicKey,
                 excludedReceiverPaths = publicationReceiverPaths + receiverPathSelection.cleanupProtectedReceiverPaths,
-                linkedReceiverPaths = linkedReceiverPaths[publicKey].orEmpty(),
+                linkedReceiverPaths = linkedReceiverPathInspection.receiverPaths,
             )
 
-            (linkableReceiverPaths + cleanupReceiverPaths).distinct().forEach { receiverPath ->
-                linkRetryKeys += PrivateMessageDrainRetryKey(publicKey, receiverPath)
-                runSuspendCatching { paykitSdkService.ensureLinkWithPeer(publicKey, receiverPath) }.onFailure {
-                    Logger.warn(
-                        "Failed to prepare private Paykit link for '${redacted(publicKey)}' during '$reason'",
-                        it,
-                        context = TAG,
-                    )
-                }
-            }
+            linkRetryKeys += preparePrivateLinks(publicKey, linkableReceiverPaths + cleanupReceiverPaths, reason)
 
             cleanupReceiverPaths.forEach { receiverPath ->
                 updates += PrivatePaymentListReservationUpdateInput(
@@ -773,6 +780,21 @@ class PrivatePaykitRepo @Inject constructor(
         }
 
         drainAndSchedulePrivateLinkRetries(reason, retryKeys.distinct())
+    }
+
+    private suspend fun preparePrivateLinks(
+        publicKey: String,
+        receiverPaths: Collection<String>,
+        reason: String,
+    ): List<PrivateMessageDrainRetryKey> = receiverPaths.distinct().map { receiverPath ->
+        runSuspendCatching { paykitSdkService.ensureLinkWithPeer(publicKey, receiverPath) }.onFailure {
+            Logger.warn(
+                "Failed to prepare private Paykit link for '${redacted(publicKey)}' during '$reason'",
+                it,
+                context = TAG,
+            )
+        }
+        PrivateMessageDrainRetryKey(publicKey, receiverPath)
     }
 
     private suspend fun drainAndSchedulePrivateLinkRetries(
@@ -1197,13 +1219,20 @@ class PrivatePaykitRepo @Inject constructor(
     private suspend fun removePublishedEndpoints(publicKeys: Collection<String>): Result<Unit> =
         withContext(serializedDispatcher) {
             runSuspendCatching {
-                val publicKeys = publicKeys.mapNotNull(::normalizedPublicKey).distinct()
-                if (publicKeys.isEmpty()) return@runSuspendCatching Unit
+                val normalizedBatch = normalizedPublicKeyBatch(publicKeys)
+                val publicKeys = normalizedBatch.publicKeys
+                var firstError: Throwable? = PrivatePaykitError.InvalidPublicKey.takeIf {
+                    normalizedBatch.hadInvalidKey
+                }
+                if (publicKeys.isEmpty()) {
+                    firstError?.let { throw it }
+                    return@runSuspendCatching Unit
+                }
 
-                val linkedReceiverPaths = linkedReceiverPathsByPublicKey()
-                val preparation = clearPrivatePaymentLists(publicKeys, linkedReceiverPaths)
+                val linkedReceiverPathsSnapshot = linkedReceiverPathsSnapshotOrNull("private endpoint cleanup")
+                val preparation = clearPrivatePaymentLists(publicKeys, linkedReceiverPathsSnapshot)
                 val failedPublicKeys = preparation.failedPublicKeys.toMutableSet()
-                var firstError = preparation.firstError
+                firstError = firstError ?: preparation.firstError
 
                 if (preparation.clearedRetryKeys.isNotEmpty()) {
                     drainPendingPrivateMessages(
@@ -1227,16 +1256,28 @@ class PrivatePaykitRepo @Inject constructor(
 
     private suspend fun clearPrivatePaymentLists(
         publicKeys: Collection<String>,
-        linkedReceiverPaths: Map<String, Set<String>>,
+        linkedReceiverPathsSnapshot: Map<String, Set<String>>?,
     ): PrivateEndpointCleanupPreparation {
         val failedPublicKeys = mutableSetOf<String>()
         val clearedRetryKeys = mutableListOf<PrivateMessageDrainRetryKey>()
         var firstError: Throwable? = null
 
         publicKeys.forEach { publicKey ->
+            val contactLinkedReceiverPaths = linkedReceiverPaths(
+                publicKey = publicKey,
+                snapshot = linkedReceiverPathsSnapshot,
+            ).onFailure {
+                failedPublicKeys += publicKey
+                firstError = firstError ?: it
+                Logger.warn(
+                    "Failed to inspect private Paykit links for '${redacted(publicKey)}' during cleanup",
+                    it,
+                    context = TAG,
+                )
+            }.getOrDefault(emptySet())
             receiverPathsForCleanup(
                 publicKey = publicKey,
-                linkedReceiverPaths = linkedReceiverPaths[publicKey].orEmpty(),
+                linkedReceiverPaths = contactLinkedReceiverPaths,
             ).forEach { receiverPath ->
                 runSuspendCatching {
                     val report = paykitSdkService.clearPrivatePaymentList(publicKey, receiverPath)
@@ -1313,6 +1354,53 @@ class PrivatePaykitRepo @Inject constructor(
             }
         }
         return linkedPaths
+    }
+
+    private suspend fun linkedReceiverPathsSnapshotOrNull(reason: String): Map<String, Set<String>>? =
+        runSuspendCatching { linkedReceiverPathsByPublicKey() }
+            .onFailure {
+                Logger.warn(
+                    "Failed to inspect private Paykit links during '$reason'; retrying per contact",
+                    it,
+                    context = TAG,
+                )
+            }.getOrNull()
+
+    private suspend fun linkedReceiverPaths(
+        publicKey: String,
+        snapshot: Map<String, Set<String>>?,
+    ): Result<Set<String>> = if (snapshot != null) {
+        Result.success(snapshot[publicKey].orEmpty())
+    } else {
+        runSuspendCatching { linkedReceiverPathsByPublicKey()[publicKey].orEmpty() }
+    }
+
+    private suspend fun inspectLinkedReceiverPaths(
+        publicKey: String,
+        snapshot: Map<String, Set<String>>?,
+        reason: String,
+    ): LinkedReceiverPathInspection {
+        val result = linkedReceiverPaths(publicKey, snapshot)
+        val error = result.exceptionOrNull()
+        if (error != null) {
+            Logger.warn(
+                "Failed to inspect private Paykit links for '${redacted(publicKey)}' during '$reason'",
+                error,
+                context = TAG,
+            )
+        }
+        return LinkedReceiverPathInspection(result.getOrDefault(emptySet()), error)
+    }
+
+    private fun normalizedPublicKeyBatch(publicKeys: Collection<String>): NormalizedPublicKeyBatch {
+        var hadInvalidKey = false
+        val normalizedKeys = publicKeys.mapNotNull { publicKey ->
+            normalizedPublicKey(publicKey) ?: run {
+                hadInvalidKey = true
+                null
+            }
+        }.distinct()
+        return NormalizedPublicKeyBatch(normalizedKeys, hadInvalidKey)
     }
 
     private fun publishedPrivatePaymentReceiverPaths(publicKey: String): List<String> {

--- a/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
@@ -114,13 +114,19 @@ class PrivatePaykitRepo @Inject constructor(
     )
 
     private data class NormalizedPublicKeyBatch(
-        val publicKeys: List<String>,
-        val hadInvalidKey: Boolean,
+        val normalizedKeys: List<String>,
+        val invalidKeys: Set<String>,
     )
 
-    private data class LinkedReceiverPathInspection(
-        val receiverPaths: Set<String>,
+    private data class LinkedReceiverPathsSnapshot(
+        val pathsByPublicKey: Map<String, Set<String>>,
         val error: Throwable?,
+    )
+
+    private data class PublishedEndpointCleanupState(
+        val remoteEndpoints: List<StoredPaymentEntry>,
+        val localInvoicesByReceiverPath: Map<String, StoredInvoice>,
+        val publishedPrivatePaymentReceiverPaths: Set<String>,
     )
 
     private data class PrivateMessageDrainRetryKey(
@@ -699,7 +705,8 @@ class PrivatePaykitRepo @Inject constructor(
         var firstError: Throwable? = null
         val updates = mutableListOf<PrivatePaymentListReservationUpdateInput>()
         val linkRetryKeys = mutableListOf<PrivateMessageDrainRetryKey>()
-        val linkedReceiverPathsSnapshot = linkedReceiverPathsSnapshotOrNull(reason)
+        val linkedReceiverPathsSnapshot = linkedReceiverPathsSnapshot(reason)
+        firstError = linkedReceiverPathsSnapshot.error
 
         for (publicKey in publicKeys) {
             val receiverPaths = runSuspendCatching { receiverPathsForSavedContact(publicKey) }
@@ -718,16 +725,10 @@ class PrivatePaykitRepo @Inject constructor(
                 firstError = firstError ?: it
                 logPrivateReceiverPathSelectionFailure(publicKey, reason, it)
             }
-            val linkedReceiverPathInspection = inspectLinkedReceiverPaths(
-                publicKey,
-                linkedReceiverPathsSnapshot,
-                reason,
-            )
-            firstError = firstError ?: linkedReceiverPathInspection.error
             val cleanupReceiverPaths = receiverPathsForPrivateEndpointCleanup(
                 publicKey = publicKey,
                 excludedReceiverPaths = publicationReceiverPaths + receiverPathSelection.cleanupProtectedReceiverPaths,
-                linkedReceiverPaths = linkedReceiverPathInspection.receiverPaths,
+                linkedReceiverPaths = linkedReceiverPathsSnapshot.pathsByPublicKey[publicKey].orEmpty(),
             )
 
             linkRetryKeys += preparePrivateLinks(publicKey, linkableReceiverPaths + cleanupReceiverPaths, reason)
@@ -786,15 +787,20 @@ class PrivatePaykitRepo @Inject constructor(
         publicKey: String,
         receiverPaths: Collection<String>,
         reason: String,
-    ): List<PrivateMessageDrainRetryKey> = receiverPaths.distinct().map { receiverPath ->
-        runSuspendCatching { paykitSdkService.ensureLinkWithPeer(publicKey, receiverPath) }.onFailure {
-            Logger.warn(
-                "Failed to prepare private Paykit link for '${redacted(publicKey)}' during '$reason'",
-                it,
-                context = TAG,
-            )
+    ): List<PrivateMessageDrainRetryKey> {
+        val retryKeys = mutableListOf<PrivateMessageDrainRetryKey>()
+        for (receiverPath in receiverPaths.distinct()) {
+            runSuspendCatching { paykitSdkService.ensureLinkWithPeer(publicKey, receiverPath) }.onFailure {
+                Logger.warn(
+                    "Failed to prepare private Paykit link for '${redacted(publicKey)}' during '$reason'",
+                    it,
+                    context = TAG,
+                )
+            }
+            retryKeys += PrivateMessageDrainRetryKey(publicKey, receiverPath)
         }
-        PrivateMessageDrainRetryKey(publicKey, receiverPath)
+
+        return retryKeys
     }
 
     private suspend fun drainAndSchedulePrivateLinkRetries(
@@ -1208,9 +1214,11 @@ class PrivatePaykitRepo @Inject constructor(
     }
 
     private suspend fun removePublishedEndpoints(): Result<Unit> = withContext(serializedDispatcher) {
-        val keys = (knownSavedContactKeys + ensureState().contacts.keys + pendingDeletedContactCleanupPublicKeys())
-            .distinct()
-        removePublishedEndpoints(keys)
+        publicationMutex.withLock {
+            val keys = (knownSavedContactKeys + ensureState().contacts.keys + pendingDeletedContactCleanupPublicKeys())
+                .distinct()
+            removePublishedEndpointsLocked(keys)
+        }
     }
 
     private suspend fun removePublishedEndpoints(publicKey: String): Result<Unit> =
@@ -1218,66 +1226,68 @@ class PrivatePaykitRepo @Inject constructor(
 
     private suspend fun removePublishedEndpoints(publicKeys: Collection<String>): Result<Unit> =
         withContext(serializedDispatcher) {
-            runSuspendCatching {
-                val normalizedBatch = normalizedPublicKeyBatch(publicKeys)
-                val publicKeys = normalizedBatch.publicKeys
-                var firstError: Throwable? = PrivatePaykitError.InvalidPublicKey.takeIf {
-                    normalizedBatch.hadInvalidKey
-                }
-                if (publicKeys.isEmpty()) {
-                    firstError?.let { throw it }
-                    return@runSuspendCatching Unit
-                }
-
-                val linkedReceiverPathsSnapshot = linkedReceiverPathsSnapshotOrNull("private endpoint cleanup")
-                val preparation = clearPrivatePaymentLists(publicKeys, linkedReceiverPathsSnapshot)
-                val failedPublicKeys = preparation.failedPublicKeys.toMutableSet()
-                firstError = firstError ?: preparation.firstError
-
-                if (preparation.clearedRetryKeys.isNotEmpty()) {
-                    drainPendingPrivateMessages(
-                        reason = "private endpoint cleanup",
-                        advancingLinksFor = preparation.clearedRetryKeys,
-                    )
-                    val pendingRetryKeys = pendingPrivateMessageDrainKeys(preparation.clearedRetryKeys)
-                    if (pendingRetryKeys.isNotEmpty()) {
-                        failedPublicKeys += pendingRetryKeys.map { it.publicKey }
-                        firstError = firstError ?: PrivatePaykitError.PrivateUnavailable
-                    }
-                }
-
-                val successfulPublicKeys = publicKeys.filterNot { it in failedPublicKeys }
-                clearPublishedEndpointCache(successfulPublicKeys)
-
-                firstError?.let { throw it }
-                Unit
+            publicationMutex.withLock {
+                removePublishedEndpointsLocked(publicKeys)
             }
+        }
+
+    private suspend fun removePublishedEndpointsLocked(publicKeys: Collection<String>): Result<Unit> =
+        runSuspendCatching {
+            val normalizedBatch = normalizedPublicKeyBatch(publicKeys)
+            discardInvalidCleanupKeys(normalizedBatch.invalidKeys)
+            val normalizedKeys = normalizedBatch.normalizedKeys
+            if (normalizedKeys.isEmpty()) return@runSuspendCatching
+
+            ensureState()
+            val cleanupStateByPublicKey = normalizedKeys.associateWith(::publishedEndpointCleanupState)
+            val linkedReceiverPathsSnapshot = linkedReceiverPathsSnapshot("private endpoint cleanup")
+            val preparation = clearPrivatePaymentLists(normalizedKeys, linkedReceiverPathsSnapshot)
+            val failedPublicKeys = preparation.failedPublicKeys.toMutableSet()
+            var firstError = preparation.firstError
+
+            if (preparation.clearedRetryKeys.isNotEmpty()) {
+                drainPendingPrivateMessages(
+                    reason = "private endpoint cleanup",
+                    advancingLinksFor = preparation.clearedRetryKeys,
+                )
+                val pendingRetryKeys = pendingPrivateMessageDrainKeys(preparation.clearedRetryKeys)
+                if (pendingRetryKeys.isNotEmpty()) {
+                    failedPublicKeys += pendingRetryKeys.map { it.publicKey }
+                    firstError = firstError ?: PrivatePaykitError.PrivateUnavailable
+                }
+            }
+
+            normalizedKeys.filterNot { it in failedPublicKeys }.forEach { publicKey ->
+                if (publishedEndpointCleanupState(publicKey) != cleanupStateByPublicKey[publicKey]) {
+                    failedPublicKeys += publicKey
+                    firstError = firstError ?: PrivatePaykitError.PrivateUnavailable
+                    Logger.warn(
+                        "Deferred private Paykit cache cleanup for '${redacted(publicKey)}' because its state changed",
+                        context = TAG,
+                    )
+                }
+            }
+
+            clearPublishedEndpointCache(normalizedKeys.filterNot { it in failedPublicKeys })
+            firstError?.let { throw it }
         }
 
     private suspend fun clearPrivatePaymentLists(
         publicKeys: Collection<String>,
-        linkedReceiverPathsSnapshot: Map<String, Set<String>>?,
+        linkedReceiverPathsSnapshot: LinkedReceiverPathsSnapshot,
     ): PrivateEndpointCleanupPreparation {
-        val failedPublicKeys = mutableSetOf<String>()
+        val failedPublicKeys = if (linkedReceiverPathsSnapshot.error == null) {
+            mutableSetOf()
+        } else {
+            publicKeys.toMutableSet()
+        }
         val clearedRetryKeys = mutableListOf<PrivateMessageDrainRetryKey>()
-        var firstError: Throwable? = null
+        var firstError = linkedReceiverPathsSnapshot.error
 
         publicKeys.forEach { publicKey ->
-            val contactLinkedReceiverPaths = linkedReceiverPaths(
-                publicKey = publicKey,
-                snapshot = linkedReceiverPathsSnapshot,
-            ).onFailure {
-                failedPublicKeys += publicKey
-                firstError = firstError ?: it
-                Logger.warn(
-                    "Failed to inspect private Paykit links for '${redacted(publicKey)}' during cleanup",
-                    it,
-                    context = TAG,
-                )
-            }.getOrDefault(emptySet())
             receiverPathsForCleanup(
                 publicKey = publicKey,
-                linkedReceiverPaths = contactLinkedReceiverPaths,
+                linkedReceiverPaths = linkedReceiverPathsSnapshot.pathsByPublicKey[publicKey].orEmpty(),
             ).forEach { receiverPath ->
                 runSuspendCatching {
                     val report = paykitSdkService.clearPrivatePaymentList(publicKey, receiverPath)
@@ -1297,6 +1307,8 @@ class PrivatePaykitRepo @Inject constructor(
     }
 
     private suspend fun clearPublishedEndpointCache(publicKeys: Collection<String>) {
+        if (publicKeys.isEmpty()) return
+
         publicKeys.forEach { publicKey ->
             state?.contacts?.get(publicKey)?.let { contactState ->
                 contactState.remoteEndpoints = emptyList()
@@ -1306,12 +1318,34 @@ class PrivatePaykitRepo @Inject constructor(
                     state?.contacts?.remove(publicKey)
                 }
             }
-            updateDeletedContactCleanupPending(publicKey, isPending = false)
         }
 
-        if (publicKeys.isNotEmpty()) {
+        persistState(markWalletBackup = true)
+        updateDeletedContactCleanupPending(publicKeys, isPending = false)
+    }
+
+    private suspend fun discardInvalidCleanupKeys(publicKeys: Collection<String>) {
+        if (publicKeys.isEmpty()) return
+
+        val contactState = ensureState().contacts
+        var didRemoveContactState = false
+        publicKeys.forEach { publicKey ->
+            Logger.warn("Dropped invalid private Paykit cleanup key '${redacted(publicKey)}'", context = TAG)
+            didRemoveContactState = contactState.remove(publicKey) != null || didRemoveContactState
+        }
+        if (didRemoveContactState) {
             persistState(markWalletBackup = true)
         }
+        updateDeletedContactCleanupPending(publicKeys, isPending = false)
+    }
+
+    private fun publishedEndpointCleanupState(publicKey: String): PublishedEndpointCleanupState {
+        val contactState = state?.contacts?.get(publicKey)
+        return PublishedEndpointCleanupState(
+            remoteEndpoints = contactState?.remoteEndpoints.orEmpty(),
+            localInvoicesByReceiverPath = contactState?.localInvoicesByReceiverPath.orEmpty(),
+            publishedPrivatePaymentReceiverPaths = contactState?.publishedPrivatePaymentReceiverPaths.orEmpty(),
+        )
     }
 
     private suspend fun receiverPathsForSavedContact(publicKey: String): List<String> {
@@ -1356,51 +1390,32 @@ class PrivatePaykitRepo @Inject constructor(
         return linkedPaths
     }
 
-    private suspend fun linkedReceiverPathsSnapshotOrNull(reason: String): Map<String, Set<String>>? =
-        runSuspendCatching { linkedReceiverPathsByPublicKey() }
-            .onFailure {
-                Logger.warn(
-                    "Failed to inspect private Paykit links during '$reason'; retrying per contact",
-                    it,
-                    context = TAG,
-                )
-            }.getOrNull()
-
-    private suspend fun linkedReceiverPaths(
-        publicKey: String,
-        snapshot: Map<String, Set<String>>?,
-    ): Result<Set<String>> = if (snapshot != null) {
-        Result.success(snapshot[publicKey].orEmpty())
-    } else {
-        runSuspendCatching { linkedReceiverPathsByPublicKey()[publicKey].orEmpty() }
-    }
-
-    private suspend fun inspectLinkedReceiverPaths(
-        publicKey: String,
-        snapshot: Map<String, Set<String>>?,
-        reason: String,
-    ): LinkedReceiverPathInspection {
-        val result = linkedReceiverPaths(publicKey, snapshot)
-        val error = result.exceptionOrNull()
-        if (error != null) {
+    private suspend fun linkedReceiverPathsSnapshot(reason: String): LinkedReceiverPathsSnapshot {
+        repeat(2) { attempt ->
+            val result = runSuspendCatching { linkedReceiverPathsByPublicKey() }
+            result.getOrNull()?.let { return LinkedReceiverPathsSnapshot(it, null) }
+            val error = result.exceptionOrNull() ?: PrivatePaykitError.PrivateUnavailable
+            val suffix = if (attempt == 0) "; retrying once" else " after retry"
             Logger.warn(
-                "Failed to inspect private Paykit links for '${redacted(publicKey)}' during '$reason'",
+                "Failed to inspect private Paykit links during '$reason'$suffix",
                 error,
                 context = TAG,
             )
+            if (attempt == 1) return LinkedReceiverPathsSnapshot(emptyMap(), error)
         }
-        return LinkedReceiverPathInspection(result.getOrDefault(emptySet()), error)
+
+        return LinkedReceiverPathsSnapshot(emptyMap(), PrivatePaykitError.PrivateUnavailable)
     }
 
     private fun normalizedPublicKeyBatch(publicKeys: Collection<String>): NormalizedPublicKeyBatch {
-        var hadInvalidKey = false
+        val invalidKeys = mutableSetOf<String>()
         val normalizedKeys = publicKeys.mapNotNull { publicKey ->
             normalizedPublicKey(publicKey) ?: run {
-                hadInvalidKey = true
+                invalidKeys += publicKey
                 null
             }
         }.distinct()
-        return NormalizedPublicKeyBatch(normalizedKeys, hadInvalidKey)
+        return NormalizedPublicKeyBatch(normalizedKeys, invalidKeys)
     }
 
     private fun publishedPrivatePaymentReceiverPaths(publicKey: String): List<String> {
@@ -1421,7 +1436,14 @@ class PrivatePaykitRepo @Inject constructor(
         }
 
     private suspend fun clearContactState(publicKey: String) {
-        ensureState().contacts.remove(publicKey)
+        clearContactStates(listOf(publicKey))
+    }
+
+    private suspend fun clearContactStates(publicKeys: Collection<String>) {
+        if (publicKeys.isEmpty()) return
+
+        val contacts = ensureState().contacts
+        publicKeys.forEach(contacts::remove)
         persistState(markWalletBackup = true)
     }
 
@@ -1514,12 +1536,17 @@ class PrivatePaykitRepo @Inject constructor(
     private suspend fun pendingDeletedContactCleanupPublicKeys(): Set<String> =
         cacheStore.data.first().deletedContactCleanupPendingPublicKeys
 
-    private suspend fun updateDeletedContactCleanupPending(publicKey: String, isPending: Boolean) {
+    private suspend fun updateDeletedContactCleanupPending(publicKey: String, isPending: Boolean) =
+        updateDeletedContactCleanupPending(listOf(publicKey), isPending)
+
+    private suspend fun updateDeletedContactCleanupPending(publicKeys: Collection<String>, isPending: Boolean) {
+        if (publicKeys.isEmpty()) return
+
         cacheStore.update {
             val pendingKeys = if (isPending) {
-                it.deletedContactCleanupPendingPublicKeys + publicKey
+                it.deletedContactCleanupPendingPublicKeys + publicKeys
             } else {
-                it.deletedContactCleanupPendingPublicKeys - publicKey
+                it.deletedContactCleanupPendingPublicKeys - publicKeys.toSet()
             }
             it.copy(deletedContactCleanupPendingPublicKeys = pendingKeys)
         }
@@ -1530,17 +1557,21 @@ class PrivatePaykitRepo @Inject constructor(
     ): Result<Unit> = withContext(serializedDispatcher) {
         runSuspendCatching {
             val savedKeys = savedPublicKeys.mapNotNull { normalizedPublicKey(it) }.toSet()
-            pendingDeletedContactCleanupPublicKeys().forEach { publicKey ->
-                if (publicKey in savedKeys) {
-                    updateDeletedContactCleanupPending(publicKey, false)
-                    return@forEach
-                }
+            val pendingKeys = pendingDeletedContactCleanupPublicKeys()
+            updateDeletedContactCleanupPending(pendingKeys.intersect(savedKeys), isPending = false)
+            val cleanupKeys = pendingKeys - savedKeys
+            if (cleanupKeys.isEmpty()) return@runSuspendCatching
 
-                removePublishedEndpoints(publicKey).getOrThrow()
-                clearContactState(publicKey)
+            val removalResult = removePublishedEndpoints(cleanupKeys)
+            val remainingPendingKeys = pendingDeletedContactCleanupPublicKeys()
+            val successfulKeys = cleanupKeys
+                .mapNotNull(::normalizedPublicKey)
+                .filterNot { it in remainingPendingKeys }
+            clearContactStates(successfulKeys)
+            successfulKeys.forEach { publicKey ->
                 addressReservationRepo.clearContactAssignment(publicKey)
-                updateDeletedContactCleanupPending(publicKey, false)
             }
+            removalResult.getOrThrow()
         }
     }
 

--- a/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
@@ -44,6 +44,7 @@ import to.bitkit.App
 import to.bitkit.CurrentActivity
 import to.bitkit.data.PrivatePaykitCacheData
 import to.bitkit.data.PrivatePaykitCacheStore
+import to.bitkit.data.PrivatePaykitContactCacheData
 import to.bitkit.data.SettingsData
 import to.bitkit.data.SettingsStore
 import to.bitkit.models.NodeLifecycleState
@@ -389,6 +390,26 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
+    fun `prepareSavedContacts reads linked peers once for multiple contacts`() = test {
+        settingsData.value = SettingsData(
+            sharesPrivatePaykitEndpoints = true,
+            publicPaykitLightningEnabled = false,
+            publicPaykitOnchainEnabled = true,
+        )
+        whenever { paykitSdkService.privateReceiverPathSelection(any(), any()) }.thenReturn(
+            privateReceiverPathSelection(
+                publishableReceiverPaths = emptyList(),
+                linkableReceiverPaths = emptyList(),
+            ),
+        )
+
+        val result = sut.prepareSavedContacts(listOf(CONTACT_KEY, OTHER_CONTACT_KEY))
+
+        assertTrue(result.isSuccess, result.exceptionOrNull().toString())
+        verifyBlocking(paykitSdkService, times(1)) { linkedPeers() }
+    }
+
+    @Test
     fun `private message drain keeps retrying while link is still pending`() = test {
         settingsData.value = SettingsData(
             sharesPrivatePaykitEndpoints = true,
@@ -633,6 +654,64 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
         assertTrue(result.isSuccess, result.exceptionOrNull().toString())
         verifyBlocking(paykitSdkService) { clearPrivatePaymentList(CONTACT_KEY, WALLET_RECEIVER_PATH) }
         verifyBlocking(paykitSdkService, never()) { clearPrivatePaymentList(CONTACT_KEY, SERVER_RECEIVER_PATH) }
+    }
+
+    @Test
+    fun `cleanup drains all contacts in one batch`() = test {
+        cacheData.value = PrivatePaykitCacheData(
+            contacts = mapOf(
+                CONTACT_KEY to cachedPublishedContact(WALLET_RECEIVER_PATH),
+                OTHER_CONTACT_KEY to cachedPublishedContact(SERVER_RECEIVER_PATH),
+            ),
+        )
+        sut = createSut()
+        whenever { paykitSdkService.linkedPeers() }.thenReturn(
+            listOf(
+                linkedPeer(CONTACT_KEY, LinkedPeerState.LINKED),
+                linkedPeer(OTHER_CONTACT_KEY, LinkedPeerState.LINKED, SERVER_RECEIVER_PATH),
+            ),
+        )
+
+        val result = sut.removePublishedEndpointsForCleanup("test")
+
+        assertTrue(result.isSuccess, result.exceptionOrNull().toString())
+        verifyBlocking(paykitSdkService) { clearPrivatePaymentList(CONTACT_KEY, WALLET_RECEIVER_PATH) }
+        verifyBlocking(paykitSdkService) { clearPrivatePaymentList(OTHER_CONTACT_KEY, SERVER_RECEIVER_PATH) }
+        verifyBlocking(paykitSdkService, times(2)) { linkedPeers() }
+        verifyBlocking(paykitSdkService, times(1)) { pendingOutboundPrivateCounterparties() }
+        verifyBlocking(paykitSdkService, times(2)) { processPendingPrivateMessages() }
+        verifyBlocking(paykitSdkService, times(2)) { receivePrivateMessagesFromLinkedPeers() }
+        assertTrue(cacheData.value.contacts.isEmpty())
+    }
+
+    @Test
+    fun `cleanup isolates a failed contact while clearing successful contacts`() = test {
+        cacheData.value = PrivatePaykitCacheData(
+            contacts = mapOf(
+                CONTACT_KEY to cachedPublishedContact(WALLET_RECEIVER_PATH),
+                OTHER_CONTACT_KEY to cachedPublishedContact(SERVER_RECEIVER_PATH),
+            ),
+        )
+        sut = createSut()
+        whenever { paykitSdkService.clearPrivatePaymentList(CONTACT_KEY, WALLET_RECEIVER_PATH) }.thenReturn(
+            privateListDeliveryReport(
+                failedToQueue = listOf(
+                    PrivatePaymentListSyncChange(
+                        counterparty = CONTACT_KEY,
+                        counterpartyReceiverPath = WALLET_RECEIVER_PATH,
+                        outboundMessageId = null,
+                        error = "failed",
+                    ),
+                ),
+            ),
+        )
+
+        val result = sut.removePublishedEndpointsForCleanup("test")
+
+        assertTrue(result.isFailure)
+        assertTrue(CONTACT_KEY in cacheData.value.contacts)
+        assertTrue(OTHER_CONTACT_KEY !in cacheData.value.contacts)
+        assertTrue(cacheData.value.cleanupPending)
     }
 
     @Test
@@ -1115,6 +1194,10 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
         },
         failedToQueue = failedToQueue,
         failedToDeliver = emptyList(),
+    )
+
+    private fun cachedPublishedContact(receiverPath: String) = PrivatePaykitContactCacheData(
+        publishedPrivatePaymentReceiverPaths = setOf(receiverPath),
     )
 
     private fun privateReceiverPathSelection(

--- a/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
@@ -634,6 +634,51 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
 
         assertTrue(result.isFailure)
         assertTrue(cacheData.value.cleanupPending)
+        verifyBlocking(paykitSdkService) { clearPrivatePaymentList(CONTACT_KEY, WALLET_RECEIVER_PATH) }
+        assertEquals(
+            setOf(WALLET_RECEIVER_PATH),
+            cacheData.value.contacts.getValue(CONTACT_KEY).publishedPrivatePaymentReceiverPaths,
+        )
+    }
+
+    @Test
+    fun `cleanup falls back per contact when shared linked receiver inspection fails`() = test {
+        cacheData.value = PrivatePaykitCacheData(
+            contacts = mapOf(
+                CONTACT_KEY to cachedPublishedContact(WALLET_RECEIVER_PATH),
+                OTHER_CONTACT_KEY to cachedPublishedContact(SERVER_RECEIVER_PATH),
+            ),
+        )
+        sut = createSut()
+        var linkedPeerReads = 0
+        whenever { paykitSdkService.linkedPeers() }.thenAnswer {
+            linkedPeerReads += 1
+            if (linkedPeerReads <= 2) error("link inspection failed")
+            emptyList<LinkedPeerRecord>()
+        }
+
+        val result = sut.removePublishedEndpointsForCleanup("test")
+
+        assertTrue(result.isFailure)
+        verifyBlocking(paykitSdkService) { clearPrivatePaymentList(CONTACT_KEY, WALLET_RECEIVER_PATH) }
+        verifyBlocking(paykitSdkService) { clearPrivatePaymentList(OTHER_CONTACT_KEY, SERVER_RECEIVER_PATH) }
+        assertTrue(CONTACT_KEY in cacheData.value.contacts)
+        assertTrue(OTHER_CONTACT_KEY !in cacheData.value.contacts)
+        assertTrue(cacheData.value.cleanupPending)
+    }
+
+    @Test
+    fun `invalid deleted contact key remains pending for cleanup`() = test {
+        val invalidPublicKey = "not-a-pubky"
+        cacheData.value = PrivatePaykitCacheData(
+            deletedContactCleanupPendingPublicKeys = setOf(invalidPublicKey),
+        )
+        sut = createSut()
+
+        val result = sut.retryPendingEndpointRemoval(emptyList())
+
+        assertTrue(result.isFailure)
+        assertEquals(setOf(invalidPublicKey), cacheData.value.deletedContactCleanupPendingPublicKeys)
         verifyBlocking(paykitSdkService, never()) { clearPrivatePaymentList(any(), any()) }
     }
 

--- a/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
@@ -16,7 +16,9 @@ import com.synonym.paykit.PrivatePaymentResolutionState
 import com.synonym.paykit.PrivatePaymentResolutionStatus
 import com.synonym.paykit.PublicationStatus
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -33,6 +35,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -642,7 +645,7 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
-    fun `cleanup falls back per contact when shared linked receiver inspection fails`() = test {
+    fun `cleanup retries linked receiver inspection once for the batch`() = test {
         cacheData.value = PrivatePaykitCacheData(
             contacts = mapOf(
                 CONTACT_KEY to cachedPublishedContact(WALLET_RECEIVER_PATH),
@@ -663,22 +666,25 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
         verifyBlocking(paykitSdkService) { clearPrivatePaymentList(CONTACT_KEY, WALLET_RECEIVER_PATH) }
         verifyBlocking(paykitSdkService) { clearPrivatePaymentList(OTHER_CONTACT_KEY, SERVER_RECEIVER_PATH) }
         assertTrue(CONTACT_KEY in cacheData.value.contacts)
-        assertTrue(OTHER_CONTACT_KEY !in cacheData.value.contacts)
+        assertTrue(OTHER_CONTACT_KEY in cacheData.value.contacts)
         assertTrue(cacheData.value.cleanupPending)
+        assertEquals(3, linkedPeerReads)
     }
 
     @Test
-    fun `invalid deleted contact key remains pending for cleanup`() = test {
+    fun `invalid deleted contact key is dropped from cleanup state`() = test {
         val invalidPublicKey = "not-a-pubky"
         cacheData.value = PrivatePaykitCacheData(
+            contacts = mapOf(invalidPublicKey to cachedPublishedContact(WALLET_RECEIVER_PATH)),
             deletedContactCleanupPendingPublicKeys = setOf(invalidPublicKey),
         )
         sut = createSut()
 
         val result = sut.retryPendingEndpointRemoval(emptyList())
 
-        assertTrue(result.isFailure)
-        assertEquals(setOf(invalidPublicKey), cacheData.value.deletedContactCleanupPendingPublicKeys)
+        assertTrue(result.isSuccess, result.exceptionOrNull().toString())
+        assertTrue(cacheData.value.contacts.isEmpty())
+        assertTrue(cacheData.value.deletedContactCleanupPendingPublicKeys.isEmpty())
         verifyBlocking(paykitSdkService, never()) { clearPrivatePaymentList(any(), any()) }
     }
 
@@ -727,6 +733,84 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
         verifyBlocking(paykitSdkService, times(2)) { processPendingPrivateMessages() }
         verifyBlocking(paykitSdkService, times(2)) { receivePrivateMessagesFromLinkedPeers() }
         assertTrue(cacheData.value.contacts.isEmpty())
+    }
+
+    @Test
+    fun `deleted contact retry cleans all pending contacts in one batch`() = test {
+        cacheData.value = PrivatePaykitCacheData(
+            contacts = mapOf(
+                CONTACT_KEY to cachedPublishedContact(WALLET_RECEIVER_PATH),
+                OTHER_CONTACT_KEY to cachedPublishedContact(SERVER_RECEIVER_PATH),
+            ),
+            deletedContactCleanupPendingPublicKeys = setOf(CONTACT_KEY, OTHER_CONTACT_KEY),
+        )
+        sut = createSut()
+
+        val result = sut.retryPendingEndpointRemoval(emptyList())
+
+        assertTrue(result.isSuccess, result.exceptionOrNull().toString())
+        verifyBlocking(paykitSdkService) { clearPrivatePaymentList(CONTACT_KEY, WALLET_RECEIVER_PATH) }
+        verifyBlocking(paykitSdkService) { clearPrivatePaymentList(OTHER_CONTACT_KEY, SERVER_RECEIVER_PATH) }
+        verifyBlocking(paykitSdkService, times(2)) { linkedPeers() }
+        assertTrue(cacheData.value.contacts.isEmpty())
+        assertTrue(cacheData.value.deletedContactCleanupPendingPublicKeys.isEmpty())
+    }
+
+    @Test
+    fun `cleanup retains the batch when drain inspection fails`() = test {
+        cacheData.value = PrivatePaykitCacheData(
+            contacts = mapOf(
+                CONTACT_KEY to cachedPublishedContact(WALLET_RECEIVER_PATH),
+                OTHER_CONTACT_KEY to cachedPublishedContact(SERVER_RECEIVER_PATH),
+            ),
+        )
+        sut = createSut()
+        whenever { paykitSdkService.linkedPeers() }
+            .thenReturn(emptyList())
+            .thenThrow(IllegalStateException("drain inspection failed"))
+
+        val result = sut.removePublishedEndpointsForCleanup("test")
+
+        assertTrue(result.isFailure)
+        assertTrue(CONTACT_KEY in cacheData.value.contacts)
+        assertTrue(OTHER_CONTACT_KEY in cacheData.value.contacts)
+        assertTrue(cacheData.value.cleanupPending)
+    }
+
+    @Test
+    fun `cleanup retains endpoint cache updated during remote removal`() = test {
+        cacheData.value = PrivatePaykitCacheData(
+            contacts = mapOf(CONTACT_KEY to cachedPublishedContact(WALLET_RECEIVER_PATH)),
+        )
+        sut = createSut()
+        val cleanupStarted = CompletableDeferred<Unit>()
+        val resumeCleanup = CompletableDeferred<Unit>()
+        whenever { paykitSdkService.clearPrivatePaymentList(CONTACT_KEY, WALLET_RECEIVER_PATH) }
+            .doSuspendableAnswer {
+                cleanupStarted.complete(Unit)
+                resumeCleanup.await()
+                privateListDeliveryReport(clearedCounterparties = listOf(CONTACT_KEY))
+            }
+        whenever {
+            paykitSdkService.prepareAndResolvePrivateContactPayment(
+                eq(CONTACT_KEY),
+                eq(SERVER_RECEIVER_PATH),
+                eq(null),
+                any(),
+            )
+        }.thenReturn(resolution(resolvedEndpoint(MethodId.P2wpkh, PRIVATE_ADDRESS), version = 7uL))
+        whenever(coreService.isAddressUsed(PRIVATE_ADDRESS)).thenReturn(false)
+
+        val cleanup = async { sut.removePublishedEndpointsForCleanup("test") }
+        cleanupStarted.await()
+        sut.beginPaymentRequest(
+            paymentRequest(acceptedEndpointIdentifiers = listOf(MethodId.P2wpkh.rawValue)),
+        ).getOrThrow()
+        resumeCleanup.complete(Unit)
+
+        assertTrue(cleanup.await().isFailure)
+        assertTrue(cacheData.value.contacts.getValue(CONTACT_KEY).remoteEndpoints.isNotEmpty())
+        assertTrue(cacheData.value.cleanupPending)
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR builds on #1098 to batch and harden private Paykit contact cleanup:

- Reads one shared SDK linked-peer snapshot per multi-contact publication or cleanup pass, with one batch-level retry instead of per-contact fallback reads.
- Clears receiver-scoped payment lists, drains outbound private messages, and checks pending status once for the whole batch.
- Processes all pending deleted contacts through the collection cleanup path instead of repeating snapshots and drains per contact.
- Serializes publication and cleanup with the same mutex and preserves endpoint cache state that changes while remote cleanup is suspended.
- Keeps per-contact failure isolation for attributable clear failures: successful contacts are cleared while failed contacts remain cached for retry.
- Drops malformed persisted cleanup keys with a warning because they cannot address SDK state, allowing cleanup to converge.
- Batches deleted-contact marker updates into one DataStore write.

Error-path behavior is intentionally conservative:

- If linked-peer inspection fails twice, cleanup still clears locally tracked published paths, but retains all affected contacts for retry.
- If the shared post-drain inspection fails, the whole batch remains cached and pending because delivery status cannot be attributed safely per contact.

### Preview

N/A — repository-only refactor.

### QA Notes

#### Manual Tests

N/A

#### Automated Checks

- `PrivatePaykitRepoTest.kt`: all 43 focused tests passed, including malformed-state recovery, shared snapshot retry, batched deleted-contact retry, drain-inspection failure, partial cleanup failure, and a concurrent cache update during remote cleanup.
- `./gradlew compileDevDebugKotlin` passed as part of the focused and full test runs.
- `./gradlew testDevDebugUnitTest` passed.
- `./gradlew detekt` passed with only pre-existing findings outside this change.
- `git diff --check` passed.
