### PR TITLE
fix: establish private Paykit links promptly

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
@@ -231,13 +231,16 @@ class PrivatePaykitRepo @Inject constructor(
 
     fun startInitialLinkBurst(publicKeys: Collection<String>, reason: String) {
         val publicKeys = normalizedPublicKeyBatch(publicKeys).normalizedKeys
-        if (publicKeys.isEmpty()) return
 
         synchronized(initialLinkBurstLock) {
-            initialLinkBurstPublicKeys += publicKeys
             initialLinkBurstGeneration += 1
-            val generation = initialLinkBurstGeneration
             initialLinkBurstJob?.cancel()
+            initialLinkBurstJob = null
+            initialLinkBurstPublicKeys.clear()
+            initialLinkBurstPublicKeys += publicKeys
+            if (publicKeys.isEmpty()) return
+
+            val generation = initialLinkBurstGeneration
             _initialLinkBurstStarted.tryEmit(Unit)
 
             initialLinkBurstJob = retryScope.launch {

--- a/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
@@ -1397,10 +1397,13 @@ class PrivatePaykitRepo @Inject constructor(
 
         return runSuspendCatching {
             val discoveredPaths = pubkyService.discoverRelevantReceiverPaths(publicKey)
-            val mergedPaths = supportedReceiverPaths(savedPaths + discoveredPaths)
-            if (mergedPaths == savedPaths) return@runSuspendCatching savedPaths
+            val currentRecord = paykitSdkService.contactRecord(publicKey)
+                ?: return@runSuspendCatching savedPaths
+            val currentSavedPaths = supportedReceiverPaths(currentRecord.receiverPaths)
+            val mergedPaths = supportedReceiverPaths(currentSavedPaths + discoveredPaths)
+            if (mergedPaths == currentSavedPaths) return@runSuspendCatching currentSavedPaths
 
-            val updatedRecord = pubkyService.saveContact(publicKey, record?.label, mergedPaths)
+            val updatedRecord = pubkyService.saveContact(publicKey, currentRecord.label, mergedPaths)
             _initialLinkBurstStarted.tryEmit(Unit)
             Logger.info("Discovered new Paykit receiver paths for '${redacted(publicKey)}'", context = TAG)
             supportedReceiverPaths(updatedRecord.receiverPaths)

--- a/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
@@ -90,8 +90,6 @@ class PrivatePaykitRepo @Inject constructor(
         )
         private val initialLinkBurstRetryDelays = List(14) { 2.seconds }
         private val privatePaymentResolutionRetryDelays = privateMessageDrainRetryDelays.take(3)
-        private val _initialLinkBurstStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-        val initialLinkBurstStarted: SharedFlow<Unit> = _initialLinkBurstStarted.asSharedFlow()
 
         fun isDuplicatePaymentError(error: Throwable): Boolean =
             PrivatePaykitErrorClassifier.isDuplicatePaymentError(error)
@@ -106,6 +104,8 @@ class PrivatePaykitRepo @Inject constructor(
     private val pendingMessageDrainRetryKeys = mutableSetOf<PrivateMessageDrainRetryKey>()
     private var pendingMessageDrainRetryJob: Job? = null
     private var pendingMessageDrainRetryGeneration = 0
+    private val _initialLinkBurstStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val initialLinkBurstStarted: SharedFlow<Unit> = _initialLinkBurstStarted.asSharedFlow()
     private val initialLinkBurstLock = Any()
     private val initialLinkBurstPublicKeys = mutableSetOf<String>()
     private var initialLinkBurstJob: Job? = null

--- a/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/PrivatePaykitRepo.kt
@@ -13,8 +13,11 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -85,7 +88,10 @@ class PrivatePaykitRepo @Inject constructor(
             45.seconds,
             90.seconds,
         )
+        private val initialLinkBurstRetryDelays = List(14) { 2.seconds }
         private val privatePaymentResolutionRetryDelays = privateMessageDrainRetryDelays.take(3)
+        private val _initialLinkBurstStarted = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        val initialLinkBurstStarted: SharedFlow<Unit> = _initialLinkBurstStarted.asSharedFlow()
 
         fun isDuplicatePaymentError(error: Throwable): Boolean =
             PrivatePaykitErrorClassifier.isDuplicatePaymentError(error)
@@ -100,6 +106,10 @@ class PrivatePaykitRepo @Inject constructor(
     private val pendingMessageDrainRetryKeys = mutableSetOf<PrivateMessageDrainRetryKey>()
     private var pendingMessageDrainRetryJob: Job? = null
     private var pendingMessageDrainRetryGeneration = 0
+    private val initialLinkBurstLock = Any()
+    private val initialLinkBurstPublicKeys = mutableSetOf<String>()
+    private var initialLinkBurstJob: Job? = null
+    private var initialLinkBurstGeneration = 0
 
     private data class PrivatePublicationPreparation(
         val updates: List<PrivatePaymentListReservationUpdateInput>,
@@ -219,6 +229,35 @@ class PrivatePaykitRepo @Inject constructor(
         }
     }
 
+    fun startInitialLinkBurst(publicKeys: Collection<String>, reason: String) {
+        val publicKeys = normalizedPublicKeyBatch(publicKeys).normalizedKeys
+        if (publicKeys.isEmpty()) return
+
+        synchronized(initialLinkBurstLock) {
+            initialLinkBurstPublicKeys += publicKeys
+            initialLinkBurstGeneration += 1
+            val generation = initialLinkBurstGeneration
+            initialLinkBurstJob?.cancel()
+            _initialLinkBurstStarted.tryEmit(Unit)
+
+            initialLinkBurstJob = retryScope.launch {
+                (listOf(kotlin.time.Duration.ZERO) + initialLinkBurstRetryDelays).forEach { retryDelay ->
+                    delay(retryDelay)
+                    val keys = synchronized(initialLinkBurstLock) {
+                        if (generation != initialLinkBurstGeneration) return@launch
+                        initialLinkBurstPublicKeys.toList()
+                    }
+                    refreshSavedContactEndpointsDuringInitialLinkBurst(keys, reason)
+                }
+                synchronized(initialLinkBurstLock) {
+                    if (generation != initialLinkBurstGeneration) return@launch
+                    initialLinkBurstJob = null
+                    initialLinkBurstPublicKeys.clear()
+                }
+            }
+        }
+    }
+
     suspend fun retryPendingEndpointRemoval(
         savedPublicKeys: Collection<String>,
     ): Result<Unit> = withContext(serializedDispatcher) {
@@ -303,6 +342,7 @@ class PrivatePaykitRepo @Inject constructor(
     suspend fun closeAndClear(): Result<Unit> = withContext(serializedDispatcher) {
         runSuspendCatching {
             publicationMutex.withLock {
+                clearInitialLinkBurst()
                 clearPendingMessageDrainRetries()
                 knownSavedContactKeys.clear()
                 state = PrivatePaykitState()
@@ -1349,11 +1389,52 @@ class PrivatePaykitRepo @Inject constructor(
     }
 
     private suspend fun receiverPathsForSavedContact(publicKey: String): List<String> {
-        val paths = paykitSdkService.contactRecord(publicKey)
-            ?.receiverPaths
-            ?.filter { it in PaykitReceiverPaths.supported }
-            .orEmpty()
-        return paths.ifEmpty { listOf(PaykitReceiverPaths.WALLET) }
+        val record = paykitSdkService.contactRecord(publicKey)
+        val savedPaths = supportedReceiverPaths(record?.receiverPaths.orEmpty())
+
+        return runSuspendCatching {
+            val discoveredPaths = pubkyService.discoverRelevantReceiverPaths(publicKey)
+            val mergedPaths = supportedReceiverPaths(savedPaths + discoveredPaths)
+            if (mergedPaths == savedPaths) return@runSuspendCatching savedPaths
+
+            val updatedRecord = pubkyService.saveContact(publicKey, record?.label, mergedPaths)
+            _initialLinkBurstStarted.tryEmit(Unit)
+            Logger.info("Discovered new Paykit receiver paths for '${redacted(publicKey)}'", context = TAG)
+            supportedReceiverPaths(updatedRecord.receiverPaths)
+        }.getOrElse {
+            if (it is CancellationException) throw it
+            Logger.warn(
+                "Failed to refresh Paykit receiver paths for '${redacted(publicKey)}'; using saved paths",
+                it,
+                context = TAG,
+            )
+            savedPaths
+        }
+    }
+
+    private fun supportedReceiverPaths(receiverPaths: Collection<String>): List<String> =
+        PaykitReceiverPaths.supported.filter { it in receiverPaths }
+            .ifEmpty { listOf(PaykitReceiverPaths.WALLET) }
+
+    private suspend fun refreshSavedContactEndpointsDuringInitialLinkBurst(
+        publicKeys: Collection<String>,
+        reason: String,
+    ) = withContext(serializedDispatcher) {
+        if (!canPublishPrivateEndpoints()) {
+            prepareRelevantPrivateLinksIfAvailable(publicKeys, "$reason initial link burst")
+            return@withContext
+        }
+        publishLocalEndpoints(publicKeys.toList(), reason = "$reason initial link burst")
+            .onFailure { Logger.warn("Failed initial private Paykit sync for '$reason'", it, context = TAG) }
+    }
+
+    private fun clearInitialLinkBurst() {
+        synchronized(initialLinkBurstLock) {
+            initialLinkBurstJob?.cancel()
+            initialLinkBurstJob = null
+            initialLinkBurstPublicKeys.clear()
+            initialLinkBurstGeneration += 1
+        }
     }
 
     private fun receiverPathsForPrivateEndpointCleanup(

--- a/app/src/main/java/to/bitkit/usecases/RefreshContactPaykitReceiversUseCase.kt
+++ b/app/src/main/java/to/bitkit/usecases/RefreshContactPaykitReceiversUseCase.kt
@@ -24,6 +24,7 @@ class RefreshContactPaykitReceiversUseCase @Inject constructor(
             pubkyRepo.refreshContactReceiverPaths(publicKey).getOrThrow()
             val savedPublicKeys = (pubkyRepo.contacts.value.map { it.publicKey } + publicKey).distinct()
             privatePaykitRepo.refreshSavedContactEndpoints(publicKey, savedPublicKeys).getOrThrow()
+            privatePaykitRepo.startInitialLinkBurst(savedPublicKeys, "contact receiver refresh")
         }.onFailure {
             Logger.warn(
                 "Failed to refresh Paykit receivers for '${PubkyPublicKeyFormat.redacted(publicKey)}'",

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -304,6 +304,7 @@ class AppViewModel @Inject constructor(
     private var isPresentingPaymentRequest = false
     private var isSubmittingPaymentRequest = false
     private var paykitPaymentRequestPollingJob: Job? = null
+    private var initialPaykitPaymentRequestPollingJob: Job? = null
     private val paymentRequestPresentationRetryAttempts = mutableMapOf<PaykitPaymentRequestId, Int>()
     private val paymentRequestPresentationRetryJobs = mutableMapOf<PaykitPaymentRequestId, Job>()
     private val timedSheetManager = timedSheetManagerProvider(viewModelScope).apply {
@@ -433,6 +434,7 @@ class AppViewModel @Inject constructor(
         observePublicPaykitInvoiceExpiry()
         observePrivatePaykitContacts()
         observePaykitPaymentRequestConnectivity()
+        observeInitialPaykitLinkBursts()
         observeIncomingPaykitPaymentRequests()
         observeSendEvents()
         viewModelScope.launch {
@@ -596,6 +598,7 @@ class AppViewModel @Inject constructor(
                         .onFailure {
                             Logger.warn("Failed to prune private Paykit contact state", it, context = TAG)
                         }
+                    privatePaykitRepo.startInitialLinkBurst(state.contactKeys, "contact sync")
                     refreshIncomingPaykitPaymentRequests()
                     lastPrivatePaykitContactKeys = state.contactKeys
                 }
@@ -617,6 +620,7 @@ class AppViewModel @Inject constructor(
                 Logger.warn("Failed to reconcile private Paykit receive indexes for '$reason'", it, context = TAG)
             }
         privatePaykitRepo.refreshKnownSavedContactEndpoints(reason, forceRefreshLightning = forceRefreshLightning)
+        privatePaykitRepo.startInitialLinkBurst(contactKeys, reason)
         refreshIncomingPaykitPaymentRequests()
     }
 
@@ -625,7 +629,13 @@ class AppViewModel @Inject constructor(
             isOnline
                 .drop(1)
                 .filter { it == ConnectivityState.CONNECTED }
-                .collect { refreshIncomingPaykitPaymentRequests() }
+                .collect { refreshPrivatePaykitEndpointsIfEnabled("network restored") }
+        }
+    }
+
+    private fun observeInitialPaykitLinkBursts() {
+        viewModelScope.launch {
+            PrivatePaykitRepo.initialLinkBurstStarted.collect { startInitialPaykitPaymentRequestPolling() }
         }
     }
 
@@ -648,6 +658,7 @@ class AppViewModel @Inject constructor(
             var refreshIntervalIndex = 0
             while (true) {
                 delay(PAYKIT_PAYMENT_REQUEST_REFRESH_INTERVALS[refreshIntervalIndex])
+                privatePaykitRepo.refreshKnownSavedContactEndpoints("payment request polling")
                 refreshIntervalIndex = if (refreshIncomingPaykitPaymentRequests()) {
                     0
                 } else {
@@ -655,14 +666,29 @@ class AppViewModel @Inject constructor(
                 }
             }
         }
+        startInitialPaykitPaymentRequestPolling()
     }
 
     fun stopPaykitPaymentRequestPolling() {
         paykitPaymentRequestPollingJob?.cancel()
         paykitPaymentRequestPollingJob = null
+        initialPaykitPaymentRequestPollingJob?.cancel()
+        initialPaykitPaymentRequestPollingJob = null
         paymentRequestPresentationRetryJobs.values.forEach { it.cancel() }
         paymentRequestPresentationRetryJobs.clear()
         paymentRequestPresentationRetryAttempts.clear()
+    }
+
+    private fun startInitialPaykitPaymentRequestPolling() {
+        if (paykitPaymentRequestPollingJob?.isActive != true) return
+        initialPaykitPaymentRequestPollingJob?.cancel()
+        initialPaykitPaymentRequestPollingJob = viewModelScope.launch {
+            refreshIncomingPaykitPaymentRequests()
+            INITIAL_PAYKIT_SYNC_RETRY_DELAYS.forEach {
+                delay(it)
+                refreshIncomingPaykitPaymentRequests()
+            }
+        }
     }
 
     private fun observeIncomingPaykitPaymentRequests() {
@@ -3862,6 +3888,7 @@ class AppViewModel @Inject constructor(
         private const val ADDRESS_VALIDATION_DEBOUNCE_MS = 1000L
         private const val PAYKIT_CHANNEL_USABILITY_REFRESH_DELAY_MS = 5_000L
         private val PAYKIT_PAYMENT_REQUEST_REFRESH_INTERVALS = listOf(30.seconds, 60.seconds, 120.seconds)
+        private val INITIAL_PAYKIT_SYNC_RETRY_DELAYS = List(14) { 2.seconds }
         private val PAYKIT_PAYMENT_REQUEST_PRESENTATION_RETRY_DELAYS = listOf(
             30.seconds,
             60.seconds,

--- a/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
+++ b/app/src/main/java/to/bitkit/viewmodels/AppViewModel.kt
@@ -635,7 +635,7 @@ class AppViewModel @Inject constructor(
 
     private fun observeInitialPaykitLinkBursts() {
         viewModelScope.launch {
-            PrivatePaykitRepo.initialLinkBurstStarted.collect { startInitialPaykitPaymentRequestPolling() }
+            privatePaykitRepo.initialLinkBurstStarted.collect { startInitialPaykitPaymentRequestPolling() }
         }
     }
 
@@ -734,8 +734,12 @@ class AppViewModel @Inject constructor(
         val result = privatePaykitRepo.beginPaymentRequest(request).getOrNull()
         if (isPaymentRequestPresentationBlocked()) return true
         val isPending = paykitPaymentRequestRepo.isPending(request)
-        if (result !is PublicPaykitPaymentResult.Opened || !isPending) {
-            if (isPending) deferPaymentRequestPresentation(request)
+        if (!isPending) {
+            presentedPaymentRequestIds += request.id
+            return false
+        }
+        if (result !is PublicPaykitPaymentResult.Opened) {
+            deferPaymentRequestPresentation(request)
             return false
         }
 

--- a/app/src/test/java/to/bitkit/models/PubkyAuthRequestTest.kt
+++ b/app/src/test/java/to/bitkit/models/PubkyAuthRequestTest.kt
@@ -51,6 +51,35 @@ class PubkyAuthRequestTest {
     }
 
     @Test
+    fun `parse deduplicates service name across public and private capabilities`() {
+        val capabilities = "/pub/locks.app/:rw,/priv/locks.app/:rw"
+
+        val request = PubkyAuthRequest.parse(
+            rawUrl = authUrl(capabilities),
+            relay = "https://httprelay.pubky.app/inbox/",
+            capabilities = capabilities,
+        ).getOrThrow()
+
+        assertEquals(listOf("/pub/locks.app/", "/priv/locks.app/"), request.permissions.map { it.path })
+        assertEquals(listOf("locks.app"), request.serviceNames)
+    }
+
+    @Test
+    fun `parse deduplicates service names across multiple paths in first-seen order`() {
+        val capabilities =
+            "/pub/locks.app/posts/:r,/pub/example.app/:r,/priv/locks.app/settings/:w,/priv/example.app/cache/:r"
+
+        val request = PubkyAuthRequest.parse(
+            rawUrl = authUrl(capabilities),
+            relay = "https://httprelay.pubky.app/inbox/",
+            capabilities = capabilities,
+        ).getOrThrow()
+
+        assertEquals(4, request.permissions.size)
+        assertEquals(listOf("locks.app", "example.app"), request.serviceNames)
+    }
+
+    @Test
     fun `parse rejects watch-only capability without Bitkit claim`() {
         val capabilities = PubkyAuthClaim.WATCH_ONLY_ACCOUNT_CAPABILITIES
         val result = PubkyAuthRequest.parse(

--- a/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
@@ -122,6 +122,8 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
         whenever(lightningRepo.lightningState).thenReturn(lightningState)
         whenever(clock.now()).thenReturn(Instant.fromEpochSeconds(NOW_SECONDS))
         whenever(pubkyService.currentPublicKey()).thenReturn(OWN_KEY)
+        whenever { pubkyService.discoverRelevantReceiverPaths(any()) }
+            .thenReturn(listOf(WALLET_RECEIVER_PATH))
         whenever(paykitSdkService.hasPrivatePaymentAccess()).thenReturn(true)
         whenever(walletRepo.walletExists()).thenReturn(true)
         whenever { walletRepo.refreshReusableReceiveAddressIfReserved() }.thenReturn(Result.success(Unit))
@@ -297,6 +299,43 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
         verifyBlocking(paykitSdkService) { ensureLinkWithPeer(CONTACT_KEY, SERVER_RECEIVER_PATH) }
         verifyBlocking(paykitSdkService, never()) { syncPrivatePaymentListsWithReservations(any(), any()) }
         verify(addressReservationRepo, never()).currentOrRotatedAddress(any(), any())
+    }
+
+    @Test
+    fun `initial link burst discovers a server receiver published after the contact was saved`() = test {
+        settingsData.value = SettingsData(sharesPrivatePaykitEndpoints = false)
+        whenever { paykitSdkService.contactRecord(CONTACT_KEY) }
+            .thenReturn(contactRecord(CONTACT_KEY, listOf(WALLET_RECEIVER_PATH)))
+        whenever { pubkyService.discoverRelevantReceiverPaths(CONTACT_KEY) }
+            .thenReturn(listOf(WALLET_RECEIVER_PATH))
+            .thenReturn(listOf(WALLET_RECEIVER_PATH))
+            .thenReturn(listOf(WALLET_RECEIVER_PATH, SERVER_RECEIVER_PATH))
+        whenever {
+            pubkyService.saveContact(
+                CONTACT_KEY,
+                null,
+                listOf(WALLET_RECEIVER_PATH, SERVER_RECEIVER_PATH),
+            )
+        }.thenReturn(contactRecord(CONTACT_KEY, listOf(WALLET_RECEIVER_PATH, SERVER_RECEIVER_PATH)))
+
+        assertTrue(sut.prepareSavedContacts(listOf(CONTACT_KEY)).isSuccess)
+        clearInvocations(paykitSdkService, pubkyService)
+
+        sut.startInitialLinkBurst(listOf(CONTACT_KEY), "test")
+        runCurrent()
+        advanceTimeBy(2_000)
+        runCurrent()
+
+        verifyBlocking(pubkyService) {
+            saveContact(
+                CONTACT_KEY,
+                null,
+                listOf(WALLET_RECEIVER_PATH, SERVER_RECEIVER_PATH),
+            )
+        }
+        verifyBlocking(paykitSdkService) { ensureLinkWithPeer(CONTACT_KEY, SERVER_RECEIVER_PATH) }
+        verifyBlocking(publicPaykitRepo, never()) { beginPayment(any()) }
+        sut.closeAndClear()
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
@@ -339,6 +339,28 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
+    fun `initial link burst does not recreate a contact deleted during discovery`() = test {
+        settingsData.value = SettingsData(sharesPrivatePaykitEndpoints = false)
+        whenever(paykitSdkService.contactRecord(CONTACT_KEY))
+            .thenReturn(contactRecord(CONTACT_KEY, listOf(WALLET_RECEIVER_PATH)), null)
+        whenever { pubkyService.discoverRelevantReceiverPaths(CONTACT_KEY) }
+            .thenReturn(listOf(WALLET_RECEIVER_PATH, SERVER_RECEIVER_PATH))
+
+        sut.startInitialLinkBurst(listOf(CONTACT_KEY), "test")
+        runCurrent()
+
+        verify(paykitSdkService, times(2)).contactRecord(CONTACT_KEY)
+        verifyBlocking(pubkyService, never()) {
+            saveContact(
+                CONTACT_KEY,
+                null,
+                listOf(WALLET_RECEIVER_PATH, SERVER_RECEIVER_PATH),
+            )
+        }
+        sut.closeAndClear()
+    }
+
+    @Test
     fun `restarting initial link burst replaces saved contact keys`() = test {
         settingsData.value = SettingsData(sharesPrivatePaykitEndpoints = false)
 

--- a/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/PrivatePaykitRepoTest.kt
@@ -339,6 +339,41 @@ class PrivatePaykitRepoTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
+    fun `restarting initial link burst replaces saved contact keys`() = test {
+        settingsData.value = SettingsData(sharesPrivatePaykitEndpoints = false)
+
+        sut.startInitialLinkBurst(listOf(CONTACT_KEY), "test")
+        runCurrent()
+        clearInvocations(pubkyService)
+
+        sut.startInitialLinkBurst(listOf(OTHER_CONTACT_KEY), "test")
+        runCurrent()
+        clearInvocations(pubkyService)
+        advanceTimeBy(2_000)
+        runCurrent()
+
+        verifyBlocking(pubkyService) { discoverRelevantReceiverPaths(OTHER_CONTACT_KEY) }
+        verifyBlocking(pubkyService, never()) { discoverRelevantReceiverPaths(CONTACT_KEY) }
+        sut.closeAndClear()
+    }
+
+    @Test
+    fun `restarting initial link burst with no contacts cancels retries`() = test {
+        settingsData.value = SettingsData(sharesPrivatePaykitEndpoints = false)
+
+        sut.startInitialLinkBurst(listOf(CONTACT_KEY), "test")
+        runCurrent()
+        clearInvocations(pubkyService)
+
+        sut.startInitialLinkBurst(emptyList(), "test")
+        advanceTimeBy(30_000)
+        runCurrent()
+
+        verifyBlocking(pubkyService, never()) { discoverRelevantReceiverPaths(any()) }
+        sut.closeAndClear()
+    }
+
+    @Test
     fun `prepareSavedContacts clears receiver paths that are no longer eligible`() = test {
         settingsData.value = SettingsData(
             sharesPrivatePaykitEndpoints = true,

--- a/app/src/test/java/to/bitkit/usecases/RefreshContactPaykitReceiversUseCaseTest.kt
+++ b/app/src/test/java/to/bitkit/usecases/RefreshContactPaykitReceiversUseCaseTest.kt
@@ -56,6 +56,7 @@ class RefreshContactPaykitReceiversUseCaseTest : BaseUnitTest() {
         inOrder(pubkyRepo, privatePaykitRepo).apply {
             verify(pubkyRepo).refreshContactReceiverPaths(contactKeys.last())
             verify(privatePaykitRepo).refreshSavedContactEndpoints(contactKeys.last(), contactKeys)
+            verify(privatePaykitRepo).startInitialLinkBurst(contactKeys, "contact receiver refresh")
         }
     }
 
@@ -68,5 +69,6 @@ class RefreshContactPaykitReceiversUseCaseTest : BaseUnitTest() {
 
         assertEquals(error, result.exceptionOrNull())
         verify(privatePaykitRepo, never()).refreshSavedContactEndpoints(contactKeys.last(), contactKeys)
+        verify(privatePaykitRepo, never()).startInitialLinkBurst(contactKeys, "contact receiver refresh")
     }
 }

--- a/app/src/test/java/to/bitkit/viewmodels/AppViewModelSendFlowTest.kt
+++ b/app/src/test/java/to/bitkit/viewmodels/AppViewModelSendFlowTest.kt
@@ -365,13 +365,18 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
     }
 
     @Test
-    fun `payment requests refresh periodically only while polling is active`() = test {
+    fun `payment requests refresh immediately and periodically only while polling is active`() = test {
         isPaykitEnabled.value = true
         pubkyPublicKey.value = testPublicKey
         whenever(paykitPaymentRequestRepo.refresh()).thenReturn(Result.success(Unit))
         runCurrent()
 
         sut.startPaykitPaymentRequestPolling()
+        runCurrent()
+
+        verify(paykitPaymentRequestRepo).refresh()
+        clearInvocations(paykitPaymentRequestRepo)
+
         advanceTimeBy(30.seconds.inWholeMilliseconds)
         runCurrent()
 

--- a/app/src/test/java/to/bitkit/viewmodels/AppViewModelSendFlowTest.kt
+++ b/app/src/test/java/to/bitkit/viewmodels/AppViewModelSendFlowTest.kt
@@ -37,6 +37,7 @@ import org.lightningdevkit.ldknode.Event
 import org.lightningdevkit.ldknode.TransactionDetails
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.check
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doSuspendableAnswer
@@ -196,6 +197,7 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
 
     @After
     fun tearDown() {
+        sut.stopPaykitPaymentRequestPolling()
         App.currentActivity = null
     }
 
@@ -238,6 +240,7 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
         whenever(pubkyRepo.contactsLoadVersion).thenReturn(pubkyContactsLoadVersion)
         whenever(paykitPaymentRequestRepo.pendingRequests).thenReturn(pendingPaykitPaymentRequests)
         whenever(paykitPaymentRequestRepo.isPending(any())).thenReturn(true)
+        whenever(privatePaykitRepo.initialLinkBurstStarted).thenReturn(MutableSharedFlow())
         whenever { privatePaykitRepo.prepareSavedContacts(any<Collection<String>>(), any()) }
             .thenReturn(Result.success(Unit))
         whenever { privatePaykitRepo.pruneUnsavedContactState(any<Collection<String>>()) }
@@ -370,28 +373,32 @@ class AppViewModelSendFlowTest : BaseUnitTest() {
         pubkyPublicKey.value = testPublicKey
         whenever(paykitPaymentRequestRepo.refresh()).thenReturn(Result.success(Unit))
         runCurrent()
+        clearInvocations(paykitPaymentRequestRepo)
 
         sut.startPaykitPaymentRequestPolling()
-        runCurrent()
+        try {
+            runCurrent()
 
-        verify(paykitPaymentRequestRepo).refresh()
-        clearInvocations(paykitPaymentRequestRepo)
+            verify(paykitPaymentRequestRepo).refresh()
+            clearInvocations(paykitPaymentRequestRepo)
 
-        advanceTimeBy(30.seconds.inWholeMilliseconds)
-        runCurrent()
+            advanceTimeBy(30.seconds.inWholeMilliseconds)
+            runCurrent()
 
-        verify(paykitPaymentRequestRepo).refresh()
-        clearInvocations(paykitPaymentRequestRepo)
+            verify(paykitPaymentRequestRepo, atLeast(2)).refresh()
+            clearInvocations(paykitPaymentRequestRepo)
 
-        advanceTimeBy(59.seconds.inWholeMilliseconds)
-        runCurrent()
-        verify(paykitPaymentRequestRepo, never()).refresh()
+            advanceTimeBy(59.seconds.inWholeMilliseconds)
+            runCurrent()
+            verify(paykitPaymentRequestRepo, never()).refresh()
 
-        advanceTimeBy(1.seconds.inWholeMilliseconds)
-        runCurrent()
-        verify(paykitPaymentRequestRepo).refresh()
+            advanceTimeBy(1.seconds.inWholeMilliseconds)
+            runCurrent()
+            verify(paykitPaymentRequestRepo).refresh()
+        } finally {
+            sut.stopPaykitPaymentRequestPolling()
+        }
 
-        sut.stopPaykitPaymentRequestPolling()
         clearInvocations(paykitPaymentRequestRepo)
         advanceTimeBy(120.seconds.inWholeMilliseconds)
         runCurrent()

--- a/changelog.d/next/1141.fixed.md
+++ b/changelog.d/next/1141.fixed.md
@@ -1,0 +1,1 @@
+Fixed delayed private payment requests after adding a Paykit contact or returning to the app.


### PR DESCRIPTION
### Description

- Refresh each saved or scanned contact’s current Paykit receiver paths from Pubky during private sync and persist newly published paths such as `bitkit/server`.
- Start a bounded 28-second, two-second-cadence private link/message sync burst after contact updates, path discovery, app foregrounding, and network restoration, then return to the existing low-frequency polling cadence.
- Refresh incoming Payment Requests during the same bounded window so a newly linked request opens automatically without waiting for the normal 30-second poll.
- Preserve private-only resolution semantics; no public payment fallback was added.

### Preview

No UI changes.

### QA Notes

Regression coverage verifies that a contact saved with only `bitkit/wallet` later discovers `bitkit/server`, persists it, calls `ensureLinkWithPeer`, and never starts public payment resolution. Existing send-flow coverage now also verifies that Payment Request polling refreshes immediately when activated.

CI is the authoritative Android build/test run because the native GitHub Packages dependencies require repository package credentials.