### PR TITLE
fix: consume vss-client 0.5.23

### DIFF
--- a/changelog.d/next/1164.security.md
+++ b/changelog.d/next/1164.security.md
@@ -1,0 +1,1 @@
+Wallet backups now use VSS 0.5.23, which rejects unauthenticated encryption.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,7 @@ test-junit-ext = { module = "androidx.test.ext:junit", version = "1.3.0" }
 test-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "6.2.2" }
 test-robolectric = { module = "org.robolectric:robolectric", version = "4.16.1" }
 test-turbine = { group = "app.cash.turbine", name = "turbine", version = "1.2.1" }
-vss-client = { module = "com.synonym:vss-client-android", version = "0.5.21" }
+vss-client = { module = "com.synonym:vss-client-android", version = "0.5.23" }
 webkit = { module = "androidx.webkit:webkit", version = "1.16.0" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version = "2.11.0" }
 zxing = { module = "com.google.zxing:core", version = "3.5.4" }


### PR DESCRIPTION
This PR bumps the VSS Android client from 0.5.21 to 0.5.23.

### Description

0.5.23 includes [synonymdev/vss-rust-client-ffi#20](https://github.com/synonymdev/vss-rust-client-ffi/pull/20). Unauthenticated client setup now returns AuthError instead of encrypting with a public all-zero key.

Related: [synonymdev/audit#55](https://github.com/synonymdev/audit/issues/55) (BITKIT-SEC-003).

Companion iOS PR: https://github.com/synonymdev/bitkit-ios/pull/673

### Preview

N/A

### QA Notes
#### Manual Tests
- [ ] **1.** `regression:` Fresh wallet → backup/Lightning start with current Env LNURL-auth URL: setup still succeeds.

#### Automated Checks
- Local `compileDevDebugKotlin`, `VssBackupClientTest`, and detekt passed against 0.5.23.