### PR TITLE
fix: update DataStore for 16 KB compatibility

### DIFF
--- a/changelog.d/next/1107.fixed.md
+++ b/changelog.d/next/1107.fixed.md
@@ -1,0 +1,1 @@
+Fixed native library compatibility on Android devices using 16 KB memory pages.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 constraintlayout-compose = { module = "androidx.constraintlayout:constraintlayout-compose", version = "1.1.1" }
 core-ktx = { module = "androidx.core:core-ktx", version = "1.17.0" }
 core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version = "1.2.0" }
-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version = "1.2.0" }
+datastore-preferences = { module = "androidx.datastore:datastore-preferences", version = "1.2.1" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detekt-compose-rules = { module = "io.nlopez.compose.rules:detekt", version = "0.5.3" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version = "34.8.0" }


### PR DESCRIPTION
Fixes #1103

This PR:

1. Updates AndroidX DataStore to 1.2.1 so `libdatastore_shared_counter.so` uses 16 KB-aligned `GNU_RELRO` padding.
2. Leaves every other native dependency version and the existing native packaging and release paths unchanged.
3. Clears the complete Android compatibility alert in a clean Android 17/API 37 installation with `PAGE_SIZE=16384`; the captured runtime result reports `pageSizeCompat=0`.

### QA Notes

#### Manual Tests

- [x] Fresh-install `mainnetDebug` on the Android 17 `Pixel_10_Pro_XL` emulator with a 16 KB page size → Confirm the Android compatibility alert is absent and `pageSizeCompat=0`.

#### Automated Checks

- [x] `just compile`
- [x] `just test`
- [x] `just lint`
- [x] `just changelog next`
- [x] Remote-only `:app:assembleMainnetDebug --refresh-dependencies` with Maven Local excluded
- [x] `git diff --check`