### PR TITLE
chore: update kotlin and compose bom

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -332,7 +332,6 @@ android {
 }
 
 composeCompiler {
-    featureFlags = setOf()
     reportsDestination = layout.buildDirectory.dir("compose_compiler")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ detekt = "1.23.8"
 glance = "1.2.0-rc01"
 hilt = "2.57.2"
 hiltAndroidx = "1.3.0"
-kotlin = "2.2.21"
+kotlin = "2.3.21"
 ktor = "3.3.3"
 lifecycle = "2.10.0"
 navCompose = "2.9.6"
@@ -28,7 +28,7 @@ camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "cam
 camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camera" }
 camera-view = { module = "androidx.camera:camera-view", version.ref = "camera" }
 # https://developer.android.com/develop/ui/compose/bom/bom-mapping
-compose-bom = { group = "androidx.compose", name = "compose-bom", version = "2025.12.01" }
+compose-bom = { group = "androidx.compose", name = "compose-bom", version = "2026.06.01" }
 compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing" }
@@ -101,7 +101,7 @@ haze-materials = { module = "dev.chrisbanes.haze:haze-materials", version.ref = 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-compose-stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.6.6" }
+compose-stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.7.5" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 google-services = { id = "com.google.gms.google-services", version = "4.4.4" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }


### PR DESCRIPTION
Closes #1115

This PR moves Kotlin to `2.3.21` and Compose to the `2026.06.01` BOM on the current AGP `8.13.2` baseline.

### Description

AGP `8.13.2` is the supported baseline for Kotlin 2.3, so the language and Compose set land here first and #1114 consumes them before touching AGP, Gradle, KSP and Hilt. `2.3.21` is the floor that satisfies the #1114 matrix: KSP `2.3.10` is published against Kotlin `2.3.20`, and AGP 9 built-in Kotlin cannot compile `2.2.21` at all, measured on #1114.

The stability analyzer plugin has to move with Kotlin, and its version is constrained from both sides. `0.6.6` throws `NoSuchMethodError` on a removed IR declaration origin under Kotlin 2.3. `0.8.0` and `0.12.0` pull AGP `9.3.1` onto the plugin classpath, which fails the AGP version check on Gradle `8.13` and would silently override a pinned AGP version later. `0.7.5` targets Kotlin `2.3.21` and leaves AGP alone.

Selected set, all stable releases:

| Component | From | To |
|---|---|---|
| Kotlin, Compose compiler and serialization plugins | `2.2.21` | `2.3.21` |
| Kotlin BOM | `2.2.21` | `2.3.21` |
| Compose BOM | `2025.12.01` | `2026.06.01` |
| Compose stability analyzer | `0.6.6` | `0.7.5` |
| AGP | `8.13.2` | unchanged |
| KSP | `2.3.2` | unchanged |

- Updates the shared Kotlin catalog version, which drives the Compose compiler plugin, the serialization plugin and the Kotlin BOM through `version.ref`.
- Updates the Compose BOM to the latest stable release set.
- Removes the empty Compose feature-flag set, which restated the plugin's own convention. Compose reports still generate without it.
- Leaves KSP and Hilt untouched. Both resolve and compile against Kotlin `2.3.21`, and #1114 owns moving them.
- Requires no source, compiler-option or stability-annotation changes. The upgrade introduces no deprecated compiler flags.
- Leaves the two follow-up issues the spec requires, `docs: align kotlin and compose agent rules` and `refactor: adopt current kotlin language features`, still to be filed and linked before #1115 closes.

### Preview

N/A

### QA Notes

#### Manual Tests

- [ ] **1.** Android Studio → open project: Gradle sync succeeds and Compose previews render.
- [ ] **2.** `regression:` Wallet → scroll activity list → tap an entry → Activity Detail: rows and detail render as before.
- [ ] **3a.** `regression:` Send → scan LN invoice → Amount → Confirm: payment completes.
  - [ ] **3b.** `regression:` back from Amount: in-sheet nav returns as before.
- [ ] **4.** `regression:` Settings → General → Payments: sheet screens open and dismiss.
- [ ] **5.** `regression:` Home → add and configure a widget: Glance widgets render and refresh.
- [ ] **6.** `regression:` switch device theme and locale while the app is open: no crash and no stale Compose state.

#### Automated Checks

- No test coverage added, modified or removed. The change is version-only, so the existing suite is the regression guard.
- Local: `just compile`, `just test` and `just lint` pass on Kotlin `2.3.21`. The full unit suite is green.
- detekt reports 11 findings, the same pre-existing set as master, with none in the changed files.
- Not run locally: `just build`, `just test android` and E2E.
- CI: standard compile, unit test and detekt checks run by the PR bot. This is a fork PR, so the run needs maintainer approval before the required checks report.
