### PR TITLE
feat: increase background stop debounce time

### DIFF
--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -586,10 +586,16 @@ class LightningRepo @Inject constructor(
      * runs on the caller thread, so an interleaved cancel could otherwise miss the job being installed
      * and stop the node after the app is back in the foreground.
      *
-     * [BACKGROUND_STOP_DELAY] plus the stop itself must stay under the cached-app freezer debounce
-     * (~10s once the process drops to `oom_adj` 900, which happens the moment the user opens another
-     * app). Past that the process is frozen mid-delay and the stop only fires on unfreeze, racing
-     * [cancelPendingStop] to tear the node down just as the user returns.
+     * [BACKGROUND_STOP_DELAY] must stay under the cached-app freezer debounce (~10s once the process
+     * drops to `oom_adj` 900) so [stop] is at least entered before the process can be frozen. Past
+     * that the process freezes mid-delay and the stop only fires on unfreeze, racing
+     * [cancelPendingStop] to tear the node down just as the user returns — and [stop] runs
+     * `NonCancellable`, so losing that race is unrecoverable.
+     *
+     * Whether the stop *completes* in that window is out of scope here: on a wallet with real
+     * payment history ldk_node reliably hits its own 30s event-handling deadline, so no delay value
+     * makes the teardown fit. That also makes an avoided teardown valuable, since a user returning
+     * mid-stop waits it out before the ~8s node rebuild can start.
      */
     fun stopDebounced() = synchronized(pendingStopLock) {
         val job = scope.launch {

--- a/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/LightningRepo.kt
@@ -585,6 +585,11 @@ class LightningRepo @Inject constructor(
      * Scheduling and cancelling are atomic: [cancelPendingStop] runs on the repo dispatcher while this
      * runs on the caller thread, so an interleaved cancel could otherwise miss the job being installed
      * and stop the node after the app is back in the foreground.
+     *
+     * [BACKGROUND_STOP_DELAY] plus the stop itself must stay under the cached-app freezer debounce
+     * (~10s once the process drops to `oom_adj` 900, which happens the moment the user opens another
+     * app). Past that the process is frozen mid-delay and the stop only fires on unfreeze, racing
+     * [cancelPendingStop] to tear the node down just as the user returns.
      */
     fun stopDebounced() = synchronized(pendingStopLock) {
         val job = scope.launch {
@@ -1896,7 +1901,7 @@ class LightningRepo @Inject constructor(
         private const val VSS_KEY_EXTERNAL_SCORES_CACHE = "external_pathfinding_scores_cache"
         private const val MS_SYNC_LOOP_DEBOUNCE = 500L
         private const val SYNC_RETRY_DELAY_MS = 15_000L
-        private val BACKGROUND_STOP_DELAY = 3.seconds
+        private val BACKGROUND_STOP_DELAY = 5.seconds
         private val CHANNELS_USABLE_TIMEOUT = 15.seconds
         private val NO_USABLE_CHANNELS_FEEDBACK_DELAY = 2_500.milliseconds
         val SEND_LN_TIMEOUT = 10.seconds

--- a/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/LightningRepoTest.kt
@@ -88,7 +88,7 @@ import kotlin.time.Duration.Companion.seconds
 class LightningRepoTest : BaseUnitTest() {
     companion object {
         private const val NO_USABLE_CHANNELS_FEEDBACK_DELAY_MS = 2_500L
-        private const val BACKGROUND_STOP_DELAY_MS = 3_000L
+        private const val BACKGROUND_STOP_DELAY_MS = 5_000L
     }
 
     private lateinit var sut: LightningRepo

--- a/changelog.d/next/1146.changed.md
+++ b/changelog.d/next/1146.changed.md
@@ -1,0 +1,1 @@
+Bitkit now keeps the Lightning node running a little longer when you briefly leave the app, so quick trips to another app no longer reload the wallet on return.


### PR DESCRIPTION
This PR raises the background stop debounce from 3 to 5 seconds, so a brief trip out of the app no longer tears down and rebuilds the Lightning node.

### Description

When the app is backgrounded without the foreground service keeping it alive, the node stop is deferred so a quick background/foreground cycle does not tear it down. Three seconds is short enough that ordinary interruptions — checking a notification, copying an address, fetching a 2FA code — fall outside the window and pay for a full teardown and rebuild.

The ceiling on that window is Android's cached-app freezer, not any API limit. Once the process drops to `oom_adj` 900 it is frozen after roughly ten seconds, and a frozen process cannot run the pending stop at all: it would fire on unfreeze instead, racing the cancel that runs when the app returns to the foreground. Because the stop runs `NonCancellable`, losing that race tears the node down exactly as the user comes back. Five seconds sits comfortably inside that window while covering meaningfully more of the short interruptions the debounce exists for.

Device testing also showed the cost of a teardown is far higher than assumed. On a wallet with real payment history the node stop takes a flat 30 seconds and ends by hitting ldk_node's own event-handling deadline, after which the rebuild takes another eight. A user who returns mid-stop waits that out before the wallet is usable again, which is what makes avoiding an unnecessary teardown worth the longer window.

That 30-second timeout is pre-existing and independent of this change — the debounce only decides when the stop begins, not how long it takes — but it is worth a separate look, since every background cycle on a real wallet now burns 30 seconds of the LDK queue and exits through an error path.

The KDoc on `stopDebounced` records the freezer ceiling so the value is not later raised past it.

### Preview

No UI changes.

### QA Notes

#### Manual Tests

- [x] **1.** Home → background the app → return within 5s: wallet stays loaded, no reload or restore screen, balances render immediately.
- [x] **2.** Home → background the app → wait past 5s → return: node restarts cleanly, balances and activity list render.
- [x] **3.** `regression:` Notifications granted and keep-active-in-background enabled → background the app: foreground service keeps the node alive, no stop occurs at all.
- [x] **4.** `regression:` Background the app → return mid-restart: no crash, wallet settles into a usable state.

#### Automated Checks

- Unit tests modified: `LightningRepoTest.kt` tracks the new 5s value; its boundary assertions still pin that the stop does not fire just before the window and does fire at it.
- Device verification on an Android 17 emulator against a wallet loaded with 137 Lightning payments (120 generated via the Blocktank regtest LSP): the debounce fired at 5.002s / 4.999s / 5.001s / 4.997s across four runs.
- Freezer ceiling measured on the same device: `freezer_cutoff_adj=900`, `freeze_debounce_timeout` unset so the AOSP 10s default applies; the process was observed frozen 8.79–9.34s after dropping to cached.
- CI: standard compile, unit test, and detekt checks run by the PR bot.

<details>
<summary>Journey used for testing</summary>

```xml
<journey name="Background stop debounce restart path">
   <description>
      Verifies the Lightning node restart path around BACKGROUND_STOP_DELAY (5s).
      Leg 1 returns to the app inside the debounce window, where the node must never be torn down.
      Leg 2 stays away past the window, so the node stops and must restart cleanly on return.
   </description>
   <actions>
     <action>
       Verify that the wallet Home screen is shown with a balance displayed
     </action>
     <action>
       Tap the Home system navigation button to send the app to the background
     </action>
     <action>
       Relaunch the Bitkit app within 5 seconds
     </action>
     <action>
       Verify that the wallet Home screen is shown with a balance displayed, and that no loading spinner or restore screen is present
     </action>
     <action>
       Tap the Home system navigation button to send the app to the background
     </action>
     <action>
       Wait 20 seconds, then relaunch the Bitkit app
     </action>
     <action>
       Verify that the wallet Home screen is shown with a balance displayed, and that no loading spinner or restore screen is present
     </action>
   </actions>
</journey>
```

All seven actions passed. Leg 1 confirmed the node is never stopped inside the window; leg 2 confirmed a clean stop and restart past it.

</details>

<details>
<summary>Logs: debounce fires at 5s, inside the window (leg 1)</summary>

```
13:14:40.109 INFO  [BoltzService.kt:168]   Stopped Boltz updates stream
13:14:40.979 INFO  [LightningRepo.kt:474]  LDK node start skipped, lifecycle state: Running
13:14:40.997 DEBUG [LightningService.kt]   LDK event listener started
```

Returned 2.0s after backgrounding. No `Stopping node…` entry — the node was never torn down. The event listener cancel and restart 15ms apart is the normal foreground re-subscribe.

</details>

<details>
<summary>Logs: debounce timing across four runs on a 137-payment wallet</summary>

```
run 1   ON_STOP 13:43:48.801 → Stopping node… 13:43:53.803   = 5.002s
run 2   ON_STOP 13:46:18.865 → Stopping node… 13:46:23.864   = 4.999s
run 3   ON_STOP 13:48:49.114 → Stopping node… 13:48:54.115   = 5.001s
run 4   ON_STOP 13:53:22.509 → Stopping node… 13:53:27.506   = 4.997s
```

</details>

<details>
<summary>Logs: pre-existing 30s stop timeout surfaced during testing</summary>

```
13:48:54.115 DEBUG [LightningService.kt:467]              Stopping node…
13:48:54.116 INFO  [ldk_node:1022]                        Shutting down LDK Node with node ID 024fce4685…
13:48:54.117 DEBUG [ldk_node:685]                         Stopping processing events.
13:48:54.117 TRACE [lightning_background_processor:1299]  Terminating background processor.
13:49:24.123 ERROR [ldk_node::runtime:183]                Stopping event handling timed out: deadline has elapsed
13:49:24.124 INFO  [ldk_node:1074]                        Shutdown complete.
13:49:24.129 INFO  [LightningService.kt:476]              Node stopped
```

30.014s / 30.022s / 30.030s / 30.047s across the four runs — a flat deadline rather than load-dependent variance. Against a near-empty wallet the same stop took ~0.5s, which is why this only appears with real payment history. Independent of this change; flagged for separate follow-up.

</details>
