### PR TITLE
feat(send): improve Lightning send failure recovery

### DIFF
--- a/app/src/main/java/to/bitkit/ext/Lnurl.kt
+++ b/app/src/main/java/to/bitkit/ext/Lnurl.kt
@@ -32,6 +32,8 @@ fun LnurlPayData.isFixedAmount(): Boolean =
 fun LnurlPayData.callbackAmountMsats(userSats: ULong? = null): ULong =
     if (isFixedAmount()) minSendable else (userSats ?: minSendableSat()) * MSat.PER_SAT
 
+fun LnurlPayData.supportPaymentRequest(): String = "LNURL: $uri"
+
 fun LnurlWithdrawData.minWithdrawableSat(): ULong = msatCeilOf(minWithdrawable ?: 0u)
 fun LnurlWithdrawData.maxWithdrawableSat(): ULong = msatFloorOf(maxWithdrawable)
 

--- a/app/src/main/java/to/bitkit/ext/PaymentFailureReasonExt.kt
+++ b/app/src/main/java/to/bitkit/ext/PaymentFailureReasonExt.kt
@@ -3,15 +3,125 @@ package to.bitkit.ext
 import android.content.Context
 import org.lightningdevkit.ldknode.PaymentFailureReason
 import to.bitkit.R
+import to.bitkit.models.SendFailureDetails
+import to.bitkit.utils.LdkError
 
 fun PaymentFailureReason?.toUserMessage(context: Context): String = when (this) {
     PaymentFailureReason.RECIPIENT_REJECTED ->
-        context.getString(R.string.wallet__toast_payment_failed_recipient_rejected)
+        context.getString(R.string.wallet__payment_recipient_rejected)
+    PaymentFailureReason.USER_ABANDONED ->
+        context.getString(R.string.wallet__payment_abandoned)
     PaymentFailureReason.RETRIES_EXHAUSTED ->
-        context.getString(R.string.wallet__toast_payment_failed_retries_exhausted)
+        context.getString(R.string.wallet__payment_retries_exhausted)
     PaymentFailureReason.ROUTE_NOT_FOUND ->
-        context.getString(R.string.wallet__toast_payment_failed_route_not_found)
+        context.getString(R.string.wallet__payment_route_not_found)
     PaymentFailureReason.PAYMENT_EXPIRED ->
-        context.getString(R.string.wallet__toast_payment_failed_timeout)
-    else -> context.getString(R.string.wallet__toast_payment_failed_description)
+        context.getString(R.string.wallet__payment_expired)
+    PaymentFailureReason.UNKNOWN_REQUIRED_FEATURES ->
+        context.getString(R.string.wallet__payment_unknown_required_features)
+    PaymentFailureReason.INVOICE_REQUEST_EXPIRED ->
+        context.getString(R.string.wallet__payment_invoice_request_expired)
+    PaymentFailureReason.INVOICE_REQUEST_REJECTED ->
+        context.getString(R.string.wallet__payment_invoice_request_rejected)
+    else -> context.getString(R.string.wallet__payment_failed_description)
 }
+
+fun PaymentFailureReason?.shouldResetRoutingCachesOnRetry(): Boolean =
+    this == PaymentFailureReason.ROUTE_NOT_FOUND || this == PaymentFailureReason.RETRIES_EXHAUSTED
+
+fun PaymentFailureReason?.toCompactFailureType(): String {
+    return this?.name?.snakeToLowerCamel() ?: UNKNOWN_FAILURE_TYPE
+}
+
+fun PaymentFailureReason?.toSendFailureDetails(
+    context: Context,
+    paymentRequest: String? = null,
+): SendFailureDetails {
+    return SendFailureDetails(
+        message = toUserMessage(context),
+        failureType = toCompactFailureType(),
+        resetRoutingCachesOnRetry = shouldResetRoutingCachesOnRetry(),
+        paymentRequest = paymentRequest,
+    )
+}
+
+fun Throwable.toSendFailureMessage(context: Context): String {
+    val fallbackMessage = context.getString(R.string.wallet__payment_failed_description)
+    val rawMessage = message?.trim().orEmpty()
+
+    if (this is LdkError || rawMessage.isBlank() || rawMessage.looksInternalPaymentError()) {
+        return fallbackMessage
+    }
+
+    return rawMessage
+}
+
+fun Throwable.toCompactFailureType(): String {
+    if (this is LdkError) return compactType ?: UNKNOWN_FAILURE_TYPE
+
+    val rawValue = message?.trim()?.takeIf { it.isNotEmpty() }
+        ?: this::class.simpleName
+        ?: UNKNOWN_FAILURE_TYPE
+
+    return rawValue.compactFailureType()
+}
+
+fun Throwable.toSendFailureDetails(
+    context: Context,
+    paymentRequest: String? = null,
+): SendFailureDetails {
+    return SendFailureDetails(
+        message = toSendFailureMessage(context),
+        failureType = toCompactFailureType(),
+        resetRoutingCachesOnRetry = false,
+        paymentRequest = paymentRequest,
+    )
+}
+
+private fun String.snakeToLowerCamel(): String {
+    return lowercase()
+        .split("_")
+        .filter { it.isNotBlank() }
+        .mapIndexed { index, segment ->
+            if (index == 0) segment else segment.replaceFirstChar { it.titlecase() }
+        }
+        .joinToString("")
+        .ifBlank { UNKNOWN_FAILURE_TYPE }
+}
+
+private fun String.compactFailureType(): String {
+    val strippedPrefixes = this
+        .removePrefix("LDK Node error:")
+        .removePrefix("LDK Build error:")
+        .trim()
+    val type = strippedPrefixes
+        .substringBefore("(")
+        .trim()
+        .trimEnd('.')
+        .trim()
+
+    return type.toCompactTypeName()
+}
+
+private fun String.toCompactTypeName(): String {
+    if (isBlank()) return UNKNOWN_FAILURE_TYPE
+    if (none { it.isWhitespace() || it == '-' || it == '_' }) return this
+
+    return split(Regex("[\\s_-]+"))
+        .filter { it.isNotBlank() }
+        .joinToString("") { it.replaceFirstChar(Char::titlecase) }
+        .ifBlank { UNKNOWN_FAILURE_TYPE }
+}
+
+private fun String.looksInternalPaymentError(): Boolean {
+    return INTERNAL_PAYMENT_ERROR_MARKERS.any { contains(it, ignoreCase = true) }
+}
+
+private val INTERNAL_PAYMENT_ERROR_MARKERS = listOf(
+    "DuplicatePayment",
+    "PaymentFailureReason",
+    "ldknode",
+    "LDK",
+)
+
+private const val UNKNOWN_FAILURE_TYPE = "Unknown"

--- a/app/src/main/java/to/bitkit/models/SendFailureDetails.kt
+++ b/app/src/main/java/to/bitkit/models/SendFailureDetails.kt
@@ -1,0 +1,12 @@
+package to.bitkit.models
+
+data class SendFailureDetails(
+    val message: String,
+    val failureType: String,
+    val resetRoutingCachesOnRetry: Boolean,
+    val paymentRequest: String? = null,
+) {
+    fun shouldResetRoutingCaches(routingCacheResetAttempted: Boolean): Boolean {
+        return resetRoutingCachesOnRetry && !routingCacheResetAttempted
+    }
+}

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -48,6 +48,7 @@ import org.lightningdevkit.ldknode.ChannelDetails
 import org.lightningdevkit.ldknode.ClosureReason
 import org.lightningdevkit.ldknode.CoinSelectionAlgorithm
 import org.lightningdevkit.ldknode.Event
+import org.lightningdevkit.ldknode.Network
 import org.lightningdevkit.ldknode.NodeStatus
 import org.lightningdevkit.ldknode.PaymentDetails
 import org.lightningdevkit.ldknode.PaymentHash
@@ -92,6 +93,7 @@ import to.bitkit.services.LnurlChannelResponse
 import to.bitkit.services.LnurlService
 import to.bitkit.services.LnurlWithdrawResponse
 import to.bitkit.services.LspNotificationsService
+import to.bitkit.services.NetworkGraphInfo
 import to.bitkit.services.NodeEventHandler
 import to.bitkit.utils.AppError
 import to.bitkit.utils.Logger
