### PR TITLE
fix(lightning): tune scorer params

### DIFF
--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -90,12 +90,12 @@ class LightningService @Inject constructor(
     companion object {
         private const val TAG = "LightningService"
         private const val NODE_ID_PREVIEW_LEN = 20
-        private const val SCORING_BASE_PENALTY_MSAT = 50_000uL
+
+        private const val SCORING_BASE_PENALTY_MSAT = 40_000uL
         private const val SCORING_LIQUIDITY_PENALTY_MULTIPLIER_MSAT = 10_000uL
         private const val SCORING_LIQUIDITY_PENALTY_AMOUNT_MULTIPLIER_MSAT = 10_000uL
         private const val SCORING_HISTORICAL_LIQUIDITY_PENALTY_AMOUNT_MULTIPLIER_MSAT = 20_000uL
         private const val SCORING_CONSIDERED_IMPOSSIBLE_PENALTY_MSAT = 1_000_000_000_000uL
-        private const val SCORING_PROBING_DIVERSITY_PENALTY_MSAT = 60_000uL
 
         private val DEFAULT_SCORING_FEE_PARAMETERS = ScoringFeeParameters(
             basePenaltyMsat = 1_024uL,
@@ -888,7 +888,6 @@ class LightningService @Inject constructor(
         historicalLiquidityPenaltyAmountMultiplierMsat =
         SCORING_HISTORICAL_LIQUIDITY_PENALTY_AMOUNT_MULTIPLIER_MSAT,
         consideredImpossiblePenaltyMsat = SCORING_CONSIDERED_IMPOSSIBLE_PENALTY_MSAT,
-        probingDiversityPenaltyMsat = SCORING_PROBING_DIVERSITY_PENALTY_MSAT,
     )
 
     // region utxo selection


### PR DESCRIPTION
### Description

Improves Lightning route selection by tuning node-wide scorer fee params. These params have been used in nightly probing testing as the `next` variant. See comparison to current (stable) [here](https://legendary-disco-3qw4ekw.pages.github.io/).

iOS counterpart: https://github.com/synonymdev/bitkit-ios/pull/639