@@ -648,8 +650,14 @@ class LightningRepo @Inject constructor(
     }
 
     private suspend fun clearNetworkGraph(walletIndex: Int): Result<Unit> {
-        lightningService.resetNetworkGraph(walletIndex)
-        return runCatching {
+        runSuspendCatching {
+            lightningService.resetNetworkGraph(walletIndex)
+        }.onFailure {
+            Logger.warn("Failed to clear local network graph", it, context = TAG)
+            return Result.failure(it)
+        }
+
+        return runSuspendCatching {
             vssBackupClientLdk.setup(walletIndex).getOrThrow()
             vssBackupClientLdk.deleteObject("network_graph").getOrThrow()
             Logger.info("Cleared network graph from VSS", context = TAG)
@@ -1870,7 +1878,7 @@ class LightningRepo @Inject constructor(
             vssBackupClientLdk.deleteObject(VSS_KEY_EXTERNAL_SCORES_CACHE).getOrThrow()
         }.onFailure {
             Logger.error("Failed to delete pathfinding scores from VSS", it, context = TAG)
-            start(walletIndex = walletIndex, shouldRetry = false).onFailure { startError ->
+            start(walletIndex = walletIndex, shouldRetry = false, shouldValidateGraph = false).onFailure { startError ->
                 Logger.error("Failed to restart node after pathfinding scores reset failure", startError, context = TAG)
             }
             return@withContext Result.failure(it)
@@ -1878,11 +1886,118 @@ class LightningRepo @Inject constructor(
 
         val resetAtSecs = nowMillis() / 1000
 
-        start(walletIndex = walletIndex, shouldRetry = false)
+        start(walletIndex = walletIndex, shouldRetry = false, shouldValidateGraph = false)
             .map { resetAtSecs }
             .onSuccess {
                 Logger.info("Pathfinding scores reset at '$resetAtSecs'", context = TAG)
             }
+    }
+
+    suspend fun resetPaymentRoutingCachesAndWait(walletIndex: Int = 0): Result<Unit> = withContext(bgDispatcher) {
+        val refreshStartedAtMs = nowMillis()
+        val refreshStartedAtSecs = (refreshStartedAtMs / 1000).toULong()
+        val requiresRgsRefresh = Env.network != Network.REGTEST &&
+            !settingsStore.data.first().rgsServerUrl.isNullOrEmpty()
+        val requiresScorerRefresh = Env.ldkScorerUrl != null
+        val resetErrors = mutableListOf<Throwable>()
+
+        Logger.info(
+            "Started payment routing refresh rgs='$requiresRgsRefresh' scorer='$requiresScorerRefresh'",
+            context = TAG,
+        )
+
+        val resetResult = withContext(NonCancellable) reset@{
+            stop().onFailure {
+                start(
+                    walletIndex = walletIndex,
+                    shouldRetry = false,
+                    shouldValidateGraph = false,
+                ).onFailure { startError ->
+                    Logger.error(
+                        "Failed to restart node after payment routing refresh stop failure",
+                        startError,
+                        context = TAG,
+                    )
+                }
+                return@reset Result.failure(it)
+            }
+
+            clearNetworkGraph(walletIndex).onFailure {
+                resetErrors.add(it)
+            }
+
+            resetPathfindingScores(walletIndex).onFailure {
+                resetErrors.add(it)
+            }
+
+            resetErrors.firstOrNull()?.let {
+                Result.failure(it)
+            } ?: Result.success(Unit)
+        }
+        resetResult.onFailure {
+            return@withContext Result.failure(it)
+        }
+
+        val result = waitForPaymentRoutingDataRefresh(
+            walletIndex = walletIndex,
+            refreshStartedAtMs = refreshStartedAtMs,
+            refreshStartedAtSecs = refreshStartedAtSecs,
+            requiresRgsRefresh = requiresRgsRefresh,
+            requiresScorerRefresh = requiresScorerRefresh,
+        )
+        result.onSuccess {
+            Logger.info(
+                "Finished payment routing refresh elapsedMs='${nowMillis() - refreshStartedAtMs}'",
+                context = TAG,
+            )
+        }
+    }
+
+    private suspend fun waitForPaymentRoutingDataRefresh(
+        walletIndex: Int,
+        refreshStartedAtMs: Long,
+        refreshStartedAtSecs: ULong,
+        requiresRgsRefresh: Boolean,
+        requiresScorerRefresh: Boolean,
+    ): Result<Unit> = withContext(bgDispatcher) {
+        if (!requiresRgsRefresh && !requiresScorerRefresh) {
+            Logger.info(
+                "Skipped payment routing refresh wait because no routing sources are required",
+                context = TAG,
+            )
+            return@withContext Result.success(Unit)
+        }
+
+        var lastStatus: PaymentRoutingRefreshStatus? = null
+        val refreshed = withTimeoutOrNull(PAYMENT_ROUTING_REFRESH_TIMEOUT) {
+            while (isActive) {
+                syncState()
+                val status = _lightningState.value.paymentRoutingRefreshStatus(
+                    graphCacheModificationDate = lightningService.networkGraphCacheModificationDate(walletIndex),
+                    networkGraphInfo = getNetworkGraphInfo(),
+                    refreshStartedAtSecs = refreshStartedAtSecs,
+                    requiresRgsRefresh = requiresRgsRefresh,
+                    requiresScorerRefresh = requiresScorerRefresh,
+                )
+                lastStatus = status
+                if (status.isFresh) {
+                    return@withTimeoutOrNull true
+                }
+                delay(PAYMENT_ROUTING_REFRESH_POLL_DELAY)
+            }
+            false
+        } == true
+
+        if (refreshed) {
+            Result.success(Unit)
+        } else {
+            Logger.warn(
+                "Timed out payment routing refresh elapsedMs='${nowMillis() - refreshStartedAtMs}' " +
+                    lastStatus?.toLogFields().orEmpty(),
+                context = TAG,
+            )
+            Result.failure(PaymentRoutingRefreshTimeoutError())
+        }
     }
     // endregion
 
@@ -1912,6 +2027,64 @@ class LightningRepo @Inject constructor(
         private val NO_USABLE_CHANNELS_FEEDBACK_DELAY = 2_500.milliseconds
         val SEND_LN_TIMEOUT = 10.seconds
         private val PROBE_TIMEOUT = 60.seconds
+        private val PAYMENT_ROUTING_REFRESH_TIMEOUT = 20.seconds
+        private val PAYMENT_ROUTING_REFRESH_POLL_DELAY = 500.milliseconds
+    }
+}
+
+private fun LightningState.paymentRoutingRefreshStatus(
+    graphCacheModificationDate: Long?,
+    networkGraphInfo: NetworkGraphInfo?,
+    refreshStartedAtSecs: ULong,
+    requiresRgsRefresh: Boolean,
+    requiresScorerRefresh: Boolean,
+): PaymentRoutingRefreshStatus {
+    val status = nodeStatus
+    val nodeRunning = nodeLifecycleState.isRunning()
+    val graphNodeCount = networkGraphInfo?.nodeCount
+    val graphChannelCount = networkGraphInfo?.channelCount
+    val hasInMemoryGraph = (graphNodeCount ?: 0) > 0 && (graphChannelCount ?: 0) > 0
+
+    val hasFreshRgs = !requiresRgsRefresh ||
+        graphCacheModificationDate != null && (graphCacheModificationDate / 1000).toULong() >= refreshStartedAtSecs ||
+        hasInMemoryGraph
+
+    val latestScoresTimestamp = status?.latestPathfindingScoresSyncTimestamp
+    val hasFreshScores = !requiresScorerRefresh ||
+        latestScoresTimestamp != null && latestScoresTimestamp >= refreshStartedAtSecs
+
+    return PaymentRoutingRefreshStatus(
+        nodeRunning = nodeRunning,
+        graphFresh = hasFreshRgs,
+        scorerFresh = hasFreshScores,
+        graphCacheModificationDate = graphCacheModificationDate,
+        graphNodeCount = graphNodeCount,
+        graphChannelCount = graphChannelCount,
+        latestPathfindingScoresSyncTimestamp = latestScoresTimestamp,
+        refreshStartedAtSecs = refreshStartedAtSecs,
+    )
+}
+
+private data class PaymentRoutingRefreshStatus(
+    val nodeRunning: Boolean,
+    val graphFresh: Boolean,
+    val scorerFresh: Boolean,
+    val graphCacheModificationDate: Long?,
+    val graphNodeCount: Int?,
+    val graphChannelCount: Int?,
+    val latestPathfindingScoresSyncTimestamp: ULong?,
+    val refreshStartedAtSecs: ULong,
+) {
+    val isFresh: Boolean = nodeRunning && graphFresh && scorerFresh
+
+    fun toLogFields(): String {
+        return "nodeRunning='$nodeRunning' graphFresh='$graphFresh' scorerFresh='$scorerFresh' " +
+            "graphMtime='${graphCacheModificationDate ?: "-"}' " +
+            "graphMtimeSecs='${graphCacheModificationDate?.let { it / 1000 } ?: "-"}' " +
+            "graphNodes='${graphNodeCount ?: "-"}' " +
+            "graphChannels='${graphChannelCount ?: "-"}' " +
+            "scorerTs='${latestPathfindingScoresSyncTimestamp ?: "-"}' " +
+            "refreshStartedAtSecs='$refreshStartedAtSecs'"
     }
 }
 
@@ -1923,6 +2096,7 @@ class NodeRunTimeoutError(opName: String) : AppError("Timeout waiting for node t
 class GetPaymentsError : AppError("It wasn't possible get the payments")
 class SyncUnhealthyError : AppError("Wallet sync failed before send")
 class LnurlPayInvoiceMismatchError : AppError("The invoice did not match the requested payment. Payment cancelled.")
+class PaymentRoutingRefreshTimeoutError : AppError("Timeout waiting for payment routing data refresh")
 
 data class NodeEventUpdate(
     val event: Event,

--- a/app/src/main/java/to/bitkit/repositories/PendingPaymentRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PendingPaymentRepo.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import org.lightningdevkit.ldknode.PaymentFailureReason
 import to.bitkit.R
 import to.bitkit.models.NotificationDetails
 import to.bitkit.utils.AppError
@@ -48,7 +49,10 @@ sealed interface PendingPaymentResolution {
     val paymentHash: String
 
     data class Success(override val paymentHash: String) : PendingPaymentResolution
-    data class Failure(override val paymentHash: String) : PendingPaymentResolution
+    data class Failure(
+        override val paymentHash: String,
+        val reason: PaymentFailureReason? = null,
+    ) : PendingPaymentResolution
 }
 
 object PendingPaymentNotification {

--- a/app/src/main/java/to/bitkit/services/LightningService.kt
+++ b/app/src/main/java/to/bitkit/services/LightningService.kt
@@ -509,14 +509,22 @@ class LightningService @Inject constructor(
         if (node != null) throw ServiceError.NodeStillRunning()
         awaitNodeRelease()
         Logger.warn("Resetting network graph cache…", context = TAG)
-        val ldkPath = Path(Env.ldkStoragePath(walletIndex)).toFile()
-        val graphFile = ldkPath.resolve("network_graph_cache")
+        val graphFile = networkGraphCacheFile(walletIndex)
         if (graphFile.exists()) {
-            graphFile.delete()
+            if (!graphFile.delete()) throw NetworkGraphCacheDeleteError()
             Logger.info("Network graph cache deleted", context = TAG)
         } else {
             Logger.info("No network graph cache found", context = TAG)
         }
+    }
+
+    fun networkGraphCacheModificationDate(walletIndex: Int): Long? {
+        val graphFile = networkGraphCacheFile(walletIndex)
+        return graphFile.takeIf { it.exists() }?.lastModified()
+    }
+
+    private fun networkGraphCacheFile(walletIndex: Int): File {
+        return Path(Env.ldkStoragePath(walletIndex)).toFile().resolve("network_graph_cache")
     }
 
     @Suppress("ReturnCount")
@@ -1368,3 +1376,5 @@ data class NetworkGraphInfo(
 class TrustedPeerForceCloseException : AppError(
     "Cannot force close channel with trusted peer. Force close is disabled for Blocktank LSP channels."
 )
+
+class NetworkGraphCacheDeleteError : AppError("Failed to delete network graph cache")

--- a/app/src/main/java/to/bitkit/ui/ContentView.kt
+++ b/app/src/main/java/to/bitkit/ui/ContentView.kt
@@ -1779,7 +1779,9 @@ private fun NavGraphBuilder.support(
     }
 
     deepLinkableComposable<Routes.ReportIssue> {
+        val route = it.toRoute<Routes.ReportIssue>()
         ReportIssueScreen(
+            prefillMessage = route.prefillMessage,
             onBack = { navController.popBackStack() },
             navigateResultScreen = { isSuccess ->
                 if (isSuccess) {
@@ -2196,7 +2198,7 @@ sealed interface Routes {
     data object Support : Routes.DeepLinkable
 
     @Serializable
-    data object ReportIssue : Routes.DeepLinkable
+    data class ReportIssue(val prefillMessage: String? = null) : Routes.DeepLinkable
 
     @Serializable
     data object ReportIssueSuccess : Routes.DeepLinkable

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendErrorScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendErrorScreen.kt
@@ -1,9 +1,7 @@
 package to.bitkit.ui.screens.wallets.send
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -31,23 +29,29 @@ import to.bitkit.ui.theme.Colors
 
 @Composable
 fun SendErrorScreen(
+    title: String,
     message: String?,
+    isRetrying: Boolean,
     onRetry: () -> Unit,
-    onClose: () -> Unit,
+    onContactSupport: () -> Unit,
 ) {
     Content(
+        title = title,
         message,
+        isRetrying = isRetrying,
         onRetry = onRetry,
-        onClose = onClose,
+        onContactSupport = onContactSupport,
     )
 }
 
 @Composable
 private fun Content(
+    title: String,
     message: String?,
     modifier: Modifier = Modifier,
+    isRetrying: Boolean = false,
     onRetry: () -> Unit = {},
-    onClose: () -> Unit = {},
+    onContactSupport: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -55,7 +59,7 @@ private fun Content(
             .gradientBackground()
             .navigationBarsPadding()
     ) {
-        SheetTopBar(stringResource(R.string.wallet__send_error_tx_failed))
+        SheetTopBar(title)
 
         Column(
             modifier = Modifier
@@ -64,9 +68,10 @@ private fun Content(
         ) {
             VerticalSpacer(16.dp)
 
-            message?.let {
-                BodyM(it, color = Colors.White64)
-            }
+            BodyM(
+                text = message ?: stringResource(R.string.wallet__payment_failed_description),
+                color = Colors.White64,
+            )
 
             FillHeight()
             Image(
@@ -78,25 +83,25 @@ private fun Content(
             )
             FillHeight()
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                SecondaryButton(
-                    text = stringResource(R.string.common__cancel),
-                    onClick = onClose,
-                    modifier = Modifier
-                        .weight(1f)
-                        .testTag("Close")
-                )
-                PrimaryButton(
-                    text = stringResource(R.string.common__try_again),
-                    onClick = onRetry,
-                    modifier = Modifier
-                        .weight(1f)
-                        .testTag("Retry")
-                )
-            }
+            SecondaryButton(
+                text = stringResource(R.string.wallet__send_error_support),
+                onClick = onContactSupport,
+                enabled = !isRetrying,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("Support")
+            )
+
+            VerticalSpacer(16.dp)
+
+            PrimaryButton(
+                text = stringResource(R.string.common__try_again),
+                onClick = onRetry,
+                isLoading = isRetrying,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("Retry")
+            )
 
             VerticalSpacer(16.dp)
         }
@@ -109,6 +114,7 @@ private fun Preview() {
     AppThemeSurface {
         BottomSheetPreview {
             Content(
+                title = stringResource(R.string.wallet__send_error_tx_failed),
                 message = stringResource(R.string.wallet__send_error_create_tx),
                 modifier = Modifier.sheetHeight(),
             )
@@ -122,6 +128,7 @@ private fun PreviewUnknown() {
     AppThemeSurface {
         BottomSheetPreview {
             Content(
+                title = stringResource(R.string.wallet__toast_payment_failed_title),
                 message = null,
                 modifier = Modifier.sheetHeight(),
             )

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendPendingScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendPendingScreen.kt
@@ -46,7 +46,7 @@ fun SendPendingScreen(
     paymentHash: String,
     amount: Long,
     onPaymentSuccess: (String) -> Unit,
-    onPaymentError: () -> Unit,
+    onPaymentError: (PendingPaymentResolution.Failure) -> Unit,
     onClose: () -> Unit,
     onViewDetails: (String) -> Unit,
     viewModel: SendPendingViewModel,
@@ -59,7 +59,7 @@ fun SendPendingScreen(
         LaunchedEffect(resolution) {
             when (resolution) {
                 is PendingPaymentResolution.Success -> onPaymentSuccess(resolution.paymentHash)
-                is PendingPaymentResolution.Failure -> onPaymentError()
+                is PendingPaymentResolution.Failure -> onPaymentError(resolution)
             }
             viewModel.onResolutionHandled()
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendQuickPayScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/SendQuickPayScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -19,7 +18,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import to.bitkit.R
 import to.bitkit.models.NodeLifecycleState
-import to.bitkit.ui.appViewModel
+import to.bitkit.models.SendFailureDetails
 import to.bitkit.ui.components.BalanceHeaderView
 import to.bitkit.ui.components.BottomSheetPreview
 import to.bitkit.ui.components.Display
@@ -39,11 +38,10 @@ import to.bitkit.viewmodels.QuickPayViewModel
 fun SendQuickPayScreen(
     quickPayData: QuickPayData,
     onPaymentComplete: (String, Long) -> Unit,
-    onPaymentPending: (String, Long) -> Unit,
-    onShowError: (String) -> Unit,
+    onPaymentPending: (String, Long, String) -> Unit,
+    onShowError: (SendFailureDetails) -> Unit,
     viewModel: QuickPayViewModel = hiltViewModel(),
 ) {
-    val app = appViewModel ?: return
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lightningState by viewModel.lightningState.collectAsStateWithLifecycle()
 
@@ -53,17 +51,15 @@ fun SendQuickPayScreen(
         }
     }
 
-    DisposableEffect(Unit) {
-        onDispose {
-            app.resetQuickPay()
-        }
-    }
-
     LaunchedEffect(uiState.result) {
         when (val result = uiState.result) {
-            is QuickPayResult.Success -> onPaymentComplete(result.paymentHash, result.amountWithFee)
-            is QuickPayResult.Pending -> onPaymentPending(result.paymentHash, result.amount)
-            is QuickPayResult.Error -> onShowError(result.message)
+            is QuickPayResult.Success -> {
+                onPaymentComplete(result.paymentHash, result.amountWithFee)
+            }
+            is QuickPayResult.Pending -> {
+                onPaymentPending(result.paymentHash, result.amount, result.paymentRequest)
+            }
+            is QuickPayResult.Error -> onShowError(result.failure)
             null -> Unit // continue showing loading state
         }
     }

--- a/app/src/main/java/to/bitkit/ui/settings/support/ReportIssueScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/support/ReportIssueScreen.kt
@@ -32,9 +32,14 @@ import to.bitkit.ui.theme.Colors
 @Composable
 fun ReportIssueScreen(
     viewModel: ReportIssueViewModel = hiltViewModel(),
+    prefillMessage: String? = null,
     onBack: () -> Unit,
     navigateResultScreen: (Boolean) -> Unit,
 ) {
+    LaunchedEffect(prefillMessage) {
+        viewModel.applyPrefillMessage(prefillMessage)
+    }
+
     LaunchedEffect(Unit) {
         viewModel.reportIssueEffect.collect { event ->
             when (event) {

--- a/app/src/main/java/to/bitkit/ui/settings/support/ReportIssueViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/support/ReportIssueViewModel.kt
@@ -24,8 +24,17 @@ class ReportIssueViewModel @Inject constructor(
 
     private val _reportIssueEffect = MutableSharedFlow<ReportIssueEffects>()
     val reportIssueEffect = _reportIssueEffect.asSharedFlow()
+    private var hasAppliedPrefillMessage = false
+
     private fun setReportIssueEffect(effect: ReportIssueEffects) =
         viewModelScope.launch { _reportIssueEffect.emit(effect) }
+
+    fun applyPrefillMessage(text: String?) {
+        if (text == null || hasAppliedPrefillMessage) return
+
+        hasAppliedPrefillMessage = true
+        updateMessage(text)
+    }
 
     fun sendMessage() {
         _uiState.update { it.copy(isLoading = true) }

--- a/app/src/main/java/to/bitkit/ui/settings/support/SupportScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/support/SupportScreen.kt
@@ -83,7 +83,7 @@ fun SupportScreen(
 
     Content(
         onBack = { navController.popBackStack() },
-        onClickReportIssue = { navController.navigateTo(Routes.ReportIssue) },
+        onClickReportIssue = { navController.navigateTo(Routes.ReportIssue()) },
         onClickHelpCenter = {
             val intent = Intent(Intent.ACTION_VIEW, Env.BITKIT_HELP_CENTER.toUri())
             context.startActivity(intent)

--- a/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
@@ -13,8 +13,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -22,11 +27,15 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import to.bitkit.R
+import to.bitkit.ext.supportPaymentRequest
+import to.bitkit.ext.toSendFailureDetails
 import to.bitkit.models.NewTransactionSheetDetails
 import to.bitkit.models.NewTransactionSheetDirection
 import to.bitkit.models.NewTransactionSheetType
+import to.bitkit.models.SendFailureDetails
 import to.bitkit.repositories.ConnectivityState
 import to.bitkit.ui.components.ConnectionIssuesView
 import to.bitkit.ui.components.SyncNodeView
@@ -58,8 +67,11 @@ import to.bitkit.ui.utils.ScreenDeepLinks
 import to.bitkit.ui.utils.composableWithDefaultTransitions
 import to.bitkit.ui.utils.navigationWithDefaultTransitions
 import to.bitkit.viewmodels.AppViewModel
+import to.bitkit.viewmodels.LnurlParams
 import to.bitkit.viewmodels.SendEffect
 import to.bitkit.viewmodels.SendEvent
+import to.bitkit.viewmodels.SendMethod
+import to.bitkit.viewmodels.SendUiState
 import to.bitkit.viewmodels.WalletViewModel
 
 @Suppress("CyclomaticComplexMethod")
@@ -69,9 +81,11 @@ fun SendSheet(
     walletViewModel: WalletViewModel,
     startDestination: SendRoute = SendRoute.Recipient,
 ) {
+    val context = LocalContext.current
     val connectivityState by appViewModel.isOnline.collectAsStateWithLifecycle()
     val isOffline by remember { derivedStateOf { connectivityState != ConnectivityState.CONNECTED } }
     val lightningState by walletViewModel.lightningState.collectAsStateWithLifecycle()
+    var routingCacheResetAttempted by rememberSaveable(startDestination) { mutableStateOf(false) }
 
     val shouldShowSyncOverlay by remember {
         derivedStateOf {
@@ -86,6 +100,7 @@ fun SendSheet(
         if (startDestination == SendRoute.Recipient) {
             appViewModel.resetSendState()
             appViewModel.resetQuickPay()
+            routingCacheResetAttempted = false
         }
     }
     Box(
@@ -128,6 +143,11 @@ fun SendSheet(
                         is SendEffect.NavigateToPending -> navController.navigateTo(
                             SendRoute.Pending(it.paymentHash, it.amount)
                         ) { popUpTo(startDestination) { inclusive = true } }
+                        is SendEffect.NavigateToError -> navController.navigateTo(
+                            SendRoute.errorFromFailure(
+                                failure = it.failure,
+                            )
+                        )
                     }
                 }
             }
@@ -318,20 +338,33 @@ fun SendSheet(
                                 ),
                             )
                         },
-                        onPaymentPending = { paymentHash, amount ->
+                        onPaymentPending = { paymentHash, amount, paymentRequest ->
                             appViewModel.preserveContactPaymentContext(paymentHash)
-                            navController.navigateTo(SendRoute.Pending(paymentHash, amount)) {
+                            navController.navigateTo(
+                                SendRoute.Pending(
+                                    paymentHash = paymentHash,
+                                    amount = amount,
+                                    retryRoute = SendRetryRoute.QuickPay,
+                                    paymentRequest = paymentRequest,
+                                )
+                            ) {
                                 popUpTo(startDestination) { inclusive = true }
                             }
                         },
-                        onShowError = { errorMessage ->
+                        onShowError = { failure ->
                             appViewModel.clearActiveContactPaymentContext()
-                            navController.navigateTo(SendRoute.Error(errorMessage))
+                            navController.navigateTo(
+                                SendRoute.errorFromFailure(
+                                    failure = failure,
+                                    retryRoute = SendRetryRoute.QuickPay,
+                                )
+                            )
                         }
                     )
                 }
                 composableWithDefaultTransitions<SendRoute.Pending> {
                     val route = it.toRoute<SendRoute.Pending>()
+                    val sendUiState by appViewModel.sendUiState.collectAsStateWithLifecycle()
                     SendPendingScreen(
                         paymentHash = route.paymentHash,
                         amount = route.amount,
@@ -345,8 +378,16 @@ fun SendSheet(
                                 ),
                             )
                         },
-                        onPaymentError = {
-                            navController.navigateTo(SendRoute.Error()) {
+                        onPaymentError = { failure ->
+                            navController.navigateTo(
+                                SendRoute.errorFromFailure(
+                                    failure = failure.reason.toSendFailureDetails(
+                                        context = context,
+                                        paymentRequest = route.paymentRequest ?: sendUiState.failurePaymentRequest(),
+                                    ),
+                                    retryRoute = route.retryRoute,
+                                )
+                            ) {
                                 popUpTo<SendRoute.Pending> { inclusive = true }
                             }
                         },
@@ -363,16 +404,44 @@ fun SendSheet(
                 }
                 composableWithDefaultTransitions<SendRoute.Error> {
                     val route = it.toRoute<SendRoute.Error>()
+                    val sendUiState by appViewModel.sendUiState.collectAsStateWithLifecycle()
+                    val isRetrying by walletViewModel.isRetryingLightningPayment.collectAsStateWithLifecycle()
+                    val scope = rememberCoroutineScope()
                     SendErrorScreen(
+                        title = stringResource(route.failureTitle(sendUiState.payMethod)),
                         message = route.message,
+                        isRetrying = isRetrying,
                         onRetry = {
-                            navController.navigateTo(SendRoute.Recipient) {
-                                popUpTo(navController.graph.id) { inclusive = true }
+                            if (isRetrying) return@SendErrorScreen
+                            scope.launch {
+                                val shouldResetRoutingCaches = route.shouldResetRoutingCaches(
+                                    routingCacheResetAttempted = routingCacheResetAttempted
+                                )
+                                if (shouldResetRoutingCaches) routingCacheResetAttempted = true
+                                val resetResult = if (shouldResetRoutingCaches) {
+                                    walletViewModel.resetPaymentRoutingCachesAndWait()
+                                } else {
+                                    Result.success(Unit)
+                                }
+
+                                resetResult
+                                    .onSuccess {
+                                        appViewModel.setSendEvent(SendEvent.ClearPayConfirmation)
+                                        navController.navigateTo(route.retryRoute.sendRoute) {
+                                            popUpTo(navController.graph.id) { inclusive = true }
+                                        }
+                                    }
+                                    .onFailure { appViewModel.toast(it) }
                             }
                         },
-                        onClose = {
-                            appViewModel.hideSheet()
-                        }
+                        onContactSupport = {
+                            appViewModel.navigateToReportIssue(
+                                route.supportMessage(
+                                    paymentMethod = route.supportPaymentMethod(sendUiState.payMethod),
+                                    routingCacheResetAttempted = routingCacheResetAttempted,
+                                )
+                            )
+                        },
                     )
                 }
             }
@@ -461,10 +530,21 @@ sealed interface SendRoute {
     data object ComingSoon : DeepLinkStart
 
     @Serializable
-    data class Pending(val paymentHash: String, val amount: Long) : InternalOnly
+    data class Pending(
+        val paymentHash: String,
+        val amount: Long,
+        val retryRoute: SendRetryRoute = SendRetryRoute.Confirm,
+        val paymentRequest: String? = null,
+    ) : InternalOnly
 
     @Serializable
-    data class Error(val message: String? = null) : InternalOnly
+    data class Error(
+        val message: String? = null,
+        val retryRoute: SendRetryRoute = SendRetryRoute.Confirm,
+        val resetRoutingCachesOnRetry: Boolean = false,
+        val failureType: String = "Unknown",
+        val paymentRequest: String? = null,
+    ) : InternalOnly
 
     companion object {
         private val DEEP_LINK_STARTS: List<DeepLinkStart> = listOf(
@@ -481,5 +561,79 @@ sealed interface SendRoute {
 
         fun fromDeepLink(path: String): DeepLinkStart? =
             ScreenDeepLinks.matchStart(path, Recipient, DEEP_LINK_STARTS)
+
+        fun errorFromFailure(
+            failure: SendFailureDetails,
+            retryRoute: SendRetryRoute = SendRetryRoute.Confirm,
+        ): Error {
+            return Error(
+                message = failure.message,
+                retryRoute = retryRoute,
+                resetRoutingCachesOnRetry = failure.resetRoutingCachesOnRetry,
+                failureType = failure.failureType,
+                paymentRequest = failure.paymentRequest,
+            )
+        }
     }
+}
+
+@Serializable
+enum class SendRetryRoute(val sendRoute: SendRoute) {
+    Confirm(SendRoute.Confirm),
+    QuickPay(SendRoute.QuickPay),
+}
+
+private fun SendRoute.Error.failureTitle(payMethod: SendMethod): Int {
+    return when (retryRoute) {
+        SendRetryRoute.QuickPay -> R.string.wallet__send_instant_failed
+        SendRetryRoute.Confirm -> when (payMethod) {
+            SendMethod.LIGHTNING -> R.string.wallet__send_instant_failed
+            SendMethod.ONCHAIN -> R.string.wallet__send_error_tx_failed
+        }
+    }
+}
+
+private fun SendRoute.Error.shouldResetRoutingCaches(routingCacheResetAttempted: Boolean): Boolean {
+    return SendFailureDetails(
+        message = message.orEmpty(),
+        failureType = failureType,
+        resetRoutingCachesOnRetry = resetRoutingCachesOnRetry,
+        paymentRequest = paymentRequest,
+    ).shouldResetRoutingCaches(routingCacheResetAttempted)
+}
+
+private fun SendRoute.Error.supportPaymentMethod(sendPayMethod: SendMethod): SendMethod {
+    return when (retryRoute) {
+        SendRetryRoute.QuickPay -> SendMethod.LIGHTNING
+        SendRetryRoute.Confirm -> sendPayMethod
+    }
+}
+
+private fun SendRoute.Error.supportMessage(
+    paymentMethod: SendMethod,
+    routingCacheResetAttempted: Boolean,
+): String {
+    return buildString {
+        appendLine("I need help with a failed send payment.")
+        appendLine()
+        appendLine("Failure type: $failureType")
+        appendLine("Payment method: ${paymentMethod.supportLabel()}")
+        appendLine("Routing cache reset attempted: ${if (routingCacheResetAttempted) "Yes" else "No"}")
+        appendLine()
+        appendLine("Payment request: ${paymentRequest?.takeIf { it.isNotBlank() } ?: "Unavailable"}")
+        appendLine()
+        append("Please investigate this payment failure.")
+    }
+}
+
+private fun SendMethod.supportLabel(): String {
+    return when (this) {
+        SendMethod.LIGHTNING -> "lightning"
+        SendMethod.ONCHAIN -> "onchain"
+    }
+}
+
+private fun SendUiState.failurePaymentRequest(): String? {
+    if (payMethod != SendMethod.LIGHTNING) return null
+    return decodedInvoice?.bolt11 ?: (lnurl as? LnurlParams.LnurlPay)?.data?.supportPaymentRequest()
 }

--- a/app/src/main/java/to/bitkit/utils/Errors.kt
+++ b/app/src/main/java/to/bitkit/utils/Errors.kt
@@ -34,11 +34,14 @@ class LdkError(private val inner: LdkException) : AppError("Unknown LDK error.")
     constructor(inner: NodeException) : this(LdkException.Node(inner))
 
     override val message get() = inner.message ?: super.message
+    val compactType get() = inner.compactType
 
     sealed interface LdkException {
         val message: String?
+        val compactType: String?
 
         class Build(exception: BuildException) : LdkException {
+            override val compactType = exception::class.simpleName
             override val message = when (exception) {
                 is BuildException.InvalidChannelMonitor -> "Invalid channel monitor."
                 is BuildException.InvalidSystemTime -> "Invalid system time."
@@ -58,6 +61,7 @@ class LdkError(private val inner: LdkException) : AppError("Unknown LDK error.")
         }
 
         class Node(exception: NodeException) : LdkException {
+            override val compactType = exception::class.simpleName
             override val message = when (exception) {
                 is NodeException.AlreadyRunning -> "The node is already running."
                 is NodeException.NotRunning -> "The node is not running."

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -101,7 +101,9 @@ import to.bitkit.ext.rawId
 import to.bitkit.ext.removeSpaces
 import to.bitkit.ext.runSuspendCatching
 import to.bitkit.ext.setClipboardText
+import to.bitkit.ext.supportPaymentRequest
 import to.bitkit.ext.toHex
+import to.bitkit.ext.toSendFailureDetails
 import to.bitkit.ext.toUserMessage
 import to.bitkit.ext.totalValue
 import to.bitkit.ext.walletId
@@ -117,6 +119,7 @@ import to.bitkit.models.PubkyPublicKeyFormat
 import to.bitkit.models.PubkyRingAuthCallback
 import to.bitkit.models.PubkyRingAuthCallbackHandlingResult
 import to.bitkit.models.SamRockSetupRequest
+import to.bitkit.models.SendFailureDetails
 import to.bitkit.models.Suggestion
 import to.bitkit.models.Toast
 import to.bitkit.models.TransactionSpeed
@@ -1127,7 +1130,7 @@ class AppViewModel @Inject constructor(
             activityRepo.handlePaymentEvent(paymentHash)
             if (pendingPaymentRepo.isPending(paymentHash)) {
                 clearPendingContactPaymentContext(paymentHash)
-                pendingPaymentRepo.resolve(PendingPaymentResolution.Failure(paymentHash))
+                pendingPaymentRepo.resolve(PendingPaymentResolution.Failure(paymentHash, event.reason))
                 if (_currentSheet.value !is Sheet.Send || !pendingPaymentRepo.isActive(paymentHash)) {
                     notifyPendingPaymentFailed()
                 }
@@ -1142,9 +1145,20 @@ class AppViewModel @Inject constructor(
         val activePaymentHash = _sendUiState.value.decodedInvoice?.paymentHash?.toHex()
         if (_currentSheet.value !is Sheet.Send || activePaymentHash != paymentHash) return false
 
-        notifyPaymentFailed(reason)
-        hideSheet()
+        setSendEffect(
+            SendEffect.NavigateToError(
+                reason.toSendFailureDetails(
+                    context = context,
+                    paymentRequest = _sendUiState.value.currentLightningPaymentRequest(),
+                )
+            )
+        )
         return true
+    }
+
+    private fun SendUiState.currentLightningPaymentRequest(): String? {
+        if (payMethod != SendMethod.LIGHTNING) return null
+        return decodedInvoice?.bolt11 ?: (lnurl as? LnurlParams.LnurlPay)?.data?.supportPaymentRequest()
     }
 
     private suspend fun handlePaymentReceived(
@@ -2844,8 +2858,13 @@ class AppViewModel @Inject constructor(
                         preActivityMetadataRepo.deletePreActivityMetadata(createdMetadataPaymentId)
                     }
                     Logger.error("Error sending lightning payment", it, context = TAG)
-                    toast(it)
-                    hideSheet()
+                    val failure = when (it) {
+                        is LightningPaymentFailedError -> it.reason.toSendFailureDetails(context, it.paymentRequest)
+                        else -> it.toSendFailureDetails(context, _sendUiState.value.currentLightningPaymentRequest())
+                    }
+                    setSendEffect(
+                        SendEffect.NavigateToError(failure)
+                    )
                 }
             }
         }
@@ -3039,7 +3058,9 @@ class AppViewModel @Inject constructor(
                 when (it) {
                     is Event.PaymentSuccessful if it.paymentHash == hash -> WatchResult.Complete(Result.success(hash))
                     is Event.PaymentFailed if it.paymentHash == hash -> WatchResult.Complete(
-                        Result.failure(AppError(it.reason.toUserMessage(context)))
+                        Result.failure(
+                            LightningPaymentFailedError(reason = it.reason, paymentRequest = bolt11)
+                        )
                     )
 
                     else -> WatchResult.Continue()
@@ -3064,6 +3085,13 @@ class AppViewModel @Inject constructor(
         viewModelScope.launch {
             hideSheet()
             mainScreenEffect(MainScreenEffect.Navigate(Routes.ActivityDetail(activityRawId)))
+        }
+    }
+
+    fun navigateToReportIssue(prefillMessage: String) {
+        viewModelScope.launch {
+            hideSheet()
+            mainScreenEffect(MainScreenEffect.Navigate(Routes.ReportIssue(prefillMessage)))
         }
     }
 
@@ -3984,6 +4012,7 @@ sealed class SendEffect {
     data object NavigateToContacts : SendEffect()
     data object NavigateToComingSoon : SendEffect()
     data object PaymentSuccess : SendEffect()
+    data class NavigateToError(val failure: SendFailureDetails) : SendEffect()
     data class NavigateToPending(val paymentHash: String, val amount: Long) : SendEffect()
 }
 
@@ -4026,6 +4055,11 @@ sealed interface SendEvent {
     data object NavToAddress : SendEvent
     data object Contacts : SendEvent
 }
+
+private class LightningPaymentFailedError(
+    val reason: PaymentFailureReason?,
+    val paymentRequest: String?,
+) : AppError(reason?.name)
 
 sealed interface LnurlParams {
     data class LnurlPay(val data: LnurlPayData) : LnurlParams

--- a/app/src/main/java/to/bitkit/viewmodels/QuickPayViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/QuickPayViewModel.kt
@@ -10,11 +10,14 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.lightningdevkit.ldknode.Event
+import org.lightningdevkit.ldknode.PaymentFailureReason
 import org.lightningdevkit.ldknode.PaymentId
 import to.bitkit.ext.WatchResult
 import to.bitkit.ext.callbackAmountMsats
-import to.bitkit.ext.toUserMessage
+import to.bitkit.ext.supportPaymentRequest
+import to.bitkit.ext.toSendFailureDetails
 import to.bitkit.ext.watchUntil
+import to.bitkit.models.SendFailureDetails
 import to.bitkit.repositories.LightningRepo
 import to.bitkit.repositories.PaymentPendingException
 import to.bitkit.repositories.PendingPaymentRepo
@@ -40,36 +43,16 @@ class QuickPayViewModel @Inject constructor(
 
     fun pay(data: QuickPayData) {
         viewModelScope.launch {
-            val (bolt11, amount, displaySats) = when (data) {
-                is QuickPayData.Bolt11 -> {
-                    Logger.info("QuickPay: processing bolt11 invoice")
-                    Triple(data.bolt11, null, data.sats)
-                }
+            val invoice = resolveQuickPayInvoice(data) ?: return@launch
 
-                is QuickPayData.LnurlPay -> {
-                    Logger.info("QuickPay: fetching LNURL Pay invoice from callback")
-                    val invoice = lightningRepo.fetchLnurlInvoice(
-                        data = data.data,
-                        amountMsats = data.data.callbackAmountMsats(data.sats),
-                    )
-                        .getOrElse { error ->
-                            _uiState.update {
-                                it.copy(result = QuickPayResult.Error(error.message.orEmpty()))
-                            }
-                            return@launch
-                        }
-                    Triple(invoice.bolt11, null, data.sats)
-                }
-            }
-
-            sendLightning(bolt11, amount)
+            sendLightning(invoice.bolt11, invoice.amount)
                 .onSuccess { paymentHash ->
                     Logger.info("QuickPay lightning payment successful")
                     _uiState.update {
                         it.copy(
                             result = QuickPayResult.Success(
                                 paymentHash = paymentHash,
-                                amountWithFee = displaySats.toLong() // TODO GET FEE WHEN AVAILABLE
+                                amountWithFee = invoice.displaySats.toLong() // TODO GET FEE WHEN AVAILABLE
                             )
                         )
                     }
@@ -81,7 +64,8 @@ class QuickPayViewModel @Inject constructor(
                             it.copy(
                                 result = QuickPayResult.Pending(
                                     paymentHash = error.paymentHash,
-                                    amount = displaySats.toLong(),
+                                    amount = invoice.displaySats.toLong(),
+                                    paymentRequest = invoice.paymentRequest,
                                 )
                             )
                         }
@@ -89,10 +73,47 @@ class QuickPayViewModel @Inject constructor(
                     }
                     Logger.error("QuickPay lightning payment failed", error, context = TAG)
 
-                    _uiState.update {
-                        it.copy(result = QuickPayResult.Error(error.message.orEmpty()))
-                    }
+                    handleQuickPayFailure(error, invoice)
                 }
+        }
+    }
+
+    private suspend fun resolveQuickPayInvoice(data: QuickPayData): QuickPayInvoice? {
+        return when (data) {
+            is QuickPayData.Bolt11 -> {
+                Logger.info("QuickPay: processing bolt11 invoice")
+                QuickPayInvoice(data.bolt11, null, data.sats, data.bolt11)
+            }
+
+            is QuickPayData.LnurlPay -> {
+                Logger.info("QuickPay: fetching LNURL Pay invoice from callback")
+                lightningRepo.fetchLnurlInvoice(
+                    data = data.data,
+                    amountMsats = data.data.callbackAmountMsats(data.sats),
+                ).fold(
+                    onSuccess = { QuickPayInvoice(it.bolt11, null, data.sats, data.data.supportPaymentRequest()) },
+                    onFailure = {
+                        _uiState.update { state ->
+                            state.copy(
+                                result = QuickPayResult.Error(
+                                    it.toSendFailureDetails(context, data.data.supportPaymentRequest())
+                                )
+                            )
+                        }
+                        null
+                    },
+                )
+            }
+        }
+    }
+
+    private fun handleQuickPayFailure(error: Throwable, invoice: QuickPayInvoice) {
+        val failure = when (error) {
+            is QuickPayPaymentFailedError -> error.reason.toSendFailureDetails(context, error.paymentRequest)
+            else -> error.toSendFailureDetails(context, invoice.bolt11.ifBlank { invoice.fallbackPaymentRequest })
+        }
+        _uiState.update {
+            it.copy(result = QuickPayResult.Error(failure))
         }
     }
 
@@ -111,7 +132,9 @@ class QuickPayViewModel @Inject constructor(
             when (it) {
                 is Event.PaymentSuccessful if it.paymentHash == hash -> WatchResult.Complete(Result.success(hash))
                 is Event.PaymentFailed if it.paymentHash == hash -> WatchResult.Complete(
-                    Result.failure(AppError(it.reason.toUserMessage(context)))
+                    Result.failure(
+                        QuickPayPaymentFailedError(reason = it.reason, paymentRequest = bolt11)
+                    )
                 )
 
                 else -> WatchResult.Continue()
@@ -130,11 +153,26 @@ sealed class QuickPayResult {
     data class Pending(
         val paymentHash: String,
         val amount: Long,
+        val paymentRequest: String,
     ) : QuickPayResult()
 
-    data class Error(val message: String) : QuickPayResult()
+    data class Error(val failure: SendFailureDetails) : QuickPayResult()
 }
 
 data class QuickPayUiState(
     val result: QuickPayResult? = null,
 )
+
+private data class QuickPayInvoice(
+    val bolt11: String,
+    val amount: ULong?,
+    val displaySats: ULong,
+    val fallbackPaymentRequest: String,
+) {
+    val paymentRequest get() = bolt11.ifBlank { fallbackPaymentRequest }
+}
+
+private class QuickPayPaymentFailedError(
+    val reason: PaymentFailureReason?,
+    val paymentRequest: String?,
+) : AppError(reason?.name)

--- a/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/TransferViewModel.kt
@@ -1124,7 +1124,7 @@ class TransferViewModel @Inject constructor(
         ToastEventBus.send(
             type = Toast.ToastType.ERROR,
             title = context.getString(R.string.common__error),
-            description = context.getString(R.string.wallet__toast_payment_failed_timeout),
+            description = context.getString(R.string.wallet__payment_timeout),
         )
     }
 

--- a/app/src/main/java/to/bitkit/viewmodels/WalletViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/WalletViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeoutOrNull
 import org.lightningdevkit.ldknode.ChannelDataMigration
 import org.lightningdevkit.ldknode.PeerDetails
@@ -44,6 +45,7 @@ import to.bitkit.services.BoltzService
 import to.bitkit.services.MigrationService
 import to.bitkit.ui.onboarding.LOADING_MS
 import to.bitkit.ui.shared.toast.ToastEventBus
+import to.bitkit.utils.AppError
 import to.bitkit.utils.Logger
 import to.bitkit.utils.isTxSyncTimeout
 import javax.inject.Inject
@@ -103,6 +105,10 @@ class WalletViewModel @Inject constructor(
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing = _isRefreshing.asStateFlow()
+
+    private val retryLightningPaymentMutex = Mutex()
+    private val _isRetryingLightningPayment = MutableStateFlow(false)
+    val isRetryingLightningPayment = _isRetryingLightningPayment.asStateFlow()
 
     private var syncJob: Job? = null
     private var pendingWalletStart = false
@@ -455,6 +461,18 @@ class WalletViewModel @Inject constructor(
         lightningRepo.syncState()
     }
 
+    suspend fun resetPaymentRoutingCachesAndWait(): Result<Unit> {
+        if (!retryLightningPaymentMutex.tryLock()) return Result.failure(LightningPaymentRetryInProgressError())
+
+        _isRetryingLightningPayment.update { true }
+        return try {
+            lightningRepo.resetPaymentRoutingCachesAndWait()
+        } finally {
+            _isRetryingLightningPayment.update { false }
+            retryLightningPaymentMutex.unlock()
+        }
+    }
+
     fun onPullToRefresh() {
         // Cancel any existing sync, manual or event triggered
         syncJob?.cancel()
@@ -587,3 +605,5 @@ sealed interface RestoreState {
     fun isOngoing() = this is InProgress
     fun isIdle() = this is Initial || this is Settled
 }
+
+class LightningPaymentRetryInProgressError : AppError("Lightning payment retry already in progress")

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">تبدو رسوم المعاملة أكثر من 50% من المبلغ الذي ترسله. هل تريد المتابعة؟</string>
     <string name="wallet__send_dialog4">تبدو رسوم المعاملة أكثر من 10$. هل تريد المتابعة؟</string>
     <string name="wallet__send_error_create_tx">تعذر بث المعاملة. يرجى المحاولة مرة أخرى.</string>
+    <string name="wallet__send_error_support">الدعم</string>
     <string name="wallet__send_error_tx_failed">فشلت المعاملة</string>
     <string name="wallet__send_fee_and_speed">السرعة والرسوم</string>
     <string name="wallet__send_fee_custom">تعيين رسوم مخصصة</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">السرعة</string>
     <string name="wallet__send_fee_total">₿ {feeSats} لهذه المعاملة</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} لهذه المعاملة ({fiatSymbol}{fiatFormatted})</string>
+    <string name="wallet__send_instant_failed">فشل الدفع</string>
     <string name="wallet__send_invoice">الفاتورة</string>
     <string name="wallet__send_invoice_expiration">انتهاء صلاحية الفاتورة</string>
     <string name="wallet__send_max">الحد الأقصى</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">علامة جديدة</string>
     <string name="wallet__tags_new_enter">أدخل علامة جديدة</string>
     <string name="wallet__tags_previously">العلامات المستخدمة سابقًا</string>
+    <string name="wallet__payment_abandoned">تم إيقاف دفعة Lightning قبل اكتمالها.</string>
+    <string name="wallet__payment_expired">انتهت صلاحية دفعة Lightning هذه. اطلب فاتورة جديدة.</string>
+    <string name="wallet__payment_failed_description">فشل دفعك الفوري. يرجى المحاولة مرة أخرى.</string>
+    <string name="wallet__payment_invoice_request_expired">انتهت صلاحية طلب فاتورة Lightning هذا. اطلب فاتورة جديدة.</string>
+    <string name="wallet__payment_invoice_request_rejected">رفض المستلم طلب فاتورة Lightning هذا.</string>
+    <string name="wallet__payment_recipient_rejected">رفض المستلم دفعة Lightning هذه. تحقق من الفاتورة وحاول مرة أخرى.</string>
+    <string name="wallet__payment_retries_exhausted">جرّب Bitkit عدة مسارات Lightning، لكن تعذر إكمال الدفعة.</string>
+    <string name="wallet__payment_route_not_found">لم يتمكن Bitkit من العثور على مسار Lightning لهذه الدفعة.</string>
+    <string name="wallet__payment_timeout">انتهت مهلة الدفع. حاول مرة أخرى.</string>
+    <string name="wallet__payment_unknown_required_features">تستخدم فاتورة Lightning هذه ميزات لا يدعمها Bitkit بعد.</string>
     <string name="wallet__toast_payment_failed_description">فشل دفعك الفوري. يرجى المحاولة مرة أخرى.</string>
     <string name="wallet__toast_payment_failed_title">فشل الدفع</string>
     <string name="wallet__toast_received_transaction_replaced_description">تم استبدال معاملتك المستلمة برفع الرسوم</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">La comisión de transacción parece ser superior al 50% del importe que está enviando. ¿Desea continuar?</string>
     <string name="wallet__send_dialog4">La tasa de transacción parece ser superior a 10 dólares. ¿Desea continuar?</string>
     <string name="wallet__send_error_create_tx">No se ha podido emitir la transacción. Por favor, inténtelo de nuevo.</string>
+    <string name="wallet__send_error_support">Contactar a soporte</string>
     <string name="wallet__send_error_tx_failed">Transacción ha fallado</string>
     <string name="wallet__send_fee_and_speed">Velocidad y tarifa</string>
     <string name="wallet__send_fee_custom">Fijar tarifa personalizada</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">Velocidad</string>
     <string name="wallet__send_fee_total">₿ {feeSats} para esta transacción</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} para esta transacción ({fiatSymbol}{fiatFormatted} )</string>
+    <string name="wallet__send_instant_failed">Pago fallido</string>
     <string name="wallet__send_invoice">Factura</string>
     <string name="wallet__send_invoice_expiration">Expiración de la factura</string>
     <string name="wallet__send_max">MAX</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">Nueva etiqueta</string>
     <string name="wallet__tags_new_enter">Introduzca una nueva etiqueta</string>
     <string name="wallet__tags_previously">Etiquetas utilizadas anteriormente</string>
+    <string name="wallet__payment_abandoned">El pago Lightning se detuvo antes de completarse.</string>
+    <string name="wallet__payment_expired">Este pago Lightning venció. Solicite una factura nueva.</string>
+    <string name="wallet__payment_failed_description">Su pago instantáneo ha fallado. Por favor, inténtelo de nuevo.</string>
+    <string name="wallet__payment_invoice_request_expired">Esta solicitud de factura Lightning venció. Solicite una factura nueva.</string>
+    <string name="wallet__payment_invoice_request_rejected">El destinatario rechazó esta solicitud de factura Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">El destinatario rechazó este pago Lightning. Revise la factura e inténtelo de nuevo.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit probó varias rutas Lightning, pero el pago no se pudo completar.</string>
+    <string name="wallet__payment_route_not_found">Bitkit no pudo encontrar una ruta Lightning para este pago.</string>
+    <string name="wallet__payment_timeout">El pago agotó el tiempo de espera. Inténtelo de nuevo.</string>
+    <string name="wallet__payment_unknown_required_features">Esta factura Lightning usa funciones que Bitkit aún no admite.</string>
     <string name="wallet__toast_payment_failed_description">Su pago instantáneo ha fallado. Por favor, inténtelo de nuevo.</string>
     <string name="wallet__toast_payment_failed_title">Pago fallido</string>
     <string name="wallet__toast_received_transaction_replaced_description">Tu transacción entrante fue reemplazada al aumentar la comisión</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">La comissió de la transacció sembla ser més del 50% de l\'import que estàs enviant. Vols continuar?</string>
     <string name="wallet__send_dialog4">La comissió de la transacció sembla ser superior a 10 $. Vols continuar?</string>
     <string name="wallet__send_error_create_tx">No es pot transmetre la transacció. Si us plau, torna-ho a provar.</string>
+    <string name="wallet__send_error_support">Contacta amb el suport</string>
     <string name="wallet__send_error_tx_failed">Transacció fallida</string>
     <string name="wallet__send_fee_and_speed">Velocitat i comissió</string>
     <string name="wallet__send_fee_custom">Estableix una tarifa personalitzada</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">Velocitat</string>
     <string name="wallet__send_fee_total">₿ {feeSats} per a aquesta transacció</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} per a aquesta transacció ({fiatSymbol}{fiatFormatted})</string>
+    <string name="wallet__send_instant_failed">Pagament fallit</string>
     <string name="wallet__send_invoice">Factura</string>
     <string name="wallet__send_invoice_expiration">Caducitat de la factura</string>
     <string name="wallet__send_max">MAX</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">Nova etiqueta</string>
     <string name="wallet__tags_new_enter">Introdueix una nova etiqueta</string>
     <string name="wallet__tags_previously">Etiquetes prèviament utilitzades</string>
+    <string name="wallet__payment_abandoned">El pagament Lightning s\'ha aturat abans de completar-se.</string>
+    <string name="wallet__payment_expired">Aquest pagament Lightning ha caducat. Demana una factura nova.</string>
+    <string name="wallet__payment_failed_description">El teu pagament instantani ha fallat. Si us plau, torna-ho a provar.</string>
+    <string name="wallet__payment_invoice_request_expired">Aquesta sol·licitud de factura Lightning ha caducat. Demana una factura nova.</string>
+    <string name="wallet__payment_invoice_request_rejected">El destinatari ha rebutjat aquesta sol·licitud de factura Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">El destinatari ha rebutjat aquest pagament Lightning. Comprova la factura i torna-ho a provar.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit ha provat diverses rutes Lightning, però el pagament no s\'ha pogut completar.</string>
+    <string name="wallet__payment_route_not_found">Bitkit no ha pogut trobar cap ruta Lightning per a aquest pagament.</string>
+    <string name="wallet__payment_timeout">El pagament ha esgotat el temps d\'espera. Torna-ho a provar.</string>
+    <string name="wallet__payment_unknown_required_features">Aquesta factura Lightning utilitza funcions que Bitkit encara no admet.</string>
     <string name="wallet__toast_payment_failed_description">El teu pagament instantani ha fallat. Si us plau, torna-ho a provar.</string>
     <string name="wallet__toast_payment_failed_title">Pagament fallit</string>
     <string name="wallet__toast_received_transaction_replaced_description">La teva transacció rebuda ha estat substituïda per un augment de tarifa</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">Zdá se, že transakční poplatek přesahuje 50 % částky, kterou odesíláte. Přejete si pokračovat?</string>
     <string name="wallet__send_dialog4">Transakční poplatek se zdá být vyšší než $10. Přejete si pokračovat?</string>
     <string name="wallet__send_error_create_tx">Transakci se nepodařilo provést. Zkuste to prosím znovu.</string>
+    <string name="wallet__send_error_support">Kontaktovat podporu</string>
     <string name="wallet__send_error_tx_failed">Transakce selhala</string>
     <string name="wallet__send_fee_and_speed">Rychlost a poplatek</string>
     <string name="wallet__send_fee_custom">Nastavit vlastní poplatek</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">Rychlost</string>
     <string name="wallet__send_fee_total">₿ {feeSats} za tuto transakci</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} za tuto transakci ({fiatSymbol}{fiatFormatted} ).</string>
+    <string name="wallet__send_instant_failed">Platba se nezdařila</string>
     <string name="wallet__send_invoice">Faktura</string>
     <string name="wallet__send_invoice_expiration">Expirace faktury</string>
     <string name="wallet__send_max">MAX</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">Nový tag</string>
     <string name="wallet__tags_new_enter">Vložte nový tag</string>
     <string name="wallet__tags_previously">Dříve použité tagy</string>
+    <string name="wallet__payment_abandoned">Lightning platba byla zastavena před dokončením.</string>
+    <string name="wallet__payment_expired">Platnost této Lightning platby vypršela. Vyžádejte si novou fakturu.</string>
+    <string name="wallet__payment_failed_description">Vaše okamžitá platba se nezdařila. Zkuste to prosím znovu.</string>
+    <string name="wallet__payment_invoice_request_expired">Platnost této žádosti o Lightning fakturu vypršela. Vyžádejte si novou fakturu.</string>
+    <string name="wallet__payment_invoice_request_rejected">Příjemce tuto žádost o Lightning fakturu odmítl.</string>
+    <string name="wallet__payment_recipient_rejected">Příjemce tuto Lightning platbu odmítl. Zkontrolujte fakturu a zkuste to znovu.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit vyzkoušel několik Lightning tras, ale platbu se nepodařilo dokončit.</string>
+    <string name="wallet__payment_route_not_found">Bitkit nenašel pro tuto platbu žádnou Lightning trasu.</string>
+    <string name="wallet__payment_timeout">Časový limit platby vypršel. Zkuste to znovu.</string>
+    <string name="wallet__payment_unknown_required_features">Tato Lightning faktura používá funkce, které Bitkit zatím nepodporuje.</string>
     <string name="wallet__toast_payment_failed_description">Vaše okamžitá platba se nezdařila. Zkuste to prosím znovu.</string>
     <string name="wallet__toast_payment_failed_title">Platba se nezdařila</string>
     <string name="wallet__toast_received_transaction_replaced_description">Vaše přijatá transakce byla nahrazena navýšením poplatku</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -784,6 +784,7 @@
     <string name="wallet__recipient_invoice">Rechnung einfügen</string>
     <string name="wallet__recipient_manual">Manuell eingeben</string>
     <string name="wallet__recipient_scan">QR-Code scannen</string>
+    <string name="wallet__send_instant_failed">Zahlung fehlgeschlagen</string>
     <string name="wallet__send_invoice">Rechnung</string>
     <string name="wallet__send_clipboard_empty_title">Zwischenablage leer</string>
     <string name="wallet__send_clipboard_empty_text">Bitte kopiere eine Adresse oder eine Rechnung.</string>
@@ -809,6 +810,7 @@
     <string name="wallet__send_quickpay__title">Bezahlen\n&lt;accent&gt;Rechnung...&lt;/accent&gt;</string>
     <string name="wallet__send_error_tx_failed">Transaktion fehlgeschlagen</string>
     <string name="wallet__send_error_create_tx">Die Transaktion konnte nicht gesendet werden. Bitte versuche es erneut.</string>
+    <string name="wallet__send_error_support">Support kontaktieren</string>
     <string name="wallet__error_invalid_bitcoin_address">Ungültige Bitcoin-Sendeadresse</string>
     <string name="wallet__error_invoice_update">Fehler beim Aktualisieren der Rechnung</string>
     <string name="wallet__error_lnurl_invoice_fetch">Fehler beim Abrufen der LNURL-Rechnung</string>
@@ -838,6 +840,16 @@
     <string name="wallet__tags_filter">Aktivität nach Tags filtern</string>
     <string name="wallet__tags_filter_title">Tag auswählen</string>
     <string name="wallet__toast_payment_failed_title">Zahlung fehlgeschlagen</string>
+    <string name="wallet__payment_abandoned">Die Lightning-Zahlung wurde gestoppt, bevor sie abgeschlossen wurde.</string>
+    <string name="wallet__payment_expired">Diese Lightning-Zahlung ist abgelaufen. Bitte fordere eine neue Rechnung an.</string>
+    <string name="wallet__payment_failed_description">Deine sofortige Zahlung ist fehlgeschlagen. Bitte versuche es erneut.</string>
+    <string name="wallet__payment_invoice_request_expired">Diese Lightning-Rechnungsanfrage ist abgelaufen. Bitte fordere eine neue Rechnung an.</string>
+    <string name="wallet__payment_invoice_request_rejected">Der Empfänger hat diese Lightning-Rechnungsanfrage abgelehnt.</string>
+    <string name="wallet__payment_recipient_rejected">Der Empfänger hat diese Lightning-Zahlung abgelehnt. Bitte prüfe die Rechnung und versuche es erneut.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit hat mehrere Lightning-Routen ausprobiert, aber die Zahlung konnte nicht abgeschlossen werden.</string>
+    <string name="wallet__payment_route_not_found">Bitkit konnte keine Lightning-Route für diese Zahlung finden.</string>
+    <string name="wallet__payment_timeout">Zeitüberschreitung bei der Zahlung. Bitte versuche es erneut.</string>
+    <string name="wallet__payment_unknown_required_features">Diese Lightning-Rechnung verwendet Funktionen, die Bitkit noch nicht unterstützt.</string>
     <string name="wallet__toast_payment_failed_description">Deine sofortige Zahlung ist fehlgeschlagen. Bitte versuche es erneut.</string>
     <string name="wallet__toast_received_transaction_replaced_title">Empfangene Transaktion ersetzt</string>
     <string name="wallet__toast_received_transaction_replaced_description">Deine empfangene Transaktion wurde durch eine Gebührenerhöhung ersetzt</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">Το τέλος συναλλαγής φαίνεται να είναι πάνω από 50% του ποσού που στέλνεις. Θέλεις να συνεχίσεις;</string>
     <string name="wallet__send_dialog4">Το τέλος συναλλαγής φαίνεται να είναι πάνω από $10. Θέλεις να συνεχίσεις;</string>
     <string name="wallet__send_error_create_tx">Δεν ήταν δυνατή η μετάδοση της συναλλαγής. Δοκίμασε ξανά.</string>
+    <string name="wallet__send_error_support">Επικοινωνία με Υποστήριξη</string>
     <string name="wallet__send_error_tx_failed">Αποτυχία συναλλαγής</string>
     <string name="wallet__send_fee_and_speed">Ταχύτητα και τέλος</string>
     <string name="wallet__send_fee_custom">Ορισμός προσαρμοσμένου τέλους</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">Ταχύτητα</string>
     <string name="wallet__send_fee_total">₿ {feeSats} για αυτή τη συναλλαγή</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} για αυτή τη συναλλαγή ({fiatSymbol}{fiatFormatted})</string>
+    <string name="wallet__send_instant_failed">Αποτυχία πληρωμής</string>
     <string name="wallet__send_invoice">Τιμολόγιο</string>
     <string name="wallet__send_invoice_expiration">Λήξη τιμολογίου</string>
     <string name="wallet__send_max">ΜΑΧ</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">Νέα ετικέτα</string>
     <string name="wallet__tags_new_enter">Εισάγαγε νέα ετικέτα</string>
     <string name="wallet__tags_previously">Προηγούμενες ετικέτες</string>
+    <string name="wallet__payment_abandoned">Η πληρωμή Lightning σταμάτησε πριν ολοκληρωθεί.</string>
+    <string name="wallet__payment_expired">Αυτή η πληρωμή Lightning έληξε. Ζητήστε νέο τιμολόγιο.</string>
+    <string name="wallet__payment_failed_description">Η άμεση πληρωμή σας απέτυχε. Παρακαλώ δοκιμάστε ξανά.</string>
+    <string name="wallet__payment_invoice_request_expired">Αυτό το αίτημα τιμολογίου Lightning έληξε. Ζητήστε νέο τιμολόγιο.</string>
+    <string name="wallet__payment_invoice_request_rejected">Ο παραλήπτης απέρριψε αυτό το αίτημα τιμολογίου Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">Ο παραλήπτης απέρριψε αυτήν την πληρωμή Lightning. Ελέγξτε το τιμολόγιο και δοκιμάστε ξανά.</string>
+    <string name="wallet__payment_retries_exhausted">Το Bitkit δοκίμασε αρκετές διαδρομές Lightning, αλλά η πληρωμή δεν μπόρεσε να ολοκληρωθεί.</string>
+    <string name="wallet__payment_route_not_found">Το Bitkit δεν μπόρεσε να βρει διαδρομή Lightning για αυτήν την πληρωμή.</string>
+    <string name="wallet__payment_timeout">Το χρονικό όριο πληρωμής έληξε. Δοκιμάστε ξανά.</string>
+    <string name="wallet__payment_unknown_required_features">Αυτό το τιμολόγιο Lightning χρησιμοποιεί λειτουργίες που το Bitkit δεν υποστηρίζει ακόμη.</string>
     <string name="wallet__toast_payment_failed_description">Η άμεση πληρωμή σου απέτυχε. Δοκίμασε ξανά.</string>
     <string name="wallet__toast_payment_failed_title">Αποτυχία πληρωμής</string>
     <string name="wallet__toast_received_transaction_replaced_description">Η εισερχόμενη συναλλαγή σου αντικαταστάθηκε από αύξηση τέλους</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">La comisión de transacción parece ser superior al 50% del importe que está enviando. ¿Desea continuar?</string>
     <string name="wallet__send_dialog4">La comisión de transacción parece ser superior a 10 dólares. ¿Desea continuar?</string>
     <string name="wallet__send_error_create_tx">No se pudo emitir la transacción. Por favor, inténtalo de nuevo.</string>
+    <string name="wallet__send_error_support">Contactar con el servicio de asistencia</string>
     <string name="wallet__send_error_tx_failed">Transacción ha fallado</string>
     <string name="wallet__send_fee_and_speed">Velocidad y tarifa</string>
     <string name="wallet__send_fee_custom">Fijar tarifa personalizada</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">Velocidad</string>
     <string name="wallet__send_fee_total">₿ {feeSats} para esta transacción</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} para esta transacción ({fiatSymbol}{fiatFormatted})</string>
+    <string name="wallet__send_instant_failed">Pago fallido</string>
     <string name="wallet__send_invoice">Factura</string>
     <string name="wallet__send_invoice_expiration">Expiración de la factura</string>
     <string name="wallet__send_max">MAX</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">Nueva etiqueta</string>
     <string name="wallet__tags_new_enter">Introduzca una nueva etiqueta</string>
     <string name="wallet__tags_previously">Etiquetas utilizadas anteriormente</string>
+    <string name="wallet__payment_abandoned">El pago Lightning se detuvo antes de completarse.</string>
+    <string name="wallet__payment_expired">Este pago Lightning ha caducado. Solicita una factura nueva.</string>
+    <string name="wallet__payment_failed_description">Tu pago instantáneo falló. Por favor, inténtalo de nuevo.</string>
+    <string name="wallet__payment_invoice_request_expired">Esta solicitud de factura Lightning ha caducado. Solicita una factura nueva.</string>
+    <string name="wallet__payment_invoice_request_rejected">El destinatario ha rechazado esta solicitud de factura Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">El destinatario ha rechazado este pago Lightning. Comprueba la factura e inténtalo de nuevo.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit ha probado varias rutas Lightning, pero el pago no se ha podido completar.</string>
+    <string name="wallet__payment_route_not_found">Bitkit no ha podido encontrar una ruta Lightning para este pago.</string>
+    <string name="wallet__payment_timeout">El pago agotó el tiempo de espera. Inténtalo de nuevo.</string>
+    <string name="wallet__payment_unknown_required_features">Esta factura Lightning usa funciones que Bitkit aún no admite.</string>
     <string name="wallet__toast_payment_failed_description">Tu pago instantáneo falló. Por favor, inténtalo de nuevo.</string>
     <string name="wallet__toast_payment_failed_title">Pago fallido</string>
     <string name="wallet__toast_received_transaction_replaced_description">Tu transacción recibida fue reemplazada por un aumento de comisión</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -785,6 +785,7 @@
     <string name="wallet__recipient_invoice">Pegar factura</string>
     <string name="wallet__recipient_manual">Introducir manualmente</string>
     <string name="wallet__recipient_scan">Escanear QR</string>
+    <string name="wallet__send_instant_failed">Pago Fallido</string>
     <string name="wallet__send_invoice">Factura</string>
     <string name="wallet__send_clipboard_empty_title">Portapapeles vacío</string>
     <string name="wallet__send_clipboard_empty_text">Por favor, copia una dirección o factura</string>
@@ -810,6 +811,7 @@
     <string name="wallet__send_address_placeholder">Introduce una factura, dirección o clave de perfil</string>
     <string name="wallet__send_available">Disponible</string>
     <string name="wallet__send_error_create_tx">No se puede emitir la transacción. Por favor, inténtalo de nuevo.</string>
+    <string name="wallet__send_error_support">Contactar con el servicio de asistencia</string>
     <string name="wallet__send_details">Detalles</string>
     <string name="wallet__send_fee_and_speed">Velocidad y tarifa</string>
     <string name="wallet__send_fee_speed">Velocidad</string>
@@ -832,6 +834,16 @@
     <string name="wallet__tags_new_enter">Introduzca una nueva etiqueta</string>
     <string name="wallet__tags_previously">Etiquetas utilizadas anteriormente</string>
     <string name="wallet__tags_filter">Filtrar la actividad mediante etiquetas</string>
+    <string name="wallet__payment_abandoned">El pago Lightning se detuvo antes de completarse.</string>
+    <string name="wallet__payment_expired">Este pago Lightning ha caducado. Solicita una factura nueva.</string>
+    <string name="wallet__payment_failed_description">Tu pago instantáneo falló. Por favor, inténtalo de nuevo.</string>
+    <string name="wallet__payment_invoice_request_expired">Esta solicitud de factura Lightning ha caducado. Solicita una factura nueva.</string>
+    <string name="wallet__payment_invoice_request_rejected">El destinatario ha rechazado esta solicitud de factura Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">El destinatario ha rechazado este pago Lightning. Comprueba la factura e inténtalo de nuevo.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit ha probado varias rutas Lightning, pero el pago no se ha podido completar.</string>
+    <string name="wallet__payment_route_not_found">Bitkit no ha podido encontrar una ruta Lightning para este pago.</string>
+    <string name="wallet__payment_timeout">El pago agotó el tiempo de espera. Inténtalo de nuevo.</string>
+    <string name="wallet__payment_unknown_required_features">Esta factura Lightning usa funciones que Bitkit aún no admite.</string>
     <string name="wallet__toast_payment_failed_description">Tu pago instantáneo ha fallado. Por favor, inténtalo de nuevo.</string>
     <string name="wallet__toast_payment_failed_title">Pago Fallido</string>
     <string name="wallet__toast_received_transaction_replaced_description">Tu transacción recibida fue reemplazada por un aumento de comisión</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -784,6 +784,7 @@
     <string name="wallet__recipient_invoice">Coller la facture</string>
     <string name="wallet__recipient_manual">Entrer manuellement</string>
     <string name="wallet__recipient_scan">Scanner QR</string>
+    <string name="wallet__send_instant_failed">Échec du paiement</string>
     <string name="wallet__send_invoice">Facture</string>
     <string name="wallet__send_address_placeholder">Saisissez une facture, une adresse ou une clé de profil</string>
     <string name="wallet__send_clipboard_empty_title">Presse-papiers vide</string>
@@ -809,6 +810,7 @@
     <string name="wallet__send_quickpay__title">Payer \n&lt;accent&gt;facture...&lt;/accent&gt;</string>
     <string name="wallet__send_error_tx_failed">Échec de la transaction</string>
     <string name="wallet__send_error_create_tx">Impossible de diffuser la transaction. Veuillez réessayer.</string>
+    <string name="wallet__send_error_support">Contacter le support</string>
     <string name="wallet__send_details">Détails</string>
     <string name="wallet__send_fee_and_speed">Vitesse et frais</string>
     <string name="wallet__send_fee_speed">Vitesse</string>
@@ -834,6 +836,16 @@
     <string name="wallet__tags_filter">Filtrer l\'activité à l\'aide de tags</string>
     <string name="wallet__tags_filter_title">Sélectionnez un Tag</string>
     <string name="wallet__toast_payment_failed_title">Échec du paiement</string>
+    <string name="wallet__payment_abandoned">Le paiement Lightning a été arrêté avant d\'être terminé.</string>
+    <string name="wallet__payment_expired">Ce paiement Lightning a expiré. Demandez une nouvelle facture.</string>
+    <string name="wallet__payment_failed_description">Votre paiement instantané a échoué. Veuillez réessayer.</string>
+    <string name="wallet__payment_invoice_request_expired">Cette demande de facture Lightning a expiré. Demandez une nouvelle facture.</string>
+    <string name="wallet__payment_invoice_request_rejected">Le destinataire a rejeté cette demande de facture Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">Le destinataire a rejeté ce paiement Lightning. Vérifiez la facture et réessayez.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit a essayé plusieurs routes Lightning, mais le paiement n\'a pas pu être terminé.</string>
+    <string name="wallet__payment_route_not_found">Bitkit n\'a pas trouvé de route Lightning pour ce paiement.</string>
+    <string name="wallet__payment_timeout">Le paiement a expiré. Veuillez réessayer.</string>
+    <string name="wallet__payment_unknown_required_features">Cette facture Lightning utilise des fonctionnalités que Bitkit ne prend pas encore en charge.</string>
     <string name="wallet__toast_payment_failed_description">Votre paiement instantané a échoué. Veuillez réessayer.</string>
     <string name="wallet__toast_received_transaction_replaced_description">Votre transaction reçue a été remplacée par une augmentation de frais</string>
     <string name="wallet__toast_received_transaction_replaced_title">Transaction reçue remplacée</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">La commissione della transazione sembra essere superiore al 50% dell\'importo che stai inviando. Vuoi continuare?</string>
     <string name="wallet__send_dialog4">La commissione della transazione sembra essere superiore a $10. Vuoi continuare?</string>
     <string name="wallet__send_error_create_tx">Impossibile trasmettere la transazione. Per favore riprova.</string>
+    <string name="wallet__send_error_support">Contatta l\'Assistenza</string>
     <string name="wallet__send_error_tx_failed">Transazione Fallita</string>
     <string name="wallet__send_fee_and_speed">Velocità e commissioni</string>
     <string name="wallet__send_fee_custom">Imposta commissione personalizzata</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">Velocità</string>
     <string name="wallet__send_fee_total">₿ {feeSats} per questa transazione</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} per questa transazione ({fiatSymbol}{fiatFormatted})</string>
+    <string name="wallet__send_instant_failed">Pagamento fallito</string>
     <string name="wallet__send_invoice">Invoice</string>
     <string name="wallet__send_invoice_expiration">Scadenza invoice</string>
     <string name="wallet__send_max">MASSIMO</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">Nuovo tag</string>
     <string name="wallet__tags_new_enter">Inserisci un nuovo tag</string>
     <string name="wallet__tags_previously">Tag usati in precedenza</string>
+    <string name="wallet__payment_abandoned">Il pagamento Lightning è stato interrotto prima del completamento.</string>
+    <string name="wallet__payment_expired">Questo pagamento Lightning è scaduto. Richiedi una nuova fattura.</string>
+    <string name="wallet__payment_failed_description">Il tuo pagamento istantaneo non è riuscito. Per favore riprova.</string>
+    <string name="wallet__payment_invoice_request_expired">Questa richiesta di fattura Lightning è scaduta. Richiedi una nuova fattura.</string>
+    <string name="wallet__payment_invoice_request_rejected">Il destinatario ha rifiutato questa richiesta di fattura Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">Il destinatario ha rifiutato questo pagamento Lightning. Controlla la fattura e riprova.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit ha provato diverse rotte Lightning, ma il pagamento non è stato completato.</string>
+    <string name="wallet__payment_route_not_found">Bitkit non ha trovato una rotta Lightning per questo pagamento.</string>
+    <string name="wallet__payment_timeout">Il pagamento è scaduto. Riprova.</string>
+    <string name="wallet__payment_unknown_required_features">Questa fattura Lightning usa funzionalità che Bitkit non supporta ancora.</string>
     <string name="wallet__toast_payment_failed_description">Il tuo pagamento istantaneo non è riuscito. Per favore riprova.</string>
     <string name="wallet__toast_payment_failed_title">Pagamento fallito</string>
     <string name="wallet__toast_received_transaction_replaced_description">La tua transazione ricevuta è stata sostituita da un aumento di commissione</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">De transactievergoeding lijkt meer dan 50% van het bedrag dat je verstuurt te zijn. Wil je doorgaan?</string>
     <string name="wallet__send_dialog4">De transactievergoeding lijkt meer dan $10 te zijn. Wil je doorgaan?</string>
     <string name="wallet__send_error_create_tx">Kan de transactie niet verzenden. Probeer het opnieuw.</string>
+    <string name="wallet__send_error_support">Contact Opnemen</string>
     <string name="wallet__send_error_tx_failed">Transactie mislukt</string>
     <string name="wallet__send_fee_and_speed">Snelheid en vergoeding</string>
     <string name="wallet__send_fee_custom">Aangepaste vergoeding instellen</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">Snelheid</string>
     <string name="wallet__send_fee_total">₿ {feeSats} voor deze transactie</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} voor deze transactie ({fiatSymbol}{fiatFormatted})</string>
+    <string name="wallet__send_instant_failed">Betaling mislukt</string>
     <string name="wallet__send_invoice">Factuur</string>
     <string name="wallet__send_invoice_expiration">Factuutvervaldatum</string>
     <string name="wallet__send_max">MAX</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">Nieuwe tag</string>
     <string name="wallet__tags_new_enter">Voer een nieuwe tag in</string>
     <string name="wallet__tags_previously">Eerder gebruikte tags</string>
+    <string name="wallet__payment_abandoned">De Lightning-betaling is gestopt voordat deze was voltooid.</string>
+    <string name="wallet__payment_expired">Deze Lightning-betaling is verlopen. Vraag een nieuwe factuur aan.</string>
+    <string name="wallet__payment_failed_description">Uw directe betaling is mislukt. Probeer het opnieuw.</string>
+    <string name="wallet__payment_invoice_request_expired">Deze Lightning-factuuraanvraag is verlopen. Vraag een nieuwe factuur aan.</string>
+    <string name="wallet__payment_invoice_request_rejected">De ontvanger heeft deze Lightning-factuuraanvraag geweigerd.</string>
+    <string name="wallet__payment_recipient_rejected">De ontvanger heeft deze Lightning-betaling geweigerd. Controleer de factuur en probeer het opnieuw.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit heeft meerdere Lightning-routes geprobeerd, maar de betaling kon niet worden voltooid.</string>
+    <string name="wallet__payment_route_not_found">Bitkit kon geen Lightning-route voor deze betaling vinden.</string>
+    <string name="wallet__payment_timeout">Time-out voor betaling. Probeer het opnieuw.</string>
+    <string name="wallet__payment_unknown_required_features">Deze Lightning-factuur gebruikt functies die Bitkit nog niet ondersteunt.</string>
     <string name="wallet__toast_payment_failed_description">Je directe betaling is mislukt. Probeer het opnieuw.</string>
     <string name="wallet__toast_payment_failed_title">Betaling mislukt</string>
     <string name="wallet__toast_received_transaction_replaced_description">Je ontvangen transactie is vervangen door een vergoedingsverhoging</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -784,6 +784,7 @@
     <string name="wallet__recipient_invoice">Wklej fakturę</string>
     <string name="wallet__recipient_manual">Wprowadź ręcznie</string>
     <string name="wallet__recipient_scan">Skanuj QR</string>
+    <string name="wallet__send_instant_failed">Płatność nie powiodła się</string>
     <string name="wallet__send_invoice">Faktura</string>
     <string name="wallet__send_address_placeholder">Wprowadzić fakturę, adres lub klucz profilu</string>
     <string name="wallet__send_clipboard_empty_title">Schowek pusty</string>
@@ -809,6 +810,7 @@
     <string name="wallet__send_quickpay__title">Płatność\n&lt;accent&gt;faktury w toku...&lt;/accent&gt;</string>
     <string name="wallet__send_error_tx_failed">Transakcja nie powiodła się</string>
     <string name="wallet__send_error_create_tx">Nie udało się wysłać transakcji. Proszę spróbować ponownie.</string>
+    <string name="wallet__send_error_support">Skontaktuj się z pomocą techniczną</string>
     <string name="wallet__send_details">Szczegóły</string>
     <string name="wallet__send_fee_and_speed">Prędkość i opłata transakcyjna</string>
     <string name="wallet__send_fee_speed">Prędkość</string>
@@ -834,6 +836,16 @@
     <string name="wallet__tags_filter">Filtruj aktywność za pomocą tagów</string>
     <string name="wallet__tags_filter_title">Wybierz tag</string>
     <string name="wallet__toast_payment_failed_title">Płatność nie powiodła się</string>
+    <string name="wallet__payment_abandoned">Płatność Lightning została zatrzymana przed zakończeniem.</string>
+    <string name="wallet__payment_expired">Ta płatność Lightning wygasła. Poproś o nową fakturę.</string>
+    <string name="wallet__payment_failed_description">Natychmiastowa płatność nie powiodła się. Proszę spróbować ponownie.</string>
+    <string name="wallet__payment_invoice_request_expired">To żądanie faktury Lightning wygasło. Poproś o nową fakturę.</string>
+    <string name="wallet__payment_invoice_request_rejected">Odbiorca odrzucił to żądanie faktury Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">Odbiorca odrzucił tę płatność Lightning. Sprawdź fakturę i spróbuj ponownie.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit wypróbował kilka tras Lightning, ale płatności nie udało się ukończyć.</string>
+    <string name="wallet__payment_route_not_found">Bitkit nie znalazł trasy Lightning dla tej płatności.</string>
+    <string name="wallet__payment_timeout">Przekroczono limit czasu płatności. Spróbuj ponownie.</string>
+    <string name="wallet__payment_unknown_required_features">Ta faktura Lightning używa funkcji, których Bitkit jeszcze nie obsługuje.</string>
     <string name="wallet__toast_payment_failed_description">Natychmiastowa płatność nie powiodła się. Proszę spróbować ponownie.</string>
     <string name="wallet__toast_received_transaction_replaced_description">Twoja otrzymana transakcja została zastąpiona przez przyspieszenie opłaty</string>
     <string name="wallet__toast_received_transaction_replaced_title">Otrzymana transakcja zastąpiona</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -929,6 +929,7 @@
     <string name="wallet__send_dialog3">A taxa de transação parece ser superior a 50% do valor que você está enviando. Deseja continuar?</string>
     <string name="wallet__send_dialog4">A taxa de transação parece ser superior a US$ 10. Deseja continuar?</string>
     <string name="wallet__send_error_create_tx">Não foi possível transmitir a transação. Por favor, tente novamente.</string>
+    <string name="wallet__send_error_support">Suporte</string>
     <string name="wallet__send_error_tx_failed">Falha na Transação</string>
     <string name="wallet__send_fee_and_speed">Taxa e velocidade</string>
     <string name="wallet__send_fee_custom">Definir Taxa Personalizada</string>
@@ -938,6 +939,7 @@
     <string name="wallet__send_fee_speed">Velocidade</string>
     <string name="wallet__send_fee_total">₿ {feeSats} para esta transação</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} para esta transação ({fiatSymbol}{fiatFormatted} )</string>
+    <string name="wallet__send_instant_failed">Pagamento Falhou</string>
     <string name="wallet__send_invoice">Invoice</string>
     <string name="wallet__send_invoice_expiration">Vencimento do invoice</string>
     <string name="wallet__send_max">MAX</string>
@@ -960,6 +962,16 @@
     <string name="wallet__tags_new">Nova Tag</string>
     <string name="wallet__tags_new_enter">Inserir uma nova tag</string>
     <string name="wallet__tags_previously">Tags usadas anteriormente</string>
+    <string name="wallet__payment_abandoned">O pagamento Lightning foi interrompido antes de ser concluído.</string>
+    <string name="wallet__payment_expired">Este pagamento Lightning expirou. Solicite uma nova fatura.</string>
+    <string name="wallet__payment_failed_description">Seu pagamento instantâneo falhou. Por favor, tente novamente.</string>
+    <string name="wallet__payment_invoice_request_expired">Esta solicitação de fatura Lightning expirou. Solicite uma nova fatura.</string>
+    <string name="wallet__payment_invoice_request_rejected">O destinatário rejeitou esta solicitação de fatura Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">O destinatário rejeitou este pagamento Lightning. Verifique a fatura e tente novamente.</string>
+    <string name="wallet__payment_retries_exhausted">O Bitkit tentou várias rotas Lightning, mas o pagamento não pôde ser concluído.</string>
+    <string name="wallet__payment_route_not_found">O Bitkit não conseguiu encontrar uma rota Lightning para este pagamento.</string>
+    <string name="wallet__payment_timeout">O pagamento expirou. Tente novamente.</string>
+    <string name="wallet__payment_unknown_required_features">Esta fatura Lightning usa recursos que o Bitkit ainda não oferece suporte.</string>
     <string name="wallet__toast_payment_failed_description">Seu pagamento instantâneo falhou. Por favor, tente novamente.</string>
     <string name="wallet__toast_payment_failed_title">Pagamento Falhou</string>
     <string name="wallet__toast_received_transaction_replaced_description">Sua transação recebida foi substituída por um aumento de taxa</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -751,6 +751,7 @@
     <string name="wallet__recipient_invoice">Colar Invoice</string>
     <string name="wallet__recipient_manual">Inserir Manualmente</string>
     <string name="wallet__recipient_scan">Escanear QR</string>
+    <string name="wallet__send_instant_failed">Pagamento Falhou</string>
     <string name="wallet__send_invoice">Invoice</string>
     <string name="wallet__send_address_placeholder">Inserir um invoice, endereço ou código de perfil</string>
     <string name="wallet__send_clipboard_empty_title">Área de transferência vazia</string>
@@ -776,6 +777,7 @@
     <string name="wallet__send_quickpay__title">Pagando \n&lt;accent&gt;invoice...&lt;/accent&gt;</string>
     <string name="wallet__send_error_tx_failed">Falha na Transação</string>
     <string name="wallet__send_error_create_tx">Não foi possível transmitir a transação. Por favor, tente novamente.</string>
+    <string name="wallet__send_error_support">Contactar Suporte</string>
     <string name="wallet__send_details">Detalhes</string>
     <string name="wallet__send_fee_and_speed">Taxa e velocidade</string>
     <string name="wallet__send_fee_speed">Velocidade</string>
@@ -800,6 +802,16 @@
     <string name="wallet__tags_filter">Filtrar atividades usando tags</string>
     <string name="wallet__tags_filter_title">Selecionar Tag</string>
     <string name="wallet__toast_payment_failed_title">Pagamento Falhou</string>
+    <string name="wallet__payment_abandoned">O pagamento Lightning foi interrompido antes de ser concluído.</string>
+    <string name="wallet__payment_expired">Este pagamento Lightning expirou. Peça uma nova fatura.</string>
+    <string name="wallet__payment_failed_description">Seu pagamento instantâneo falhou. Por favor, tente novamente.</string>
+    <string name="wallet__payment_invoice_request_expired">Este pedido de fatura Lightning expirou. Peça uma nova fatura.</string>
+    <string name="wallet__payment_invoice_request_rejected">O destinatário rejeitou este pedido de fatura Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">O destinatário rejeitou este pagamento Lightning. Verifique a fatura e tente novamente.</string>
+    <string name="wallet__payment_retries_exhausted">O Bitkit tentou várias rotas Lightning, mas o pagamento não pôde ser concluído.</string>
+    <string name="wallet__payment_route_not_found">O Bitkit não conseguiu encontrar uma rota Lightning para este pagamento.</string>
+    <string name="wallet__payment_timeout">O pagamento expirou. Tente novamente.</string>
+    <string name="wallet__payment_unknown_required_features">Esta fatura Lightning usa funcionalidades que o Bitkit ainda não suporta.</string>
     <string name="wallet__toast_payment_failed_description">Seu pagamento instantâneo falhou. Por favor, tente novamente.</string>
     <string name="wallet__selection_title">Seleção de Moedas</string>
     <string name="wallet__selection_auto">Auto</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -956,6 +956,7 @@ Bitkit должен увеличить приёмную ёмкость ваше�
     <string name="wallet__send_dialog3">Комиссия за транзакцию составляет более 50% от суммы, которую вы отправляете. Вы хотите продолжать?</string>
     <string name="wallet__send_dialog4">Комиссия за транзакцию составляет более 10$. Вы хотите продолжать?</string>
     <string name="wallet__send_error_create_tx">Не удалось отправить транзакцию. Пожалуйста, попробуйте снова.</string>
+    <string name="wallet__send_error_support">Связаться с Поддержкой</string>
     <string name="wallet__send_error_tx_failed">Транзакция не удалась</string>
     <string name="wallet__send_fee_and_speed">Скорость и комиссия</string>
     <string name="wallet__send_fee_custom">Установить Пользовательскую Комиссию</string>
@@ -965,6 +966,7 @@ Bitkit должен увеличить приёмную ёмкость ваше�
     <string name="wallet__send_fee_speed">Скорость</string>
     <string name="wallet__send_fee_total">₿ {feeSats} за эту транзакцию</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} за эту транзакцию ({fiatSymbol}{fiatFormatted})</string>
+    <string name="wallet__send_instant_failed">Платеж не выполнен</string>
     <string name="wallet__send_invoice">Инвойс</string>
     <string name="wallet__send_invoice_expiration">Срок действия инвойса</string>
     <string name="wallet__send_max">МАКС</string>
@@ -988,6 +990,16 @@ Bitkit должен увеличить приёмную ёмкость ваше�
     <string name="wallet__tags_new">Новый тег</string>
     <string name="wallet__tags_new_enter">Введите тег</string>
     <string name="wallet__tags_previously">Ранее использовавшиеся теги</string>
+    <string name="wallet__payment_abandoned">Платеж Lightning был остановлен до завершения.</string>
+    <string name="wallet__payment_expired">Срок действия этого платежа Lightning истек. Запросите новый счет.</string>
+    <string name="wallet__payment_failed_description">Ваш мгновенный платеж не удался. Пожалуйста, попробуйте снова.</string>
+    <string name="wallet__payment_invoice_request_expired">Срок действия этого запроса счета Lightning истек. Запросите новый счет.</string>
+    <string name="wallet__payment_invoice_request_rejected">Получатель отклонил этот запрос счета Lightning.</string>
+    <string name="wallet__payment_recipient_rejected">Получатель отклонил этот платеж Lightning. Проверьте счет и попробуйте снова.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit попробовал несколько маршрутов Lightning, но платеж не удалось завершить.</string>
+    <string name="wallet__payment_route_not_found">Bitkit не смог найти маршрут Lightning для этого платежа.</string>
+    <string name="wallet__payment_timeout">Время ожидания платежа истекло. Попробуйте еще раз.</string>
+    <string name="wallet__payment_unknown_required_features">Этот счет Lightning использует функции, которые Bitkit пока не поддерживает.</string>
     <string name="wallet__toast_payment_failed_description">Ваш мгновенный платеж не удался. Пожалуйста, попробуйте снова.</string>
     <string name="wallet__toast_payment_failed_title">Платеж не выполнен</string>
     <string name="wallet__toast_received_transaction_replaced_description">Ваша полученная транзакция была заменена повышением комиссии</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1161,8 +1161,18 @@
     <string name="wallet__minimum">MINIMUM</string>
     <string name="wallet__note">Note</string>
     <string name="wallet__payment_received">Received Bitcoin</string>
+    <string name="wallet__payment_abandoned">The Lightning payment was stopped before it completed.</string>
+    <string name="wallet__payment_expired">This Lightning payment expired. Please request a new invoice.</string>
+    <string name="wallet__payment_failed_description">Your instant payment failed. Please try again.</string>
+    <string name="wallet__payment_invoice_request_expired">This Lightning invoice request expired. Please request a new invoice.</string>
+    <string name="wallet__payment_invoice_request_rejected">The recipient rejected this Lightning invoice request.</string>
+    <string name="wallet__payment_recipient_rejected">The recipient rejected this Lightning payment. Please check the invoice and try again.</string>
     <string name="wallet__payment_request">Payment Request</string>
     <string name="wallet__payment_request_mismatch">The payment details did not match the request. Payment cancelled.</string>
+    <string name="wallet__payment_retries_exhausted">Bitkit tried several Lightning routes, but the payment could not be completed.</string>
+    <string name="wallet__payment_route_not_found">Bitkit couldn\'t find a Lightning route for this payment.</string>
+    <string name="wallet__payment_timeout">Payment timed out. Please try again.</string>
+    <string name="wallet__payment_unknown_required_features">This Lightning invoice uses features Bitkit does not support yet.</string>
     <string name="wallet__peer_disconnected">Peer disconnected.</string>
     <string name="wallet__receive">Receive</string>
     <string name="wallet__receive__cjit">Receive Lightning funds</string>
@@ -1220,6 +1230,7 @@
     <string name="wallet__send_dialog3">The transaction fee appears to be over 50% of the amount you are sending. Do you want to continue?</string>
     <string name="wallet__send_dialog4">The transaction fee appears to be over $10. Do you want to continue?</string>
     <string name="wallet__send_error_create_tx">Unable to broadcast the transaction. Please try again.</string>
+    <string name="wallet__send_error_support">Contact Support</string>
     <string name="wallet__send_error_tx_failed">Transaction Failed</string>
     <string name="wallet__send_fee_and_speed">Speed and fee</string>
     <string name="wallet__send_fee_custom">Set Custom Fee</string>
@@ -1230,6 +1241,7 @@
     <string name="wallet__send_fee_total">₿ {feeSats} for this transaction</string>
     <string name="wallet__send_fee_total_fiat">₿ {feeSats} for this transaction ({fiatSymbol}{fiatFormatted})</string>
     <string name="wallet__send_from">From</string>
+    <string name="wallet__send_instant_failed">Payment Failed</string>
     <string name="wallet__send_invoice">Invoice</string>
     <string name="wallet__send_invoice_expiration">Invoice expiration</string>
     <string name="wallet__send_max">MAX</string>
@@ -1255,10 +1267,6 @@
     <string name="wallet__tags_new_enter">Enter a new tag</string>
     <string name="wallet__tags_previously">Previously used tags</string>
     <string name="wallet__toast_payment_failed_description">Your instant payment failed. Please try again.</string>
-    <string name="wallet__toast_payment_failed_recipient_rejected">The recipient rejected this payment. Try a different amount.</string>
-    <string name="wallet__toast_payment_failed_retries_exhausted">Could not find a route with sufficient liquidity. Try a smaller amount or wait and try again.</string>
-    <string name="wallet__toast_payment_failed_route_not_found">Could not find a payment path to the recipient.</string>
-    <string name="wallet__toast_payment_failed_timeout">Payment timed out. Please try again.</string>
     <string name="wallet__toast_payment_failed_title">Payment Failed</string>
     <string name="wallet__toast_payment_sent_description">Your instant payment was sent successfully.</string>
     <string name="wallet__toast_payment_sent_title">Payment Sent</string>

--- a/app/src/test/java/to/bitkit/ext/PaymentFailureReasonExtTest.kt
+++ b/app/src/test/java/to/bitkit/ext/PaymentFailureReasonExtTest.kt
@@ -1,0 +1,90 @@
+package to.bitkit.ext
+
+import android.content.Context
+import org.junit.Test
+import org.lightningdevkit.ldknode.NodeException
+import org.lightningdevkit.ldknode.PaymentFailureReason
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import to.bitkit.R
+import to.bitkit.models.SendFailureDetails
+import to.bitkit.utils.LdkError
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class PaymentFailureReasonExtTest {
+    private val context = mock<Context>()
+
+    @Test
+    fun `routing failures use generic payment copy in send context`() {
+        val generic = "Generic route message"
+        whenever(context.getString(R.string.wallet__payment_route_not_found)).thenReturn(generic)
+
+        assertEquals(generic, PaymentFailureReason.ROUTE_NOT_FOUND.toUserMessage(context))
+        assertEquals(generic, PaymentFailureReason.ROUTE_NOT_FOUND.toSendFailureDetails(context).message)
+    }
+
+    @Test
+    fun `unmapped reasons fall back to generic payment failure copy`() {
+        val message = "Generic payment failed"
+        whenever(context.getString(R.string.wallet__payment_failed_description)).thenReturn(message)
+
+        assertEquals(message, PaymentFailureReason.UNEXPECTED_ERROR.toUserMessage(context))
+        assertEquals(message, (null as PaymentFailureReason?).toUserMessage(context))
+    }
+
+    @Test
+    fun `send failure messages fall back for blank and internal exception messages`() {
+        val message = "Generic payment failed"
+        whenever(context.getString(R.string.wallet__payment_failed_description)).thenReturn(message)
+
+        assertEquals(message, Exception("  ").toSendFailureMessage(context))
+        assertEquals(
+            message,
+            LdkError(NodeException.DuplicatePayment("Duplicate payment.")).toSendFailureMessage(context),
+        )
+    }
+
+    @Test
+    fun `payment failure reason compact failure types use lower camel case`() {
+        assertEquals("routeNotFound", PaymentFailureReason.ROUTE_NOT_FOUND.toCompactFailureType())
+    }
+
+    @Test
+    fun `compact failure types use android ldk error classes`() {
+        assertEquals(
+            "DuplicatePayment",
+            LdkError(NodeException.DuplicatePayment("Duplicate payment.")).toCompactFailureType(),
+        )
+        assertEquals(
+            "InvalidCustomTlvs",
+            LdkError(NodeException.InvalidCustomTlvs("Invalid custom TLVs")).toCompactFailureType(),
+        )
+    }
+
+    @Test
+    fun `compact failure types fall back to the exception class name`() {
+        assertEquals("IllegalStateException", IllegalStateException().toCompactFailureType())
+    }
+
+    @Test
+    fun `compact failure types ignore sentence punctuation`() {
+        assertNotEquals("Unknown", Exception("Payment sending failed.").toCompactFailureType())
+    }
+
+    @Test
+    fun `routing cache reset is gated to one routing failure retry attempt`() {
+        val routingFailure = SendFailureDetails(
+            message = "Route not found",
+            failureType = "routeNotFound",
+            resetRoutingCachesOnRetry = true,
+        )
+        val genericFailure = routingFailure.copy(resetRoutingCachesOnRetry = false)
+
+        assertTrue(routingFailure.shouldResetRoutingCaches(routingCacheResetAttempted = false))
+        assertFalse(routingFailure.shouldResetRoutingCaches(routingCacheResetAttempted = true))
+        assertFalse(genericFailure.shouldResetRoutingCaches(routingCacheResetAttempted = false))
+    }
+}

--- a/app/src/test/java/to/bitkit/viewmodels/AppViewModelSendFlowTest.kt
+++ b/app/src/test/java/to/bitkit/viewmodels/AppViewModelSendFlowTest.kt
@@ -34,6 +34,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.lightningdevkit.ldknode.Event
+import org.lightningdevkit.ldknode.PaymentFailureReason
 import org.lightningdevkit.ldknode.TransactionDetails
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -67,6 +68,7 @@ import to.bitkit.models.NewTransactionSheetType
 import to.bitkit.models.PubkyProfile
 import to.bitkit.models.SamRockPaymentMethod
 import to.bitkit.models.SamRockSetupRequest
+import to.bitkit.models.SendFailureDetails
 import to.bitkit.models.TransactionSpeed
 import to.bitkit.models.TransportType
 import to.bitkit.repositories.ActivityRepo
@@ -1716,19 +1718,26 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
             Event.PaymentFailed(
                 paymentId = "payment_id",
                 paymentHash = paymentHash,
-                reason = null,
+                reason = PaymentFailureReason.RETRIES_EXHAUSTED,
             ),
         )
         advanceUntilIdle()
 
-        verify(pendingPaymentRepo).resolve(PendingPaymentResolution.Failure(paymentHash))
+        verify(pendingPaymentRepo).resolve(
+            PendingPaymentResolution.Failure(
+                paymentHash = paymentHash,
+                reason = PaymentFailureReason.RETRIES_EXHAUSTED,
+            )
+        )
         assertNull(pendingContactPaymentContext(paymentHash))
     }
 
     @Test
-    fun `active lightning send failure hides send sheet`() = test {
+    fun `active lightning send failure navigates to failure screen`() = test {
         val bolt11 = "lnbcrt1activefailure"
         val paymentHash = "010203"
+        val errorMessage = "Bitkit could not find a route"
+        whenever(context.getString(R.string.wallet__payment_route_not_found)).thenReturn(errorMessage)
         whenever(pendingPaymentRepo.isPending(paymentHash)).thenReturn(false)
         setSendState(
             SendUiState(
@@ -1741,16 +1750,28 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
         sut.showSheet(Sheet.Send())
         advanceUntilIdle()
 
-        emitNodeEvent(
-            Event.PaymentFailed(
-                paymentId = "payment_id",
-                paymentHash = paymentHash,
-                reason = null,
-            ),
-        )
-        advanceUntilIdle()
+        sut.sendEffect.test {
+            emitNodeEvent(
+                Event.PaymentFailed(
+                    paymentId = "payment_id",
+                    paymentHash = paymentHash,
+                    reason = PaymentFailureReason.ROUTE_NOT_FOUND,
+                ),
+            )
+            advanceUntilIdle()
 
-        assertNull(sut.currentSheet.value)
+            assertEquals(
+                SendEffect.NavigateToError(
+                    SendFailureDetails(
+                        message = errorMessage,
+                        failureType = "routeNotFound",
+                        resetRoutingCachesOnRetry = true,
+                        paymentRequest = bolt11,
+                    )
+                ),
+                awaitItem(),
+            )
+        }
     }
 
     @Test
@@ -2138,6 +2159,8 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
         advanceUntilIdle()
 
         assertEquals(QuickPayData.Bolt11(sats = 500u, bolt11 = bolt11), sut.quickPayData.value)
+        assertEquals(SendMethod.ONCHAIN, sut.sendUiState.value.payMethod)
+        assertNull(sut.sendUiState.value.decodedInvoice)
         assertEquals(Sheet.Send(SendRoute.QuickPay), sut.currentSheet.value)
     }
 
@@ -2151,6 +2174,8 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
         advanceUntilIdle()
 
         assertEquals(QuickPayData.Bolt11(sats = 500u, bolt11 = bolt11), sut.quickPayData.value)
+        assertEquals(SendMethod.ONCHAIN, sut.sendUiState.value.payMethod)
+        assertNull(sut.sendUiState.value.decodedInvoice)
         assertEquals(Sheet.Send(SendRoute.QuickPay), sut.currentSheet.value)
     }
 

--- a/app/src/test/java/to/bitkit/viewmodels/TransferViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/viewmodels/TransferViewModelTest.kt
@@ -1607,7 +1607,7 @@ class TransferViewModelTest : BaseUnitTest() {
     @Test
     fun `startSavingsSwap fails when the paid invoice reports a lightning routing failure`() = test {
         stubSavingsSwapHappyPath()
-        whenever(context.getString(R.string.wallet__toast_payment_failed_route_not_found))
+        whenever(context.getString(R.string.wallet__payment_route_not_found))
             .thenReturn(ROUTE_NOT_FOUND_MSG)
         sut.loadSavingsSwapQuote(REQUESTED_SAT)
         advanceUntilIdle()

--- a/changelog.d/next/1140.feat.md
+++ b/changelog.d/next/1140.feat.md
@@ -1,0 +1,1 @@
+Improved Lightning send failure recovery with clearer messages and a retry action that refreshes payment routing.


### PR DESCRIPTION
### Description

Ports the iOS Lightning send-failure retry/support behavior to Android.

- Shows the send failure screen for failed Lightning sends instead of relying only on toasts.
- Maps LDK payment failure reasons to localized, user-facing strings and avoids exposing internal error values like `Optional(...)`, `NodeError`, or `DuplicatePayment`.
- Uses the reusable generic route failure copy for `routeNotFound` and `retriesExhausted`.
- Preserves LDK failure reasons for payments that first enter `SendPendingScreen` and fail later.
- Shows the correct failure title for Lightning vs on-chain send errors.
- Shows Contact Support above Try Again on the Lightning send failure screen.
- Prefills the support report with failure type, payment method, routing cache reset status, and the available Lightning payment request.
- Resets routing caches only for routing-related failures, and only once per current send flow/payment attempt.
- Retries non-routing failures normally without resetting graph/scorer caches.
- Retry clears local/VSS network graph data and scorer/pathfinding score data before restarting ldk-node when a routing reset is needed.
- Retry waits for local routing data to be usable again without requiring a newer remote RGS snapshot timestamp or waiting only on delayed graph-cache persistence.
- Guards retry state in `WalletViewModel` so overlapping retry flows cannot surface stale timeout errors.
- Resets send navigation back to the retry route instead of stacking retry screens on top of the failure screen.

Closes https://github.com/synonymdev/bitkit-android/issues/829

### Preview

Normal payment:

https://github.com/user-attachments/assets/7980c47a-eb25-4557-85be-cabb5dd33c54

QuickPay:

https://github.com/user-attachments/assets/2ccb4ee8-6af1-4fef-b147-891f7d36c26d

### QA Notes

Tested on mainnet emulator:
- Confirmed `ROUTE_NOT_FOUND` surfaces user-facing payment failure copy.
- Confirmed pending `RETRIES_EXHAUSTED` failures surface the localized retries-exhausted copy instead of generic failure copy.
- Confirmed Try Again deletes local graph, VSS graph, scorer, and external scores cache for the first routing-related retry.
- Confirmed Try Again does not repeat routing cache reset after a reset has already been attempted in the current send flow.
- Confirmed retry restarts from an empty graph and accepts the same RGS snapshot timestamp.
- Confirmed retry waits through RGS/scorer refresh and returns to the send confirmation path without timing out when graph cache persistence lags behind the in-memory graph.
- Confirmed no stale retry timeout after repeated retry attempts.

Automated checks:
- `compileDevDebugKotlin`
- `PaymentFailureReasonExtTest.kt`
- `AppViewModelSendFlowTest.kt`
- `detekt`
