### PR TITLE
feat: back up hardware wallet names

### DIFF
--- a/app/src/main/java/to/bitkit/data/HwWalletStore.kt
+++ b/app/src/main/java/to/bitkit/data/HwWalletStore.kt
@@ -34,20 +34,18 @@ class HwWalletStore @Inject constructor(
     }
 
     /**
-     * @param consumedPendingName the wallet whose pending name one of [devices] has just adopted, dropped
-     * in the same write. Splitting the two would let the entry carrying the name fail to save while the
-     * pending copy is deleted anyway, leaving the name nowhere.
+     * @param pendingName a pending-name change to apply in the same write, or null to leave them alone.
+     * Splitting the two would publish a device list without its matching name change, which restarts a
+     * watcher for a wallet already being removed and can leave a name in both places or in neither.
      */
     suspend fun saveKnownDevices(
         devices: List<KnownDevice>,
-        consumedPendingName: String? = null,
+        pendingName: PendingNameUpdate? = null,
     ) = withContext(ioDispatcher) {
         store.updateData { data ->
             data.copy(
                 knownDevices = devices,
-                pendingNames = consumedPendingName
-                    ?.let { data.pendingNames - it }
-                    ?: data.pendingNames,
+                pendingNames = pendingName?.applyTo(data.pendingNames) ?: data.pendingNames,
             )
         }
         Unit
@@ -89,6 +87,18 @@ class HwWalletStore @Inject constructor(
     suspend fun reset() = withContext(ioDispatcher) {
         store.updateData { HwWalletData() }
         Unit
+    }
+}
+
+/** A pending-name change applied together with a device list write; a null [name] drops the entry. */
+data class PendingNameUpdate(
+    val walletId: String,
+    val name: String?,
+) {
+    fun applyTo(pendingNames: Map<String, String>): Map<String, String> = when {
+        walletId.isBlank() -> pendingNames
+        name.isNullOrBlank() -> pendingNames - walletId
+        else -> pendingNames + (walletId to name)
     }
 }
 

--- a/app/src/main/java/to/bitkit/data/HwWalletStore.kt
+++ b/app/src/main/java/to/bitkit/data/HwWalletStore.kt
@@ -38,6 +38,39 @@ class HwWalletStore @Inject constructor(
         Unit
     }
 
+    suspend fun loadPendingNames(): Map<String, String> = withContext(ioDispatcher) {
+        store.data.first().pendingNames
+    }
+
+    /** Stores the name of a wallet with no device entry, or drops it when [name] is null. */
+    suspend fun setPendingName(walletId: String, name: String?) = withContext(ioDispatcher) {
+        if (walletId.isBlank()) return@withContext
+        store.updateData { data ->
+            val pendingNames = when {
+                name.isNullOrBlank() -> data.pendingNames - walletId
+                else -> data.pendingNames + (walletId to name)
+            }
+            data.copy(pendingNames = pendingNames)
+        }
+        Unit
+    }
+
+    suspend fun backupSnapshot(): Map<String, String> = withContext(ioDispatcher) {
+        store.data.first().hwWalletNames()
+    }
+
+    /**
+     * Merges backed up names into the pending ones, so they are adopted the next time each wallet is
+     * paired. Names already held locally win: they were set on this device after the backup was written.
+     *
+     * Never clears: an envelope without names predates this field, and must not drop what is stored.
+     */
+    suspend fun restoreNames(names: Map<String, String>) = withContext(ioDispatcher) {
+        if (names.isEmpty()) return@withContext
+        store.updateData { it.copy(pendingNames = names + it.pendingNames) }
+        Unit
+    }
+
     suspend fun reset() = withContext(ioDispatcher) {
         store.updateData { HwWalletData() }
         Unit
@@ -47,4 +80,24 @@ class HwWalletStore @Inject constructor(
 @Serializable
 data class HwWalletData(
     val knownDevices: List<KnownDevice> = emptyList(),
+    /**
+     * Names of wallets with no [KnownDevice] entry, keyed by wallet id: restored from a backup before
+     * the device was paired again, or kept when the wallet was removed. Pairing consumes an entry into
+     * the device's own `customLabel`.
+     */
+    val pendingNames: Map<String, String> = emptyMap(),
 )
+
+/**
+ * Every hardware wallet name this wallet knows, keyed by wallet id: the name of each paired wallet,
+ * overlaid on the pending ones. A paired name wins because it is what the user currently sees.
+ *
+ * Entries without a wallet id are skipped. Only a device stored before any account key was captured
+ * has none, and such an entry is filtered out of the wallet list, so it can never have been named.
+ */
+internal fun HwWalletData.hwWalletNames(): Map<String, String> =
+    pendingNames + knownDevices.mapNotNull { device ->
+        val walletId = device.walletId.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        val name = device.customLabel?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        walletId to name
+    }

--- a/app/src/main/java/to/bitkit/data/HwWalletStore.kt
+++ b/app/src/main/java/to/bitkit/data/HwWalletStore.kt
@@ -33,8 +33,23 @@ class HwWalletStore @Inject constructor(
         store.data.first().knownDevices
     }
 
-    suspend fun saveKnownDevices(devices: List<KnownDevice>) = withContext(ioDispatcher) {
-        store.updateData { it.copy(knownDevices = devices) }
+    /**
+     * @param consumedPendingName the wallet whose pending name one of [devices] has just adopted, dropped
+     * in the same write. Splitting the two would let the entry carrying the name fail to save while the
+     * pending copy is deleted anyway, leaving the name nowhere.
+     */
+    suspend fun saveKnownDevices(
+        devices: List<KnownDevice>,
+        consumedPendingName: String? = null,
+    ) = withContext(ioDispatcher) {
+        store.updateData { data ->
+            data.copy(
+                knownDevices = devices,
+                pendingNames = consumedPendingName
+                    ?.let { data.pendingNames - it }
+                    ?: data.pendingNames,
+            )
+        }
         Unit
     }
 

--- a/app/src/main/java/to/bitkit/models/BackupPayloads.kt
+++ b/app/src/main/java/to/bitkit/models/BackupPayloads.kt
@@ -34,6 +34,8 @@ data class MetadataBackupV1(
     val cache: AppCacheData,
     val pubkySession: PubkySessionBackupV1? = null,
     val pubkyContactProfileOverrides: Map<String, PubkyProfileData>? = null,
+    /** User-set hardware wallet names, keyed by wallet id. Null in envelopes written before this field. */
+    val hwWalletNames: Map<String, String>? = null,
 )
 
 @Serializable

--- a/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/ActivityRepo.kt
@@ -902,6 +902,27 @@ class ActivityRepo @Inject constructor(
         }
 
     /**
+     * The slice of the metadata backup's tag data that belongs to [walletId], built the same way the
+     * envelope builds it so a caller can preserve a wallet's tags across a deletion.
+     *
+     * Both sources are needed: Core drops the stored [PreActivityMetadata] of a wallet along with its
+     * activities, and those rows are not covered by [getHardwareTagsAsPreActivityMetadata], which only
+     * renders tags that already reached an activity.
+     */
+    suspend fun getTagMetadataForWallet(walletId: String): Result<List<PreActivityMetadata>> =
+        withContext(bgDispatcher) {
+            runSuspendCatching {
+                val stored = coreService.activity.getAllPreActivityMetadata()
+                    .filter { it.walletId == walletId }
+                val rendered = getHardwareTagsAsPreActivityMetadata().getOrThrow()
+                    .filter { it.walletId == walletId }
+                (stored + rendered).distinctBy { it.walletId to it.paymentId }
+            }.onFailure {
+                Logger.error("Failed to read tag metadata of '$walletId'", it, context = TAG)
+            }
+        }
+
+    /**
      * Fill in wallet ids missing from a backup envelope's `activities` slice, letting Core migrate its own
      * model JSON before the app decodes it.
      */

--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -31,11 +31,13 @@ import to.bitkit.R
 import to.bitkit.async.appScope
 import to.bitkit.data.AppDb
 import to.bitkit.data.CacheStore
+import to.bitkit.data.HwWalletStore
 import to.bitkit.data.SettingsStore
 import to.bitkit.data.WatchOnlyAccountStore
 import to.bitkit.data.WidgetsStore
 import to.bitkit.data.backup.VssBackupClient
 import to.bitkit.data.backup.VssBackupClientLdk
+import to.bitkit.data.hwWalletNames
 import to.bitkit.data.resetPin
 import to.bitkit.di.IoDispatcher
 import to.bitkit.di.json
@@ -91,6 +93,7 @@ class BackupRepo @Inject constructor(
     private val widgetsStore: WidgetsStore,
     private val watchOnlyAccountStore: WatchOnlyAccountStore,
     private val watchOnlyAccountRepo: WatchOnlyAccountRepo,
+    private val hwWalletStore: HwWalletStore,
     private val blocktankRepo: BlocktankRepo,
     private val activityRepo: ActivityRepo,
     private val pubkyRepo: PubkyRepo,
@@ -297,6 +300,20 @@ class BackupRepo @Inject constructor(
                 }
         }
         dataListenerJobs.add(preActivityMetadataJob)
+
+        // METADATA - Observe hardware wallet names only: the store is also rewritten by every connect,
+        // and reconnect traffic must not re-upload the whole metadata envelope.
+        val hwWalletNamesJob = scope.launch {
+            hwWalletStore.data
+                .map { it.hwWalletNames() }
+                .distinctUntilChanged()
+                .drop(1)
+                .collect {
+                    if (shouldSkipBackup()) return@collect
+                    markBackupRequired(BackupCategory.METADATA)
+                }
+        }
+        dataListenerJobs.add(hwWalletNamesJob)
 
         dataListenerJobs.add(observeBackupChanges(pubkyRepo.backupStateVersion, BackupCategory.METADATA))
         dataListenerJobs.add(observeBackupChanges(privatePaykitRepo.get().backupStateVersion, BackupCategory.WALLET))
@@ -548,6 +565,9 @@ class BackupRepo @Inject constructor(
         val hardwareTagMetadata = activityRepo.getHardwareTagsAsPreActivityMetadata().getOrThrow()
         val tagMetadata = (preActivityMetadata + hardwareTagMetadata)
             .distinctBy { it.walletId to it.paymentId }
+        // Like the tags above, this envelope is the only copy of the names, so a read failure must
+        // propagate and fail the backup rather than upload an empty set over the stored ones.
+        val hwWalletNames = hwWalletStore.backupSnapshot().takeIf { it.isNotEmpty() }
         val cacheData = cacheStore.data.first()
         val pubkySession = pubkyRepo.snapshotSessionBackupState().getOrDefault(null)
         val pubkyContactProfileOverrides = pubkyRepo.snapshotContactProfileOverrides().getOrDefault(null)
@@ -558,6 +578,7 @@ class BackupRepo @Inject constructor(
             cache = cacheData,
             pubkySession = pubkySession,
             pubkyContactProfileOverrides = pubkyContactProfileOverrides,
+            hwWalletNames = hwWalletNames,
         )
 
         json.encodeToString(payload).toByteArray()
@@ -661,7 +682,11 @@ class BackupRepo @Inject constructor(
             .onFailure {
                 Logger.warn("Failed to restore pubky contact profile overrides", it, context = TAG)
             }
+        // App-owned, so it takes no part in the Core field migration above and never sets needsRewrite.
+        // Restored names wait as pending ones until each wallet is paired again.
+        hwWalletStore.restoreNames(parsed.hwWalletNames.orEmpty())
         Logger.debug("Restored ${parsed.tagMetadata.size} pre-activity metadata", TAG)
+        Logger.debug("Restored ${parsed.hwWalletNames.orEmpty().size} hardware wallet names", TAG)
 
         return RestoredCoreBackup(createdAt = parsed.createdAt, needsRewrite = migration.changed && persisted)
     }

--- a/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/BackupRepo.kt
@@ -683,8 +683,10 @@ class BackupRepo @Inject constructor(
                 Logger.warn("Failed to restore pubky contact profile overrides", it, context = TAG)
             }
         // App-owned, so it takes no part in the Core field migration above and never sets needsRewrite.
-        // Restored names wait as pending ones until each wallet is paired again.
-        hwWalletStore.restoreNames(parsed.hwWalletNames.orEmpty())
+        // Restored names wait as pending ones until each wallet is paired again. Failing to store them
+        // must not discard the rest of this envelope, which has already been applied by here.
+        runSuspendCatching { hwWalletStore.restoreNames(parsed.hwWalletNames.orEmpty()) }
+            .onFailure { Logger.warn("Failed to restore hardware wallet names", it, context = TAG) }
         Logger.debug("Restored ${parsed.tagMetadata.size} pre-activity metadata", TAG)
         Logger.debug("Restored ${parsed.hwWalletNames.orEmpty().size} hardware wallet names", TAG)
 

--- a/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
@@ -688,15 +688,21 @@ class HwWalletRepo @Inject constructor(
         knownDevices: List<KnownDevice>,
         watcherSettings: WatcherSettings,
     ) {
-        val persistedWalletIds = activityRepo.getWalletIds().getOrDefault(emptySet())
-            .filterNot { it == WalletScope.default }
-            .toSet()
         watcherMutex.withLock {
+            // Read under the lock: a removal deletes a wallet's activities while holding it, and this
+            // set decides what to delete. Reading it first would let a removal complete in between and
+            // then be undone here, taking the tag metadata it deliberately kept with it.
+            val persistedWalletIds = activityRepo.getWalletIds().getOrDefault(emptySet())
+                .filterNot { it == WalletScope.default }
+                .toSet()
             val specs = knownDevices.toWatcherSpecs(watcherSettings.electrumUrl)
             val desiredIds = specs.map { it.watcherId }.toSet()
             val knownWalletIds = knownDevices.mapNotNull { it.resolvedWalletId() }.toSet()
             trackedWalletIds += persistedWalletIds
-            val removedWalletIds = trackedWalletIds - knownWalletIds
+            // Only wallets that still have activities to clear. Core drops a wallet's tag metadata
+            // along with its activities whether or not any matched, so cleaning up a wallet that has
+            // none is not a no-op: it takes the metadata a removal deliberately kept.
+            val removedWalletIds = (trackedWalletIds - knownWalletIds).intersect(persistedWalletIds)
             trackedWalletIds += knownWalletIds
 
             specs.forEach { spec ->

--- a/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
@@ -466,8 +466,11 @@ class HwWalletRepo @Inject constructor(
                 // Read before the deletion below, which takes the tags with the activities they are on.
                 val keptName = targets.firstNotNullOfOrNull { it.customLabel?.takeIf(String::isNotBlank) }
                     .takeIf { keepBackupData }
+                // Nothing has been deleted yet, so failing here costs nothing and keeps the choice with
+                // the user: retry, or remove the wallet without keeping its data.
                 val keptTagMetadata = when {
-                    keepBackupData -> activityRepo.getTagMetadataForWallet(walletId).getOrThrow()
+                    keepBackupData -> activityRepo.getTagMetadataForWallet(walletId)
+                        .getOrElse { throw HwBackupDataUnreadableError(it) }
                     else -> emptyList()
                 }
                 activeWatchers.toList()
@@ -889,6 +892,13 @@ class HwPassphraseRequiredError : AppError("Passphrase needed to reopen this wal
 
 /** The entered passphrase opened a different wallet than the one being signed from. */
 class HwPassphraseMismatchError : AppError("Passphrase opened a different wallet")
+
+/**
+ * A removal asked to keep the wallet's backup data, but its tags could not be read. Raised before
+ * anything is deleted, so the wallet is untouched and the removal can be retried or repeated without
+ * keeping the data.
+ */
+class HwBackupDataUnreadableError(cause: Throwable) : AppError("Could not read the backup data", cause)
 
 private data class HwWatcherData(
     val walletId: String,

--- a/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
@@ -77,6 +77,7 @@ import kotlin.time.Duration.Companion.seconds
 class HwWalletRepo @Inject constructor(
     private val trezorRepo: TrezorRepo,
     private val activityRepo: ActivityRepo,
+    private val preActivityMetadataRepo: PreActivityMetadataRepo,
     private val hwWalletStore: HwWalletStore,
     private val settingsStore: SettingsStore,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
@@ -444,8 +445,15 @@ class HwWalletRepo @Inject constructor(
      * is stored once per transport but shares an xpub-derived identity, so forgetting a single id
      * would leave the tile reappearing through the other transport. Other identities on the same
      * device — the standard wallet, or another passphrase wallet — are left paired.
+     *
+     * @param keepBackupData whether to carry the wallet's name and tags in the backup, so re-pairing
+     * the device restores them. Off by default: only a user removing a wallet is asked, and internal
+     * cleanup of a wallet the user never meant to watch must not leave its data behind.
      */
-    suspend fun removeDevice(walletId: String): Result<Unit> = withContext(ioDispatcher) {
+    suspend fun removeDevice(
+        walletId: String,
+        keepBackupData: Boolean = false,
+    ): Result<Unit> = withContext(ioDispatcher) {
         runSuspendCatching {
             watcherMutex.withLock {
                 val knownDevices = hwWalletStore.loadKnownDevices()
@@ -453,6 +461,13 @@ class HwWalletRepo @Inject constructor(
                 // Without an entry there is nothing to forget, and the check below would pass on an
                 // empty set: report the failure instead of telling the user the wallet was removed.
                 require(targets.isNotEmpty()) { "Unknown hardware wallet '$walletId'" }
+                // Read before the deletion below, which takes the tags with the activities they are on.
+                val keptName = targets.firstNotNullOfOrNull { it.customLabel?.takeIf(String::isNotBlank) }
+                    .takeIf { keepBackupData }
+                val keptTagMetadata = when {
+                    keepBackupData -> activityRepo.getTagMetadataForWallet(walletId).getOrThrow()
+                    else -> emptyList()
+                }
                 activeWatchers.toList()
                     .filter { it.toWalletId() == walletId }
                     .forEach {
@@ -461,6 +476,17 @@ class HwWalletRepo @Inject constructor(
                         }
                     }
                 activityRepo.deleteForWallet(walletId).getOrThrow()
+                // Written back only now: the deletion above drops the wallet's stored tag metadata
+                // along with its activities. Core re-attaches these once the watcher recreates them,
+                // so re-pairing the device brings the tags back.
+                if (keptTagMetadata.isNotEmpty()) {
+                    // Nothing to roll back to at this point, and the wallet is already half removed,
+                    // so a failure here loses the tags rather than failing the removal.
+                    preActivityMetadataRepo.upsertPreActivityMetadata(keptTagMetadata)
+                }
+                // Before forgetting the entries below, so the name is never absent from the backup:
+                // dropping the entries takes their label with them.
+                hwWalletStore.setPendingName(walletId, keptName)
                 trackedWalletIds -= walletId
                 lastPersistedHwSnapshots -= walletId
                 val failures = targets.mapNotNull {

--- a/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import to.bitkit.async.appScope
 import to.bitkit.data.HwWalletStore
+import to.bitkit.data.PendingNameUpdate
 import to.bitkit.data.SettingsStore
 import to.bitkit.di.IoDispatcher
 import to.bitkit.env.Env
@@ -489,13 +490,17 @@ class HwWalletRepo @Inject constructor(
                     // so a failure here loses the tags rather than failing the removal.
                     preActivityMetadataRepo.upsertPreActivityMetadata(keptTagMetadata)
                 }
-                // Before forgetting the entries below, so the name is never absent from the backup:
-                // dropping the entries takes their label with them.
-                hwWalletStore.setPendingName(walletId, keptName)
                 trackedWalletIds -= walletId
                 lastPersistedHwSnapshots -= walletId
-                val failures = targets.mapNotNull {
-                    trezorRepo.forgetDevice(it.id, walletKey = it.walletKey).exceptionOrNull()
+                // The name is stored in the same write that forgets the entries carrying it, so the
+                // store never publishes a device list still holding this wallet. A separate write would,
+                // and a reconcile reading it restarts the watcher of the wallet being removed.
+                val failures = targets.mapNotNull { device ->
+                    trezorRepo.forgetDevice(
+                        device.id,
+                        walletKey = device.walletKey,
+                        pendingName = PendingNameUpdate(walletId, keptName),
+                    ).exceptionOrNull()
                 }
                 val remaining = hwWalletStore.loadKnownDevices()
                 failures.firstOrNull()?.let { throw it }

--- a/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/HwWalletRepo.kt
@@ -298,9 +298,11 @@ class HwWalletRepo @Inject constructor(
 
                 Logger.warn("Rejected hardware session for '$walletId': opened wallet '$opened'", context = TAG)
                 // Reading the accounts of the wrong wallet already stored it; a mistyped passphrase
-                // must not leave a stray watch-only wallet behind.
+                // must not leave a stray watch-only wallet behind. Its backup data is kept: the wallet
+                // is a real one the user owns, and storing it has already consumed any name restored
+                // for it into the entry about to be forgotten.
                 if (opened !in watchedBefore) {
-                    removeDevice(opened)
+                    removeDevice(opened, keepBackupData = true)
                         .onFailure { Logger.warn("Failed to drop unwatched wallet '$opened'", it, context = TAG) }
                 }
                 trezorRepo.disconnectStaleSession(deviceId)

--- a/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
@@ -1143,12 +1143,7 @@ class TrezorRepo @Inject constructor(
         val named = previous ?: knownDevices.firstOrNull { it.walletKey == identityKey }
         val resolvedWalletId = previous?.walletId?.takeIf { it.isNotBlank() }
             ?: knownDevices.findHardwareWalletId(xpubs, fallback = deviceInfo.id)
-        // A name restored from a backup, or kept when this wallet was removed, belongs to the wallet
-        // identity rather than to any device entry, so adopt it the first time the identity is paired
-        // again. An entry that already carries one was named on this device more recently.
-        val pendingName = resolvedWalletId.takeIf { it.isNotBlank() }
-            ?.let { hwWalletStore.loadPendingNames()[it] }
-            ?.takeIf { it.isNotBlank() }
+        val pendingName = pendingNameFor(resolvedWalletId)
         val customLabel = named?.customLabel ?: pendingName
         val known = KnownDevice(
             id = deviceInfo.id,
@@ -1161,15 +1156,7 @@ class TrezorRepo @Inject constructor(
             xpubs = xpubs,
             customLabel = customLabel,
             walletId = resolvedWalletId,
-            // The selection that derived these keys is authoritative, so a wallet wrongly marked
-            // hidden is corrected the next time it is opened rather than staying gated behind a
-            // passphrase forever. On-device entry cannot say which wallet was opened, so it keeps
-            // what the entry already knew and assumes hidden only for one it has never seen.
-            passphraseProtected = when (selection) {
-                WalletSelection.Standard -> false
-                is WalletSelection.Hidden -> true
-                WalletSelection.OnDevice -> previous?.passphraseProtected ?: true
-            },
+            passphraseProtected = selection.isPassphraseProtected(previous),
             trezorDeviceId = features.deviceId ?: previous?.trezorDeviceId,
         )
         val updated = knownDevices.filterNot { it.isReplacedBy(known, refreshed = previous) } + known
@@ -1182,6 +1169,27 @@ class TrezorRepo @Inject constructor(
         _state.update { it.copy(knownDevices = updated.toImmutableList()) }
         return known
     }
+
+    /**
+     * The selection that derived a device's keys is authoritative, so a wallet wrongly marked hidden is
+     * corrected the next time it is opened rather than staying gated behind a passphrase forever.
+     * On-device entry cannot say which wallet was opened, so it keeps what the entry already knew and
+     * assumes hidden only for one it has never seen.
+     */
+    private fun WalletSelection.isPassphraseProtected(previous: KnownDevice?): Boolean = when (this) {
+        WalletSelection.Standard -> false
+        is WalletSelection.Hidden -> true
+        WalletSelection.OnDevice -> previous?.passphraseProtected ?: true
+    }
+
+    /**
+     * The name a wallet identity carries while it has no device entry: restored from a backup, or kept
+     * when the wallet was removed. Adopted the first time the identity is paired again.
+     */
+    private suspend fun pendingNameFor(walletId: String): String? = walletId
+        .takeIf { it.isNotBlank() }
+        ?.let { hwWalletStore.loadPendingNames()[it] }
+        ?.takeIf { it.isNotBlank() }
 
     /**
      * Reads account-level extended public keys for every supported address type so a

--- a/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
@@ -1188,7 +1188,8 @@ class TrezorRepo @Inject constructor(
      */
     private suspend fun pendingNameFor(walletId: String): String? = walletId
         .takeIf { it.isNotBlank() }
-        ?.let { hwWalletStore.loadPendingNames()[it] }
+        // Only a name: failing to read one must not stop the device being paired.
+        ?.let { runSuspendCatching { hwWalletStore.loadPendingNames()[it] }.getOrNull() }
         ?.takeIf { it.isNotBlank() }
 
     /**

--- a/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import to.bitkit.async.appScope
 import to.bitkit.data.HwWalletStore
+import to.bitkit.data.PendingNameUpdate
 import to.bitkit.data.SettingsStore
 import to.bitkit.di.IoDispatcher
 import to.bitkit.env.Env
@@ -889,7 +890,11 @@ class TrezorRepo @Inject constructor(
      * credentials are only cleared once no identity of the device remains, so removing one hidden
      * wallet does not unpair the device for the others.
      */
-    suspend fun forgetDevice(deviceId: String, walletKey: String? = null): Result<Unit> = withContext(ioDispatcher) {
+    suspend fun forgetDevice(
+        deviceId: String,
+        walletKey: String? = null,
+        pendingName: PendingNameUpdate? = null,
+    ): Result<Unit> = withContext(ioDispatcher) {
         runSuspendCatching {
             TrezorDebugLog.log("FORGET", "forgetDevice called for: $deviceId")
             // The store is the source of truth here: labels are written straight to it, so a
@@ -938,7 +943,7 @@ class TrezorRepo @Inject constructor(
                 TrezorDebugLog.log("FORGET", "Keeping credentials, another wallet still uses $deviceId")
                 Result.success(Unit)
             }
-            saveKnownDevices(updated)
+            saveKnownDevices(updated, pendingName)
             _state.update { it.copy(knownDevices = updated.toImmutableList()) }
             clearCredentialsResult.getOrThrow()
             disconnectResult.onFailure {
@@ -1163,7 +1168,10 @@ class TrezorRepo @Inject constructor(
         // The pending name is consumed in the same write as the entry that adopted it, so the name
         // lives in exactly one place: leaving it pending would resurrect it once the user clears the
         // entry's own label, and dropping it separately would lose it if saving the entry failed.
-        saveKnownDevices(updated, consumedPendingName = resolvedWalletId.takeIf { pendingName != null })
+        saveKnownDevices(
+            updated,
+            pendingName = pendingName?.let { PendingNameUpdate(resolvedWalletId, name = null) },
+        )
         _state.update { it.copy(knownDevices = updated.toImmutableList()) }
         return known
     }
@@ -1252,9 +1260,9 @@ class TrezorRepo @Inject constructor(
         Logger.error("Failed to load known devices", it, context = TAG)
     }.getOrDefault(emptyList())
 
-    private suspend fun saveKnownDevices(devices: List<KnownDevice>, consumedPendingName: String? = null) {
+    private suspend fun saveKnownDevices(devices: List<KnownDevice>, pendingName: PendingNameUpdate? = null) {
         runSuspendCatching {
-            hwWalletStore.saveKnownDevices(devices, consumedPendingName)
+            hwWalletStore.saveKnownDevices(devices, pendingName)
         }.onFailure { Logger.error("Failed to save known devices", it, context = TAG) }
     }
 

--- a/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
@@ -1160,12 +1160,10 @@ class TrezorRepo @Inject constructor(
             trezorDeviceId = features.deviceId ?: previous?.trezorDeviceId,
         )
         val updated = knownDevices.filterNot { it.isReplacedBy(known, refreshed = previous) } + known
-        saveKnownDevices(updated)
-        // Consumed, so the name lives on the entry alone: leaving it would resurrect a name the user
-        // later clears, since the entry would then fall back to the pending one again.
-        if (pendingName != null) {
-            hwWalletStore.setPendingName(resolvedWalletId, null)
-        }
+        // The pending name is consumed in the same write as the entry that adopted it, so the name
+        // lives in exactly one place: leaving it pending would resurrect it once the user clears the
+        // entry's own label, and dropping it separately would lose it if saving the entry failed.
+        saveKnownDevices(updated, consumedPendingName = resolvedWalletId.takeIf { pendingName != null })
         _state.update { it.copy(knownDevices = updated.toImmutableList()) }
         return known
     }
@@ -1254,9 +1252,9 @@ class TrezorRepo @Inject constructor(
         Logger.error("Failed to load known devices", it, context = TAG)
     }.getOrDefault(emptyList())
 
-    private suspend fun saveKnownDevices(devices: List<KnownDevice>) {
-        runCatching {
-            hwWalletStore.saveKnownDevices(devices)
+    private suspend fun saveKnownDevices(devices: List<KnownDevice>, consumedPendingName: String? = null) {
+        runSuspendCatching {
+            hwWalletStore.saveKnownDevices(devices, consumedPendingName)
         }.onFailure { Logger.error("Failed to save known devices", it, context = TAG) }
     }
 

--- a/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
+++ b/app/src/main/java/to/bitkit/repositories/TrezorRepo.kt
@@ -1141,6 +1141,15 @@ class TrezorRepo @Inject constructor(
         // must keep the name the user gave it instead of falling back to the device's own.
         val identityKey = walletKey(xpubs, deviceInfo.id)
         val named = previous ?: knownDevices.firstOrNull { it.walletKey == identityKey }
+        val resolvedWalletId = previous?.walletId?.takeIf { it.isNotBlank() }
+            ?: knownDevices.findHardwareWalletId(xpubs, fallback = deviceInfo.id)
+        // A name restored from a backup, or kept when this wallet was removed, belongs to the wallet
+        // identity rather than to any device entry, so adopt it the first time the identity is paired
+        // again. An entry that already carries one was named on this device more recently.
+        val pendingName = resolvedWalletId.takeIf { it.isNotBlank() }
+            ?.let { hwWalletStore.loadPendingNames()[it] }
+            ?.takeIf { it.isNotBlank() }
+        val customLabel = named?.customLabel ?: pendingName
         val known = KnownDevice(
             id = deviceInfo.id,
             name = deviceInfo.name,
@@ -1150,9 +1159,8 @@ class TrezorRepo @Inject constructor(
             model = features.model ?: deviceInfo.model,
             lastConnectedAt = clock.nowMs(),
             xpubs = xpubs,
-            customLabel = named?.customLabel,
-            walletId = previous?.walletId?.takeIf { it.isNotBlank() }
-                ?: knownDevices.findHardwareWalletId(xpubs, fallback = deviceInfo.id),
+            customLabel = customLabel,
+            walletId = resolvedWalletId,
             // The selection that derived these keys is authoritative, so a wallet wrongly marked
             // hidden is corrected the next time it is opened rather than staying gated behind a
             // passphrase forever. On-device entry cannot say which wallet was opened, so it keeps
@@ -1166,6 +1174,11 @@ class TrezorRepo @Inject constructor(
         )
         val updated = knownDevices.filterNot { it.isReplacedBy(known, refreshed = previous) } + known
         saveKnownDevices(updated)
+        // Consumed, so the name lives on the entry alone: leaving it would resurrect a name the user
+        // later clears, since the entry would then fall back to the pending one again.
+        if (pendingName != null) {
+            hwWalletStore.setPendingName(resolvedWalletId, null)
+        }
         _state.update { it.copy(knownDevices = updated.toImmutableList()) }
         return known
     }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HardwareWalletScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HardwareWalletScreen.kt
@@ -49,7 +49,6 @@ import to.bitkit.ui.components.TabBar
 import to.bitkit.ui.components.TertiaryButton
 import to.bitkit.ui.components.TopBarSpacer
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.scaffold.AppAlertDialog
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.screens.wallets.activity.components.activityListGroupedItems
@@ -87,6 +86,8 @@ fun HardwareWalletScreen(
             onConfirmRemove = { viewModel.removeDevice(walletId) },
             onDismissRemoveDialog = viewModel::onDismissRemoveDialog,
             onBackClick = onBackClick,
+            keepBackupData = uiState.keepBackupDataOnRemoval,
+            onKeepBackupDataChange = viewModel::onKeepBackupDataChange,
         )
     }
 }
@@ -101,6 +102,8 @@ private fun HardwareWalletContent(
     onConfirmRemove: () -> Unit,
     onDismissRemoveDialog: () -> Unit,
     onBackClick: () -> Unit,
+    keepBackupData: Boolean = true,
+    onKeepBackupDataChange: (Boolean) -> Unit = {},
 ) {
     val hasFunds = wallet.balanceSats > 0uL
     val hasFundingFunds = wallet.fundingBalanceSats > 0uL
@@ -215,11 +218,10 @@ private fun HardwareWalletContent(
         }
 
         if (showRemoveDialog) {
-            AppAlertDialog(
-                title = stringResource(R.string.hardware__remove_dialog_title, wallet.name),
-                text = stringResource(R.string.hardware__remove_dialog_text),
-                confirmText = stringResource(R.string.common__remove),
-                dismissText = stringResource(R.string.common__cancel),
+            RemoveHwWalletDialog(
+                walletName = wallet.name,
+                keepBackupData = keepBackupData,
+                onKeepBackupDataChange = onKeepBackupDataChange,
                 onConfirm = onConfirmRemove,
                 onDismiss = onDismissRemoveDialog,
             )

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HwWalletViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HwWalletViewModel.kt
@@ -34,7 +34,13 @@ class HwWalletViewModel @Inject constructor(
 
     private var renameSessionId = 0L
 
-    fun onRemoveClick(wallet: HwWallet) = _uiState.update { it.copy(isPendingRemoval = wallet) }
+    // Reset on open rather than on dismiss, so a back press, a failed removal or another wallet picked
+    // from the list all start from the default rather than from the last choice.
+    fun onRemoveClick(wallet: HwWallet) = _uiState.update {
+        it.copy(isPendingRemoval = wallet, keepBackupDataOnRemoval = true)
+    }
+
+    fun onKeepBackupDataChange(value: Boolean) = _uiState.update { it.copy(keepBackupDataOnRemoval = value) }
 
     fun onDismissRemoveDialog() = _uiState.update { it.copy(isPendingRemoval = null) }
 
@@ -112,9 +118,12 @@ class HwWalletViewModel @Inject constructor(
         renameSessionId == sessionId && isPendingRename?.id == walletId
 
     fun removeDevice(walletId: String) {
+        // Read before the update below clears the pending state this choice was made in.
+        val keepBackupData = _uiState.value.keepBackupDataOnRemoval
+
         viewModelScope.launch {
             _uiState.update { it.copy(isPendingRemoval = null) }
-            hwWalletRepo.removeDevice(walletId).onFailure {
+            hwWalletRepo.removeDevice(walletId, keepBackupData).onFailure {
                 ToastEventBus.send(
                     type = Toast.ToastType.ERROR,
                     title = context.getString(R.string.common__error),
@@ -128,6 +137,7 @@ class HwWalletViewModel @Inject constructor(
 @Immutable
 data class HwWalletDetailUiState(
     val isPendingRemoval: HwWallet? = null,
+    val keepBackupDataOnRemoval: Boolean = true,
     val isPendingRename: HwWallet? = null,
     val labelInput: String = "",
     val isSavingLabel: Boolean = false,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/HwWalletViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/HwWalletViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 import to.bitkit.R
 import to.bitkit.models.HwWallet
 import to.bitkit.models.Toast
+import to.bitkit.repositories.HwBackupDataUnreadableError
 import to.bitkit.repositories.HwWalletRepo
 import to.bitkit.repositories.HwWalletRepo.Companion.DEVICE_LABEL_MAX_LENGTH
 import to.bitkit.ui.shared.toast.ToastEventBus
@@ -124,10 +125,16 @@ class HwWalletViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isPendingRemoval = null) }
             hwWalletRepo.removeDevice(walletId, keepBackupData).onFailure {
+                // The wallet is untouched when its backup data could not be read, so say what failed
+                // and point at the way through instead of asking for a retry that repeats it.
+                val description = when (it) {
+                    is HwBackupDataUnreadableError -> R.string.hardware__remove_keep_error
+                    else -> R.string.hardware__remove_error
+                }
                 ToastEventBus.send(
                     type = Toast.ToastType.ERROR,
                     title = context.getString(R.string.common__error),
-                    description = context.getString(R.string.hardware__remove_error),
+                    description = context.getString(description),
                 )
             }
         }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/RemoveHwWalletDialog.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/RemoveHwWalletDialog.kt
@@ -1,0 +1,92 @@
+package to.bitkit.ui.screens.wallets
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import to.bitkit.R
+import to.bitkit.ui.components.BodyM
+import to.bitkit.ui.components.BodyMSB
+import to.bitkit.ui.components.VerticalSpacer
+import to.bitkit.ui.scaffold.AppAlertDialog
+import to.bitkit.ui.shared.modifiers.clickableAlpha
+import to.bitkit.ui.theme.AppSwitchDefaults
+import to.bitkit.ui.theme.AppThemeSurface
+import to.bitkit.ui.theme.Colors
+
+/**
+ * Confirms removing a paired hardware wallet, offering to carry its name and tags in the backup so
+ * re-pairing the device restores them. Shared by the wallet screen and the hardware wallet settings.
+ */
+@Composable
+fun RemoveHwWalletDialog(
+    walletName: String,
+    keepBackupData: Boolean,
+    onKeepBackupDataChange: (Boolean) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AppAlertDialog(
+        title = stringResource(R.string.hardware__remove_dialog_title, walletName),
+        confirmText = stringResource(R.string.common__remove),
+        dismissText = stringResource(R.string.common__cancel),
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+        modifier = modifier.testTag("RemoveHwWalletDialog")
+    ) {
+        Column {
+            BodyM(text = stringResource(R.string.hardware__remove_dialog_text), color = Colors.White64)
+            VerticalSpacer(16.dp)
+            KeepBackupDataRow(
+                keepBackupData = keepBackupData,
+                onKeepBackupDataChange = onKeepBackupDataChange,
+            )
+        }
+    }
+}
+
+@Composable
+private fun KeepBackupDataRow(
+    keepBackupData: Boolean,
+    onKeepBackupDataChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .clickableAlpha { onKeepBackupDataChange(!keepBackupData) }
+            .testTag("HwRemoveKeepBackupToggle")
+    ) {
+        BodyMSB(text = stringResource(R.string.hardware__remove_dialog_keep))
+        Switch(
+            checked = keepBackupData,
+            onCheckedChange = null, // handled by parent
+            colors = AppSwitchDefaults.colors,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun Preview() {
+    AppThemeSurface {
+        RemoveHwWalletDialog(
+            walletName = "Trezor Safe 3",
+            keepBackupData = true,
+            onKeepBackupDataChange = {},
+            onConfirm = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/RemoveHwWalletDialog.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/RemoveHwWalletDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import to.bitkit.R
 import to.bitkit.ui.components.BodyM
 import to.bitkit.ui.components.BodyMSB
+import to.bitkit.ui.components.HorizontalSpacer
 import to.bitkit.ui.components.VerticalSpacer
 import to.bitkit.ui.scaffold.AppAlertDialog
 import to.bitkit.ui.shared.modifiers.clickableAlpha
@@ -68,7 +69,11 @@ private fun KeepBackupDataRow(
             .clickableAlpha { onKeepBackupDataChange(!keepBackupData) }
             .testTag("HwRemoveKeepBackupToggle")
     ) {
-        BodyMSB(text = stringResource(R.string.hardware__remove_dialog_keep))
+        BodyMSB(
+            text = stringResource(R.string.hardware__remove_dialog_keep),
+            modifier = Modifier.weight(1f)
+        )
+        HorizontalSpacer(16.dp)
         Switch(
             checked = keepBackupData,
             onCheckedChange = null, // handled by parent

--- a/app/src/main/java/to/bitkit/ui/settings/general/HardwareWalletsSettingsScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/settings/general/HardwareWalletsSettingsScreen.kt
@@ -63,13 +63,13 @@ import to.bitkit.ui.components.MoneySSB
 import to.bitkit.ui.components.PrimaryButton
 import to.bitkit.ui.components.TextInput
 import to.bitkit.ui.components.VerticalSpacer
-import to.bitkit.ui.scaffold.AppAlertDialog
 import to.bitkit.ui.scaffold.AppTopBar
 import to.bitkit.ui.scaffold.DrawerNavIcon
 import to.bitkit.ui.scaffold.ScreenColumn
 import to.bitkit.ui.scaffold.SheetTopBar
 import to.bitkit.ui.screens.wallets.HwWalletDetailUiState
 import to.bitkit.ui.screens.wallets.HwWalletViewModel
+import to.bitkit.ui.screens.wallets.RemoveHwWalletDialog
 import to.bitkit.ui.shared.modifiers.clickableAlpha
 import to.bitkit.ui.shared.modifiers.sheetHeight
 import to.bitkit.ui.shared.util.gradientBackground
@@ -96,6 +96,7 @@ fun HardwareWalletsSettingsScreen(
         onRemoveClick = viewModel::onRemoveClick,
         onConfirmRemove = { viewModel.removeDevice(it.id) },
         onDismissRemoveDialog = viewModel::onDismissRemoveDialog,
+        onKeepBackupDataChange = viewModel::onKeepBackupDataChange,
         onRenameClick = viewModel::onRenameClick,
         onDismissRenameSheet = viewModel::onDismissRenameSheet,
         onLabelChange = viewModel::onLabelChange,
@@ -112,6 +113,7 @@ private fun Content(
     onRemoveClick: (HwWallet) -> Unit = {},
     onConfirmRemove: (HwWallet) -> Unit = {},
     onDismissRemoveDialog: () -> Unit = {},
+    onKeepBackupDataChange: (Boolean) -> Unit = {},
     onRenameClick: (HwWallet) -> Unit = {},
     onDismissRenameSheet: () -> Unit = {},
     onLabelChange: (String) -> Unit = {},
@@ -178,11 +180,10 @@ private fun Content(
     }
 
     uiState.isPendingRemoval?.let { wallet ->
-        AppAlertDialog(
-            title = stringResource(R.string.hardware__remove_dialog_title, wallet.name),
-            text = stringResource(R.string.hardware__remove_dialog_text),
-            confirmText = stringResource(R.string.common__remove),
-            dismissText = stringResource(R.string.common__cancel),
+        RemoveHwWalletDialog(
+            walletName = wallet.name,
+            keepBackupData = uiState.keepBackupDataOnRemoval,
+            onKeepBackupDataChange = onKeepBackupDataChange,
             onConfirm = { onConfirmRemove(wallet) },
             onDismiss = onDismissRemoveDialog,
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,7 @@
     <string name="hardware__remove_dialog_text">Don\'t worry, your funds are safe and your coins won\'t be deleted. Bitkit will simply stop displaying the amounts in the wallet.</string>
     <string name="hardware__remove_dialog_title">Remove %1$s</string>
     <string name="hardware__remove_error">Could not remove the hardware wallet. Please try again.</string>
+    <string name="hardware__remove_keep_error">Could not keep this wallet\'s tags in your backup. Try again, or remove it without keeping them.</string>
     <string name="hardware__rename_error">Could not rename the hardware wallet. Please try again.</string>
     <string name="hardware__search_error">Could not search for hardware wallets. Check your connection and try again.</string>
     <string name="lightning__availability__text">Funds transfer to savings is usually instant, but settlement may take up to &lt;accent&gt;14 days&lt;/accent&gt; under certain network conditions.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <string name="hardware__passphrase_text">If you have funds protected by a passphrase, enter it below to add these funds to your wallet balance as well.</string>
     <string name="hardware__passphrase_title">Passphrase</string>
     <string name="hardware__remove_button">Remove %1$s</string>
+    <string name="hardware__remove_dialog_keep">Keep name and tags in backup</string>
     <string name="hardware__remove_dialog_text">Don\'t worry, your funds are safe and your coins won\'t be deleted. Bitkit will simply stop displaying the amounts in the wallet.</string>
     <string name="hardware__remove_dialog_title">Remove %1$s</string>
     <string name="hardware__remove_error">Could not remove the hardware wallet. Please try again.</string>

--- a/app/src/test/java/to/bitkit/repositories/ActivityRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/ActivityRepoTest.kt
@@ -7,6 +7,7 @@ import com.synonym.bitkitcore.IcJitEntry
 import com.synonym.bitkitcore.LightningActivity
 import com.synonym.bitkitcore.OnchainActivity
 import com.synonym.bitkitcore.PaymentType
+import com.synonym.bitkitcore.PreActivityMetadata
 import com.synonym.bitkitcore.SortDirection
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -855,6 +856,53 @@ class ActivityRepoTest : BaseUnitTest() {
         val result = sut.getHardwareTagsAsPreActivityMetadata().getOrThrow()
 
         assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `getTagMetadataForWallet unions the stored and the rendered tag metadata`() = test {
+        stubHardwareTagLookup(hardwareOnchainActivity(txType = PaymentType.SENT))
+        val stored = PreActivityMetadata(
+            walletId = HARDWARE_WALLET_ID,
+            paymentId = "not-yet-seen",
+            tags = listOf("gift"),
+            paymentHash = null,
+            txId = "not-yet-seen",
+            address = null,
+            isReceive = false,
+            feeRate = 0uL,
+            isTransfer = false,
+            channelId = null,
+            createdAt = 1uL,
+        )
+        whenever { coreService.activity.getAllPreActivityMetadata() }.thenReturn(listOf(stored))
+
+        val result = sut.getTagMetadataForWallet(HARDWARE_WALLET_ID).getOrThrow()
+
+        // Core drops both on delete, and only the rendered half comes back from the activity tags.
+        assertEquals(listOf("not-yet-seen", "hw-txid"), result.map { it.paymentId })
+    }
+
+    @Test
+    fun `getTagMetadataForWallet ignores the metadata of other wallets`() = test {
+        stubHardwareTagLookup(hardwareOnchainActivity(txType = PaymentType.SENT))
+        val otherWallet = PreActivityMetadata(
+            walletId = WalletScope.default,
+            paymentId = "default-payment",
+            tags = listOf("daily"),
+            paymentHash = null,
+            txId = null,
+            address = null,
+            isReceive = true,
+            feeRate = 0uL,
+            isTransfer = false,
+            channelId = null,
+            createdAt = 1uL,
+        )
+        whenever { coreService.activity.getAllPreActivityMetadata() }.thenReturn(listOf(otherWallet))
+
+        val result = sut.getTagMetadataForWallet(HARDWARE_WALLET_ID).getOrThrow()
+
+        assertEquals(listOf("hw-txid"), result.map { it.paymentId })
     }
 
     private suspend fun stubHardwareTagLookup(activity: Activity.Onchain) {

--- a/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
@@ -535,6 +535,26 @@ class BackupRepoTest : BaseUnitTest() {
     }
 
     @Test
+    fun `metadata restore records the category when the hardware wallet names cannot be stored`() = test {
+        stubWalletBackup()
+        stubMetadataRestore(
+            envelope = metadataEnvelope(
+                metadata = listOf(preActivityMetadata()),
+                hwWalletNames = mapOf(HARDWARE_WALLET_ID to "Cold Storage"),
+            ),
+        )
+        whenever { hwWalletStore.restoreNames(any()) }
+            .doSuspendableAnswer { throw BackupRepoTestError("store unavailable") }
+
+        val result = sut.performFullRestoreFromLatestBackup()
+
+        assertTrue(result.isSuccess)
+        // The names are the last and the least of this envelope: the caches and tags above them were
+        // already applied, so losing the whole category's synced marker over a name would be wrong.
+        verifyBlocking(cacheStore) { updateBackupStatus(eq(BackupCategory.METADATA), any()) }
+    }
+
+    @Test
     fun `renaming a hardware wallet triggers a metadata backup`() = test {
         stubMetadataBackupReads()
         stubBackupObservers()

--- a/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/BackupRepoTest.kt
@@ -29,6 +29,8 @@ import org.mockito.kotlin.whenever
 import to.bitkit.data.AppCacheData
 import to.bitkit.data.AppDb
 import to.bitkit.data.CacheStore
+import to.bitkit.data.HwWalletData
+import to.bitkit.data.HwWalletStore
 import to.bitkit.data.SettingsData
 import to.bitkit.data.SettingsStore
 import to.bitkit.data.WatchOnlyAccountAllocationState
@@ -45,7 +47,9 @@ import to.bitkit.di.json
 import to.bitkit.models.ActivityBackupV1
 import to.bitkit.models.BackupCategory
 import to.bitkit.models.BackupItemStatus
+import to.bitkit.models.KnownDevice
 import to.bitkit.models.MetadataBackupV1
+import to.bitkit.models.TransportType
 import to.bitkit.models.WalletBackupV1
 import to.bitkit.models.WalletScope
 import to.bitkit.models.WatchOnlyAccountRecord
@@ -57,12 +61,14 @@ import to.bitkit.utils.AppError
 import javax.inject.Provider
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+@Suppress("LargeClass")
 class BackupRepoTest : BaseUnitTest() {
     private val context = mock<Context>()
     private val cacheStore = mock<CacheStore>()
@@ -72,6 +78,7 @@ class BackupRepoTest : BaseUnitTest() {
     private val widgetsStore = mock<WidgetsStore>()
     private val watchOnlyAccountStore = mock<WatchOnlyAccountStore>()
     private val watchOnlyAccountRepo = mock<WatchOnlyAccountRepo>()
+    private val hwWalletStore = mock<HwWalletStore>()
     private val blocktankRepo = mock<BlocktankRepo>()
     private val activityRepo = mock<ActivityRepo>()
     private val pubkyRepo = mock<PubkyRepo>()
@@ -86,6 +93,7 @@ class BackupRepoTest : BaseUnitTest() {
     private val cacheData = MutableStateFlow(AppCacheData())
     private val settingsData = MutableStateFlow(SettingsData())
     private val widgetsData = MutableStateFlow(WidgetsData())
+    private val hwWalletData = MutableStateFlow(HwWalletData())
 
     private lateinit var sut: BackupRepo
 
@@ -105,6 +113,9 @@ class BackupRepoTest : BaseUnitTest() {
         whenever { watchOnlyAccountStore.backupSnapshot() }.thenReturn(
             WatchOnlyAccountBackupSnapshot(emptyList(), WatchOnlyAccountAllocationState())
         )
+        whenever(hwWalletStore.data).thenReturn(hwWalletData)
+        whenever { hwWalletStore.backupSnapshot() }.thenReturn(emptyMap())
+        whenever { hwWalletStore.restoreNames(any()) }.thenReturn(Unit)
         whenever { vssBackupClient.getObject(any()) }.thenReturn(Result.success(null))
         whenever { vssBackupClient.putObject(any(), any()) }
             .thenReturn(Result.success(VssItem(key = BackupCategory.SETTINGS.name, value = byteArrayOf(), version = 1)))
@@ -460,6 +471,102 @@ class BackupRepoTest : BaseUnitTest() {
     }
 
     @Test
+    fun `metadata backup carries the hardware wallet names`() = test {
+        stubMetadataBackupReads()
+        whenever { hwWalletStore.backupSnapshot() }.thenReturn(mapOf(HARDWARE_WALLET_ID to "Cold Storage"))
+        val dataCaptor = argumentCaptor<ByteArray>()
+
+        sut.triggerBackup(BackupCategory.METADATA)
+
+        verifyBlocking(vssBackupClient) {
+            putObject(eq(BackupCategory.METADATA.name), dataCaptor.capture())
+        }
+        val payload = json.decodeFromString<MetadataBackupV1>(dataCaptor.firstValue.decodeToString())
+        assertEquals(mapOf(HARDWARE_WALLET_ID to "Cold Storage"), payload.hwWalletNames)
+    }
+
+    @Test
+    fun `metadata backup omits the hardware wallet names when none are set`() = test {
+        stubMetadataBackupReads()
+        val dataCaptor = argumentCaptor<ByteArray>()
+
+        sut.triggerBackup(BackupCategory.METADATA)
+
+        verifyBlocking(vssBackupClient) {
+            putObject(eq(BackupCategory.METADATA.name), dataCaptor.capture())
+        }
+        val payload = json.decodeFromString<MetadataBackupV1>(dataCaptor.firstValue.decodeToString())
+        assertNull(payload.hwWalletNames)
+    }
+
+    @Test
+    fun `metadata backup fails when the hardware wallet names cannot be read`() = test {
+        stubMetadataBackupReads()
+        whenever { hwWalletStore.backupSnapshot() }
+            .doSuspendableAnswer { throw BackupRepoTestError("store unavailable") }
+
+        val result = sut.triggerBackup(BackupCategory.METADATA)
+
+        assertTrue(result.isFailure)
+        // This envelope is the only copy of the names, so uploading without them would drop them.
+        verify(vssBackupClient, never()).putObject(eq(BackupCategory.METADATA.name), any())
+    }
+
+    @Test
+    fun `metadata restore applies the backed up hardware wallet names`() = test {
+        val names = mapOf(HARDWARE_WALLET_ID to "Cold Storage")
+        stubMetadataRestore(
+            envelope = metadataEnvelope(metadata = listOf(preActivityMetadata()), hwWalletNames = names),
+        )
+
+        sut.performFullRestoreFromLatestBackup()
+
+        verifyBlocking(hwWalletStore) { restoreNames(names) }
+    }
+
+    @Test
+    fun `metadata restore keeps the stored names when the envelope carries none`() = test {
+        stubMetadataRestore(envelope = metadataEnvelope(metadata = listOf(preActivityMetadata())))
+
+        sut.performFullRestoreFromLatestBackup()
+
+        // An envelope written before this field must not clear what this wallet already holds.
+        verifyBlocking(hwWalletStore) { restoreNames(emptyMap()) }
+    }
+
+    @Test
+    fun `renaming a hardware wallet triggers a metadata backup`() = test {
+        stubMetadataBackupReads()
+        stubBackupObservers()
+        stubBackupStatuses(
+            MutableStateFlow(emptyMap()),
+            CompletableDeferred<Unit>().apply { complete(Unit) },
+        ) {}
+
+        try {
+            sut.startObservingBackups()
+            runCurrent()
+
+            // Reconnecting rewrites the entry without touching its name.
+            hwWalletData.update { HwWalletData(knownDevices = listOf(knownDevice())) }
+            runCurrent()
+            advanceTimeBy(10_000)
+            runCurrent()
+
+            verify(vssBackupClient, never()).putObject(eq(BackupCategory.METADATA.name), any())
+
+            hwWalletData.update { HwWalletData(knownDevices = listOf(knownDevice(customLabel = "Cold Storage"))) }
+            runCurrent()
+            advanceTimeBy(10_000)
+            runCurrent()
+
+            verifyBlocking(vssBackupClient) { putObject(eq(BackupCategory.METADATA.name), any()) }
+        } finally {
+            sut.stopObservingBackups()
+        }
+    }
+
+    @Test
     fun `activity traffic alone does not trigger a metadata backup`() = test {
         val activitiesChanged = MutableStateFlow(0L)
         val activityTagsChanged = MutableStateFlow(0L)
@@ -643,8 +750,16 @@ class BackupRepoTest : BaseUnitTest() {
         )
     )
 
-    private fun metadataEnvelope(metadata: List<PreActivityMetadata> = emptyList()) = json.encodeToString(
-        MetadataBackupV1(createdAt = 123, tagMetadata = metadata, cache = AppCacheData())
+    private fun metadataEnvelope(
+        metadata: List<PreActivityMetadata> = emptyList(),
+        hwWalletNames: Map<String, String>? = null,
+    ) = json.encodeToString(
+        MetadataBackupV1(
+            createdAt = 123,
+            tagMetadata = metadata,
+            cache = AppCacheData(),
+            hwWalletNames = hwWalletNames,
+        )
     )
 
     private fun envelopeWithRawField(base: String, field: String, rawJson: String): String {
@@ -657,6 +772,19 @@ class BackupRepoTest : BaseUnitTest() {
         walletId = WalletScope.default,
         activityId = "a1",
         tags = listOf("coffee"),
+    )
+
+    private fun knownDevice(customLabel: String? = null) = KnownDevice(
+        id = "dev1",
+        name = "Trezor",
+        path = "usb-1",
+        transportType = TransportType.USB,
+        label = null,
+        model = "Safe 3",
+        lastConnectedAt = 1,
+        xpubs = mapOf("nativeSegwit" to "zpubNS"),
+        customLabel = customLabel,
+        walletId = HARDWARE_WALLET_ID,
     )
 
     private fun preActivityMetadata() = PreActivityMetadata(
@@ -741,6 +869,7 @@ class BackupRepoTest : BaseUnitTest() {
         widgetsStore = widgetsStore,
         watchOnlyAccountStore = watchOnlyAccountStore,
         watchOnlyAccountRepo = watchOnlyAccountRepo,
+        hwWalletStore = hwWalletStore,
         blocktankRepo = blocktankRepo,
         activityRepo = activityRepo,
         pubkyRepo = pubkyRepo,

--- a/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
@@ -1581,7 +1581,8 @@ class HwWalletRepoTest : BaseUnitTest() {
     @Test
     fun `removeDevice fails when forget reports credential cleanup failure despite the device being gone`() = test {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.failure(AppError("clear failed")))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }
+            .thenReturn(Result.failure(AppError("clear failed")))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID)

--- a/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
@@ -48,6 +48,7 @@ import to.bitkit.test.BaseUnitTest
 import to.bitkit.utils.AppError
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
@@ -1476,6 +1477,25 @@ class HwWalletRepoTest : BaseUnitTest() {
         val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
 
         assertTrue(result.isSuccess)
+        verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
+    }
+
+    @Test
+    fun `removeDevice keeping backup data keeps the tags of a wallet that was never renamed`() = test {
+        // The name and the tags are kept independently: a wallet is far more likely to carry tags than
+        // a name the user bothered to set, and having no name must not cost it its tags.
+        val tagMetadata = listOf(preActivityMetadata())
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
+        whenever { activityRepo.getTagMetadataForWallet(HARDWARE_WALLET_ID) }
+            .thenReturn(Result.success(tagMetadata))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        val sut = createRepo()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
+
+        assertTrue(result.isSuccess)
+        assertNull(device.customLabel)
+        verify(preActivityMetadataRepo).upsertPreActivityMetadata(tagMetadata)
         verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
     }
 

--- a/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
@@ -5,6 +5,7 @@ import com.synonym.bitkitcore.Activity
 import com.synonym.bitkitcore.ComposeResult
 import com.synonym.bitkitcore.OnchainActivity
 import com.synonym.bitkitcore.PaymentType
+import com.synonym.bitkitcore.PreActivityMetadata
 import com.synonym.bitkitcore.TransactionDetails
 import com.synonym.bitkitcore.TrezorException
 import com.synonym.bitkitcore.TrezorFeatures
@@ -61,6 +62,7 @@ class HwWalletRepoTest : BaseUnitTest() {
 
     private val trezorRepo = mock<TrezorRepo>()
     private val activityRepo = mock<ActivityRepo>()
+    private val preActivityMetadataRepo = mock<PreActivityMetadataRepo>()
     private val hwWalletStore = mock<HwWalletStore>()
     private val settingsStore = mock<SettingsStore>()
 
@@ -113,6 +115,9 @@ class HwWalletRepoTest : BaseUnitTest() {
         }
         whenever { activityRepo.getWalletIds() }.thenReturn(Result.success(emptySet()))
         whenever { activityRepo.deleteForWallet(any()) }.thenReturn(Result.success(Unit))
+        whenever { activityRepo.getTagMetadataForWallet(any()) }.thenReturn(Result.success(emptyList()))
+        whenever { preActivityMetadataRepo.upsertPreActivityMetadata(any()) }.thenReturn(Result.success(Unit))
+        whenever { hwWalletStore.setPendingName(any(), anyOrNull()) }.thenReturn(Unit)
     }
 
     private fun passphraseCapableFeatures(): TrezorFeatures =
@@ -121,6 +126,7 @@ class HwWalletRepoTest : BaseUnitTest() {
     private fun createRepo() = HwWalletRepo(
         trezorRepo = trezorRepo,
         activityRepo = activityRepo,
+        preActivityMetadataRepo = preActivityMetadataRepo,
         hwWalletStore = hwWalletStore,
         settingsStore = settingsStore,
         ioDispatcher = testDispatcher,
@@ -1373,6 +1379,102 @@ class HwWalletRepoTest : BaseUnitTest() {
     }
 
     @Test
+    fun `removeDevice keeping backup data rewrites the tag metadata after deleting the activities`() = test {
+        val named = device.copy(customLabel = "Cold Storage")
+        val tagMetadata = listOf(preActivityMetadata())
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())
+        whenever { activityRepo.getTagMetadataForWallet(HARDWARE_WALLET_ID) }
+            .thenReturn(Result.success(tagMetadata))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        val sut = createRepo()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
+
+        assertTrue(result.isSuccess)
+        // Core drops the wallet's tag metadata with its activities, so the rewrite must follow the delete.
+        inOrder(activityRepo, preActivityMetadataRepo) {
+            verify(activityRepo).deleteForWallet(HARDWARE_WALLET_ID)
+            verify(preActivityMetadataRepo).upsertPreActivityMetadata(tagMetadata)
+        }
+    }
+
+    @Test
+    fun `removeDevice keeping backup data stores the wallet name before forgetting the device`() = test {
+        val named = device.copy(customLabel = "Cold Storage")
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        val sut = createRepo()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
+
+        assertTrue(result.isSuccess)
+        // Forgetting the entry takes its label, so the name must be stored while it is still there.
+        inOrder(hwWalletStore, trezorRepo) {
+            verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, "Cold Storage")
+            verify(trezorRepo).forgetDevice("dev1", "zpubNS")
+        }
+    }
+
+    @Test
+    fun `removeDevice keeping backup data stores no name for a wallet that was never renamed`() = test {
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        val sut = createRepo()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
+
+        assertTrue(result.isSuccess)
+        verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
+    }
+
+    @Test
+    fun `removeDevice without keeping backup data drops the name and the tag metadata`() = test {
+        val named = device.copy(customLabel = "Cold Storage")
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        val sut = createRepo()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = false)
+
+        assertTrue(result.isSuccess)
+        verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
+        verify(activityRepo, never()).getTagMetadataForWallet(any())
+        verify(preActivityMetadataRepo, never()).upsertPreActivityMetadata(any())
+    }
+
+    @Test
+    fun `removeDevice keeps nothing by default`() = test {
+        val named = device.copy(customLabel = "Cold Storage")
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        val sut = createRepo()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID)
+
+        assertTrue(result.isSuccess)
+        verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
+        verify(preActivityMetadataRepo, never()).upsertPreActivityMetadata(any())
+    }
+
+    @Test
+    fun `removeDevice still removes the wallet when the tag metadata cannot be rewritten`() = test {
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
+        whenever { activityRepo.getTagMetadataForWallet(HARDWARE_WALLET_ID) }
+            .thenReturn(Result.success(listOf(preActivityMetadata())))
+        whenever { preActivityMetadataRepo.upsertPreActivityMetadata(any()) }
+            .thenReturn(Result.failure(AppError("core unavailable")))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        val sut = createRepo()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
+
+        // The activities are already gone and the watchers stopped, so there is nothing to roll back to:
+        // the tags are lost rather than the removal reported as failed.
+        assertTrue(result.isSuccess)
+        verify(trezorRepo).forgetDevice("dev1", "zpubNS")
+    }
+
+    @Test
     fun `removeDevice fails when forget reports credential cleanup failure despite the device being gone`() = test {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
         whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.failure(AppError("clear failed")))
@@ -1822,6 +1924,20 @@ class HwWalletRepoTest : BaseUnitTest() {
 
         assertEquals("My Cold Wallet", sut.wallets.value.single().name)
     }
+
+    private fun preActivityMetadata() = PreActivityMetadata(
+        walletId = HARDWARE_WALLET_ID,
+        paymentId = "hw-txid",
+        tags = listOf("cold"),
+        paymentHash = null,
+        txId = "hw-txid",
+        address = null,
+        isReceive = false,
+        feeRate = 0uL,
+        isTransfer = false,
+        channelId = null,
+        createdAt = 1uL,
+    )
 
     private suspend fun wheneverStartWatcher() = whenever(
         trezorRepo.startWatcher(

--- a/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
@@ -1249,6 +1249,43 @@ class HwWalletRepoTest : BaseUnitTest() {
     }
 
     @Test
+    fun `reconnectWithPassphrase keeps the backup data of the wallet a wrong passphrase opened`() = test {
+        // The wallet is a real one the user owns, and storing it consumed the name restored for it,
+        // so dropping it here would erase a backed up name a typo was never meant to touch.
+        val strayWallet = device.copy(
+            xpubs = mapOf("nativeSegwit" to "zpubStray"),
+            walletId = "stray-wallet",
+            customLabel = "Hidden Stash",
+            passphraseProtected = true,
+        )
+        val strayTagMetadata = listOf(preActivityMetadata().copy(walletId = "stray-wallet"))
+        var stored = listOf(device, hiddenWallet)
+        whenever { hwWalletStore.loadKnownDevices() }.thenAnswer { stored }
+        whenever { activityRepo.getTagMetadataForWallet("stray-wallet") }
+            .thenReturn(Result.success(strayTagMetadata))
+        whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenAnswer {
+            stored = stored.filterNot { it.walletId == "stray-wallet" }
+            Result.success(Unit)
+        }
+        whenever { trezorRepo.connectWithWalletMode("dev1", TrezorWalletMode.PASSPHRASE_HOST, "wrong") }
+            .thenAnswer {
+                stored = stored + strayWallet
+                trezorState.value = TrezorState(
+                    connected = ConnectedTrezorDevice(id = "dev1", features = mock(), walletId = "stray-wallet"),
+                )
+                Result.success(mock<TrezorFeatures>())
+            }
+        val sut = createRepo()
+
+        val result = sut.reconnectWithPassphrase(HIDDEN_WALLET_ID, "wrong")
+
+        assertTrue(result.exceptionOrNull() is HwPassphraseMismatchError)
+        verify(hwWalletStore).setPendingName("stray-wallet", "Hidden Stash")
+        verify(preActivityMetadataRepo).upsertPreActivityMetadata(strayTagMetadata)
+    }
+
+    @Test
     fun `funding account resolves the requested identity on a shared device`() = test {
         storeData.value = HwWalletData(knownDevices = listOf(device, hiddenWallet))
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device, hiddenWallet))

--- a/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
@@ -1436,6 +1436,21 @@ class HwWalletRepoTest : BaseUnitTest() {
     }
 
     @Test
+    fun `removeDevice keeping backup data reports unreadable data without touching the wallet`() = test {
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device))
+        whenever { activityRepo.getTagMetadataForWallet(HARDWARE_WALLET_ID) }
+            .thenReturn(Result.failure(AppError("core unavailable")))
+        val sut = createRepo()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
+
+        // Raised before anything is deleted, so the wallet survives and the user keeps the choice.
+        assertTrue(result.exceptionOrNull() is HwBackupDataUnreadableError)
+        verify(activityRepo, never()).deleteForWallet(any())
+        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull())
+    }
+
+    @Test
     fun `removeDevice keeping backup data stores the wallet name before forgetting the device`() = test {
         val named = device.copy(customLabel = "Cold Storage")
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())

--- a/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
@@ -31,6 +31,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import to.bitkit.data.HwWalletData
 import to.bitkit.data.HwWalletStore
+import to.bitkit.data.PendingNameUpdate
 import to.bitkit.data.SettingsData
 import to.bitkit.data.SettingsStore
 import to.bitkit.env.Env
@@ -940,7 +941,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         val result = sut.removeDevice("unknown-wallet")
 
         assertTrue(result.isFailure)
-        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull())
+        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull(), anyOrNull())
         verify(activityRepo, never()).deleteForWallet("unknown-wallet")
     }
 
@@ -950,14 +951,14 @@ class HwWalletRepoTest : BaseUnitTest() {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device, hiddenWallet), listOf(device))
         wheneverStartWatcher().thenReturn(Result.success(Unit))
         whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
         runCurrent()
 
         val result = sut.removeDevice(HIDDEN_WALLET_ID)
 
         assertTrue(result.isSuccess)
-        verify(trezorRepo).forgetDevice("dev1", "zpubHidden")
+        verify(trezorRepo).forgetDevice(eq("dev1"), eq("zpubHidden"), anyOrNull())
         verify(trezorRepo).stopWatcher("$HIDDEN_WALLET_ID|nativeSegwit")
         verify(trezorRepo, never()).stopWatcher("$HARDWARE_WALLET_ID|nativeSegwit")
         verify(activityRepo).deleteForWallet(HIDDEN_WALLET_ID)
@@ -1227,7 +1228,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         var stored = listOf(device, hiddenWallet)
         whenever { hwWalletStore.loadKnownDevices() }.thenAnswer { stored }
         whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenAnswer {
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenAnswer {
             stored = stored.filterNot { it.walletId == "stray-wallet" }
             Result.success(Unit)
         }
@@ -1245,7 +1246,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         val result = sut.reconnectWithPassphrase(HIDDEN_WALLET_ID, "wrong")
 
         assertTrue(result.exceptionOrNull() is HwPassphraseMismatchError)
-        verify(trezorRepo).forgetDevice("dev1", "zpubStray")
+        verify(trezorRepo).forgetDevice(eq("dev1"), eq("zpubStray"), anyOrNull())
         verify(trezorRepo).disconnectStaleSession("dev1")
     }
 
@@ -1265,7 +1266,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         whenever { activityRepo.getTagMetadataForWallet("stray-wallet") }
             .thenReturn(Result.success(strayTagMetadata))
         whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenAnswer {
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenAnswer {
             stored = stored.filterNot { it.walletId == "stray-wallet" }
             Result.success(Unit)
         }
@@ -1282,7 +1283,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         val result = sut.reconnectWithPassphrase(HIDDEN_WALLET_ID, "wrong")
 
         assertTrue(result.exceptionOrNull() is HwPassphraseMismatchError)
-        verify(hwWalletStore).setPendingName("stray-wallet", "Hidden Stash")
+        verify(trezorRepo).forgetDevice(any(), anyOrNull(), eq(PendingNameUpdate("stray-wallet", "Hidden Stash")))
         verify(preActivityMetadataRepo).upsertPreActivityMetadata(strayTagMetadata)
     }
 
@@ -1390,7 +1391,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
         wheneverStartWatcher().thenReturn(Result.success(Unit))
         whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
         runCurrent()
 
@@ -1433,7 +1434,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
         wheneverStartWatcher().thenReturn(Result.success(Unit))
         whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
         runCurrent()
 
@@ -1442,7 +1443,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         assertEquals(true, result.isSuccess)
         verify(trezorRepo).stopWatcher("hardware-wallet|nativeSegwit")
         verify(activityRepo).deleteForWallet(HARDWARE_WALLET_ID)
-        verify(trezorRepo).forgetDevice("dev1", "zpubNS")
+        verify(trezorRepo).forgetDevice(eq("dev1"), eq("zpubNS"), anyOrNull())
     }
 
     @Test
@@ -1452,7 +1453,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())
         whenever { activityRepo.getTagMetadataForWallet(HARDWARE_WALLET_ID) }
             .thenReturn(Result.success(tagMetadata))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
@@ -1477,36 +1478,38 @@ class HwWalletRepoTest : BaseUnitTest() {
         // Raised before anything is deleted, so the wallet survives and the user keeps the choice.
         assertTrue(result.exceptionOrNull() is HwBackupDataUnreadableError)
         verify(activityRepo, never()).deleteForWallet(any())
-        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull())
+        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull(), anyOrNull())
     }
 
     @Test
     fun `removeDevice keeping backup data stores the wallet name before forgetting the device`() = test {
         val named = device.copy(customLabel = "Cold Storage")
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
 
         assertTrue(result.isSuccess)
-        // Forgetting the entry takes its label, so the name must be stored while it is still there.
-        inOrder(hwWalletStore, trezorRepo) {
-            verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, "Cold Storage")
-            verify(trezorRepo).forgetDevice("dev1", "zpubNS")
-        }
+        // Carried by the write that forgets the entry, so the store never publishes a device list
+        // still holding this wallet, which would restart the watcher of the wallet being removed.
+        verify(trezorRepo).forgetDevice(
+            eq("dev1"),
+            eq("zpubNS"),
+            eq(PendingNameUpdate(HARDWARE_WALLET_ID, "Cold Storage")),
+        )
     }
 
     @Test
     fun `removeDevice keeping backup data stores no name for a wallet that was never renamed`() = test {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
 
         assertTrue(result.isSuccess)
-        verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
+        verify(trezorRepo).forgetDevice(any(), anyOrNull(), eq(PendingNameUpdate(HARDWARE_WALLET_ID, null)))
     }
 
     @Test
@@ -1517,7 +1520,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
         whenever { activityRepo.getTagMetadataForWallet(HARDWARE_WALLET_ID) }
             .thenReturn(Result.success(tagMetadata))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
@@ -1525,20 +1528,20 @@ class HwWalletRepoTest : BaseUnitTest() {
         assertTrue(result.isSuccess)
         assertNull(device.customLabel)
         verify(preActivityMetadataRepo).upsertPreActivityMetadata(tagMetadata)
-        verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
+        verify(trezorRepo).forgetDevice(any(), anyOrNull(), eq(PendingNameUpdate(HARDWARE_WALLET_ID, null)))
     }
 
     @Test
     fun `removeDevice without keeping backup data drops the name and the tag metadata`() = test {
         val named = device.copy(customLabel = "Cold Storage")
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = false)
 
         assertTrue(result.isSuccess)
-        verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
+        verify(trezorRepo).forgetDevice(any(), anyOrNull(), eq(PendingNameUpdate(HARDWARE_WALLET_ID, null)))
         verify(activityRepo, never()).getTagMetadataForWallet(any())
         verify(preActivityMetadataRepo, never()).upsertPreActivityMetadata(any())
     }
@@ -1547,13 +1550,13 @@ class HwWalletRepoTest : BaseUnitTest() {
     fun `removeDevice keeps nothing by default`() = test {
         val named = device.copy(customLabel = "Cold Storage")
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(named), emptyList())
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID)
 
         assertTrue(result.isSuccess)
-        verify(hwWalletStore).setPendingName(HARDWARE_WALLET_ID, null)
+        verify(trezorRepo).forgetDevice(any(), anyOrNull(), eq(PendingNameUpdate(HARDWARE_WALLET_ID, null)))
         verify(preActivityMetadataRepo, never()).upsertPreActivityMetadata(any())
     }
 
@@ -1564,7 +1567,7 @@ class HwWalletRepoTest : BaseUnitTest() {
             .thenReturn(Result.success(listOf(preActivityMetadata())))
         whenever { preActivityMetadataRepo.upsertPreActivityMetadata(any()) }
             .thenReturn(Result.failure(AppError("core unavailable")))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
@@ -1572,19 +1575,19 @@ class HwWalletRepoTest : BaseUnitTest() {
         // The activities are already gone and the watchers stopped, so there is nothing to roll back to:
         // the tags are lost rather than the removal reported as failed.
         assertTrue(result.isSuccess)
-        verify(trezorRepo).forgetDevice("dev1", "zpubNS")
+        verify(trezorRepo).forgetDevice(eq("dev1"), eq("zpubNS"), anyOrNull())
     }
 
     @Test
     fun `removeDevice fails when forget reports credential cleanup failure despite the device being gone`() = test {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.failure(AppError("clear failed")))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.failure(AppError("clear failed")))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID)
 
         assertEquals(true, result.isFailure)
-        verify(trezorRepo).forgetDevice("dev1", "zpubNS")
+        verify(trezorRepo).forgetDevice(eq("dev1"), eq("zpubNS"), anyOrNull())
     }
 
     @Test
@@ -1599,7 +1602,7 @@ class HwWalletRepoTest : BaseUnitTest() {
 
         assertEquals(true, result.isFailure)
         verify(trezorRepo).stopWatcher("hardware-wallet|nativeSegwit")
-        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull())
+        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull(), anyOrNull())
     }
 
     @Test
@@ -1613,7 +1616,7 @@ class HwWalletRepoTest : BaseUnitTest() {
 
         assertTrue(result.isFailure)
         verify(activityRepo).deleteForWallet(HARDWARE_WALLET_ID)
-        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull())
+        verify(trezorRepo, never()).forgetDevice(any(), anyOrNull(), anyOrNull())
     }
 
     @Test
@@ -1624,21 +1627,21 @@ class HwWalletRepoTest : BaseUnitTest() {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(bleEntry, usbEntry), emptyList())
         wheneverStartWatcher().thenReturn(Result.success(Unit))
         whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
         runCurrent()
 
         sut.removeDevice(HARDWARE_WALLET_ID)
 
         verify(trezorRepo).stopWatcher("hardware-wallet|nativeSegwit")
-        verify(trezorRepo).forgetDevice("ble1", "zpubNS")
-        verify(trezorRepo).forgetDevice("usb1", "zpubNS")
+        verify(trezorRepo).forgetDevice(eq("ble1"), eq("zpubNS"), anyOrNull())
+        verify(trezorRepo).forgetDevice(eq("usb1"), eq("zpubNS"), anyOrNull())
     }
 
     @Test
     fun `removeDevice fails when the device is still present afterwards`() = test {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), listOf(device))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
 
         val result = sut.removeDevice(HARDWARE_WALLET_ID)
@@ -1651,7 +1654,7 @@ class HwWalletRepoTest : BaseUnitTest() {
         whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), listOf(device))
         wheneverStartWatcher().thenReturn(Result.success(Unit))
         whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
-        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull(), anyOrNull()) }.thenReturn(Result.success(Unit))
         val sut = createRepo()
         runCurrent()
 

--- a/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/HwWalletRepoTest.kt
@@ -1346,6 +1346,8 @@ class HwWalletRepoTest : BaseUnitTest() {
 
     @Test
     fun `store removal deletes the hardware wallet activity scope`() = test {
+        // Only a wallet with activities left behind is cleaned up, so it must have some to clean.
+        whenever { activityRepo.getWalletIds() }.thenReturn(Result.success(setOf(HARDWARE_WALLET_ID)))
         wheneverStartWatcher().thenReturn(Result.success(Unit))
         whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
         createRepo()
@@ -1371,6 +1373,33 @@ class HwWalletRepoTest : BaseUnitTest() {
         verify(activityRepo).deleteForWallet("orphan-wallet")
         verify(activityRepo, never()).deleteForWallet(WalletScope.default)
         verify(activityRepo, never()).deleteForWallet(HARDWARE_WALLET_ID)
+    }
+
+    @Test
+    fun `removing a wallet deletes its activities exactly once`() = test {
+        // A second delete would run Core's cascade again and take the tag metadata the removal
+        // deliberately kept. The interleaving that caused this in the field — the cleanup deciding from
+        // a scope set read before it takes the lock — needs real concurrency and is covered by manual
+        // QA; this pins the simpler invariant that the cleanup adds no delete of its own.
+        var persisted = setOf(HARDWARE_WALLET_ID)
+        whenever { activityRepo.getWalletIds() }.thenAnswer { Result.success(persisted) }
+        whenever { activityRepo.deleteForWallet(any()) }.thenAnswer {
+            persisted = emptySet()
+            Result.success(Unit)
+        }
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(device), emptyList())
+        wheneverStartWatcher().thenReturn(Result.success(Unit))
+        whenever { trezorRepo.stopWatcher(any()) }.thenReturn(Result.success(Unit))
+        whenever { trezorRepo.forgetDevice(any(), anyOrNull()) }.thenReturn(Result.success(Unit))
+        val sut = createRepo()
+        runCurrent()
+
+        val result = sut.removeDevice(HARDWARE_WALLET_ID, keepBackupData = true)
+        storeData.value = HwWalletData(knownDevices = emptyList())
+        runCurrent()
+
+        assertTrue(result.isSuccess)
+        verify(activityRepo, times(1)).deleteForWallet(HARDWARE_WALLET_ID)
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/repositories/TrezorRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/TrezorRepoTest.kt
@@ -112,6 +112,8 @@ class TrezorRepoTest : BaseUnitTest() {
         whenever(context.getString(R.string.hardware__connect_error)).thenReturn("Could not connect to your Trezor.")
         whenever(context.getString(R.string.hardware__device_busy)).thenReturn(DEVICE_BUSY_MESSAGE)
         whenever { hwWalletStore.loadKnownDevices() }.thenReturn(emptyList())
+        whenever { hwWalletStore.loadPendingNames() }.thenReturn(emptyMap())
+        whenever { hwWalletStore.setPendingName(any(), anyOrNull()) }.thenReturn(Unit)
         stubAccountXpubFetch()
     }
 
@@ -830,6 +832,97 @@ class TrezorRepoTest : BaseUnitTest() {
         val added = captor.firstValue.single { it.id == DEVICE_ID }
         assertEquals("No Pass", added.customLabel)
         assertEquals("standard-wallet", added.walletId)
+    }
+
+    @Test
+    fun `connect adopts the pending name of a wallet paired again`() = test {
+        // Restored from a backup, or kept when the wallet was removed: pairing takes the name over.
+        val sharedKey = "shared-native-xpub"
+        val unnamed = mockKnownDevice(
+            id = DEVICE_ID,
+            xpubs = ALL_ADDRESS_TYPE_KEYS.associateWith { sharedKey },
+            customLabel = null,
+            walletId = "standard-wallet",
+        )
+        val features = mockFeatures()
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(unnamed))
+        whenever { hwWalletStore.loadPendingNames() }.thenReturn(mapOf("standard-wallet" to "Cold Storage"))
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
+        whenever(trezorService.scan()).thenReturn(listOf(mockDeviceInfo()))
+        whenever(
+            trezorService.getPublicKey(path = any(), coin = anyOrNull(), showOnTrezor = eq(false))
+        ).thenAnswer { mockPublicKeyResponse(xpub = sharedKey, path = it.getArgument(0)) }
+        sut = createSut()
+
+        sut.scan()
+        val result = sut.connect(DEVICE_ID)
+
+        assertTrue(result.isSuccess)
+        val captor = argumentCaptor<List<KnownDevice>>()
+        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        assertEquals("Cold Storage", captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
+        // Consumed, so clearing the name later cannot fall back to it again.
+        verify(hwWalletStore).setPendingName("standard-wallet", null)
+    }
+
+    @Test
+    fun `connect prefers the stored custom label over a pending name`() = test {
+        val sharedKey = "shared-native-xpub"
+        val stored = mockKnownDevice(
+            id = DEVICE_ID,
+            xpubs = ALL_ADDRESS_TYPE_KEYS.associateWith { sharedKey },
+            customLabel = "Renamed Here",
+            walletId = "standard-wallet",
+        )
+        val features = mockFeatures()
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(stored))
+        whenever { hwWalletStore.loadPendingNames() }.thenReturn(mapOf("standard-wallet" to "Cold Storage"))
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
+        whenever(trezorService.scan()).thenReturn(listOf(mockDeviceInfo()))
+        whenever(
+            trezorService.getPublicKey(path = any(), coin = anyOrNull(), showOnTrezor = eq(false))
+        ).thenAnswer { mockPublicKeyResponse(xpub = sharedKey, path = it.getArgument(0)) }
+        sut = createSut()
+
+        sut.scan()
+        val result = sut.connect(DEVICE_ID)
+
+        assertTrue(result.isSuccess)
+        val captor = argumentCaptor<List<KnownDevice>>()
+        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        assertEquals("Renamed Here", captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
+        // The pending name lost, so it is stale: dropping it keeps a later rename from falling back to it.
+        verify(hwWalletStore).setPendingName("standard-wallet", null)
+    }
+
+    @Test
+    fun `connect leaves the pending name of another identity on the device alone`() = test {
+        val sharedKey = "shared-native-xpub"
+        val unnamed = mockKnownDevice(
+            id = DEVICE_ID,
+            xpubs = ALL_ADDRESS_TYPE_KEYS.associateWith { sharedKey },
+            customLabel = null,
+            walletId = "standard-wallet",
+        )
+        val features = mockFeatures()
+        whenever(hwWalletStore.loadKnownDevices()).thenReturn(listOf(unnamed))
+        // A passphrase wallet on the same device derives its own keys, so its name is its own.
+        whenever { hwWalletStore.loadPendingNames() }.thenReturn(mapOf("hidden-wallet" to "Hidden Stash"))
+        whenever(trezorService.connect(eq(DEVICE_ID), any())).thenReturn(features)
+        whenever(trezorService.scan()).thenReturn(listOf(mockDeviceInfo()))
+        whenever(
+            trezorService.getPublicKey(path = any(), coin = anyOrNull(), showOnTrezor = eq(false))
+        ).thenAnswer { mockPublicKeyResponse(xpub = sharedKey, path = it.getArgument(0)) }
+        sut = createSut()
+
+        sut.scan()
+        val result = sut.connect(DEVICE_ID)
+
+        assertTrue(result.isSuccess)
+        val captor = argumentCaptor<List<KnownDevice>>()
+        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        assertNull(captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
+        verify(hwWalletStore, never()).setPendingName(any(), anyOrNull())
     }
 
     @Test

--- a/app/src/test/java/to/bitkit/repositories/TrezorRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/TrezorRepoTest.kt
@@ -28,6 +28,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -113,7 +114,6 @@ class TrezorRepoTest : BaseUnitTest() {
         whenever(context.getString(R.string.hardware__device_busy)).thenReturn(DEVICE_BUSY_MESSAGE)
         whenever { hwWalletStore.loadKnownDevices() }.thenReturn(emptyList())
         whenever { hwWalletStore.loadPendingNames() }.thenReturn(emptyMap())
-        whenever { hwWalletStore.setPendingName(any(), anyOrNull()) }.thenReturn(Unit)
         stubAccountXpubFetch()
     }
 
@@ -241,7 +241,7 @@ class TrezorRepoTest : BaseUnitTest() {
         val result = sut.initialize()
 
         assertTrue(result.isSuccess)
-        verify(hwWalletStore, never()).saveKnownDevices(any())
+        verify(hwWalletStore, never()).saveKnownDevices(any(), anyOrNull())
         assertEquals("", sut.state.value.knownDevices.single().walletId)
     }
 
@@ -721,7 +721,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         val saved = captor.firstValue.single()
         assertEquals(DEVICE_ID, saved.id)
         assertEquals(TransportType.USB, saved.transportType)
@@ -767,7 +767,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         assertEquals(setOf(walletId), captor.firstValue.map { it.walletId }.toSet())
     }
 
@@ -789,7 +789,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         val saved = captor.firstValue
         assertEquals(2, saved.size)
         assertEquals(standard, saved.first())
@@ -828,7 +828,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         val added = captor.firstValue.single { it.id == DEVICE_ID }
         assertEquals("No Pass", added.customLabel)
         assertEquals("standard-wallet", added.walletId)
@@ -859,10 +859,10 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        // Consumed in the same write as the entry that adopted it, so a failed save cannot lose it,
+        // and clearing the name later cannot fall back to it again.
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), eq("standard-wallet"))
         assertEquals("Cold Storage", captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
-        // Consumed, so clearing the name later cannot fall back to it again.
-        verify(hwWalletStore).setPendingName("standard-wallet", null)
     }
 
     @Test
@@ -889,10 +889,9 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
-        assertEquals("Renamed Here", captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
         // The pending name lost, so it is stale: dropping it keeps a later rename from falling back to it.
-        verify(hwWalletStore).setPendingName("standard-wallet", null)
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), eq("standard-wallet"))
+        assertEquals("Renamed Here", captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
     }
 
     @Test
@@ -920,9 +919,8 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), isNull())
         assertNull(captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
-        verify(hwWalletStore, never()).setPendingName(any(), anyOrNull())
     }
 
     @Test
@@ -944,7 +942,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         val saved = captor.firstValue.single()
         assertEquals("new-device-id", saved.trezorDeviceId)
         assertTrue(saved.xpubs.values.none { it == "old-seed-xpub" })
@@ -969,7 +967,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         assertEquals(2, captor.firstValue.size)
         assertEquals(standard, captor.firstValue.first())
     }
@@ -993,7 +991,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         assertFalse(captor.firstValue.single().passphraseProtected)
     }
 
@@ -1017,7 +1015,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         assertTrue(captor.firstValue.single().passphraseProtected)
     }
 
@@ -1035,7 +1033,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         val saved = captor.firstValue.single()
         assertFalse(saved.passphraseProtected)
     }
@@ -1075,7 +1073,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         assertEquals(
             mapOf(
                 "nativeSegwit" to "native-xpub",
@@ -1101,7 +1099,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         assertEquals("Cold Storage", captor.lastValue.single().customLabel)
     }
 
@@ -1230,7 +1228,7 @@ class TrezorRepoTest : BaseUnitTest() {
         assertTrue(result.isFailure)
         assertEquals(DEVICE_BUSY_MESSAGE, sut.state.value.error)
         assertNull(sut.state.value.connectedDevice())
-        verify(hwWalletStore, never()).saveKnownDevices(any())
+        verify(hwWalletStore, never()).saveKnownDevices(any(), anyOrNull())
     }
 
     @Test
@@ -1277,7 +1275,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isFailure)
         assertNull(sut.state.value.connectedDevice())
-        verify(hwWalletStore, never()).saveKnownDevices(any())
+        verify(hwWalletStore, never()).saveKnownDevices(any(), anyOrNull())
     }
 
     @Test
@@ -1301,7 +1299,7 @@ class TrezorRepoTest : BaseUnitTest() {
         assertTrue(result.isFailure)
         assertEquals("DeviceDisconnected", sut.state.value.error)
         assertNull(sut.state.value.connectedDevice())
-        verify(hwWalletStore, never()).saveKnownDevices(any())
+        verify(hwWalletStore, never()).saveKnownDevices(any(), anyOrNull())
     }
 
     @Test
@@ -2084,7 +2082,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         assertEquals(emptyList(), captor.lastValue)
         assertTrue(sut.state.value.knownDevices.isEmpty())
     }
@@ -2220,7 +2218,7 @@ class TrezorRepoTest : BaseUnitTest() {
 
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
-        verify(hwWalletStore).saveKnownDevices(captor.capture())
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), anyOrNull())
         assertEquals(listOf(keptWhenStored), captor.lastValue)
     }
 

--- a/app/src/test/java/to/bitkit/repositories/TrezorRepoTest.kt
+++ b/app/src/test/java/to/bitkit/repositories/TrezorRepoTest.kt
@@ -36,6 +36,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import to.bitkit.R
 import to.bitkit.data.HwWalletStore
+import to.bitkit.data.PendingNameUpdate
 import to.bitkit.data.SettingsData
 import to.bitkit.data.SettingsStore
 import to.bitkit.env.Env
@@ -861,7 +862,7 @@ class TrezorRepoTest : BaseUnitTest() {
         val captor = argumentCaptor<List<KnownDevice>>()
         // Consumed in the same write as the entry that adopted it, so a failed save cannot lose it,
         // and clearing the name later cannot fall back to it again.
-        verify(hwWalletStore).saveKnownDevices(captor.capture(), eq("standard-wallet"))
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), eq(PendingNameUpdate("standard-wallet", name = null)))
         assertEquals("Cold Storage", captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
     }
 
@@ -890,7 +891,7 @@ class TrezorRepoTest : BaseUnitTest() {
         assertTrue(result.isSuccess)
         val captor = argumentCaptor<List<KnownDevice>>()
         // The pending name lost, so it is stale: dropping it keeps a later rename from falling back to it.
-        verify(hwWalletStore).saveKnownDevices(captor.capture(), eq("standard-wallet"))
+        verify(hwWalletStore).saveKnownDevices(captor.capture(), eq(PendingNameUpdate("standard-wallet", name = null)))
         assertEquals("Renamed Here", captor.firstValue.single { it.id == DEVICE_ID }.customLabel)
     }
 

--- a/app/src/test/java/to/bitkit/ui/screens/wallets/HwWalletViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/wallets/HwWalletViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -98,20 +99,57 @@ class HwWalletViewModelTest : BaseUnitTest() {
 
     @Test
     fun `removeDevice delegates to the repo and clears the pending device`() = test {
-        whenever { hwWalletRepo.removeDevice("dev1") }.thenReturn(Result.success(Unit))
+        whenever { hwWalletRepo.removeDevice("dev1", true) }.thenReturn(Result.success(Unit))
         val sut = createSut()
         sut.onRemoveClick(wallet)
 
         sut.removeDevice("dev1")
         advanceUntilIdle()
 
-        verify(hwWalletRepo).removeDevice("dev1")
+        verify(hwWalletRepo).removeDevice("dev1", true)
         assertNull(sut.uiState.value.isPendingRemoval)
     }
 
     @Test
+    fun `onRemoveClick offers to keep the backup data`() = test {
+        val sut = createSut()
+
+        sut.onRemoveClick(wallet)
+
+        assertEquals(true, sut.uiState.value.keepBackupDataOnRemoval)
+    }
+
+    @Test
+    fun `onRemoveClick restores the default after a wallet was removed without keeping its data`() = test {
+        whenever { hwWalletRepo.removeDevice(any(), any()) }.thenReturn(Result.success(Unit))
+        val sut = createSut()
+        sut.onRemoveClick(wallet)
+        sut.onKeepBackupDataChange(false)
+        sut.removeDevice("dev1")
+        advanceUntilIdle()
+
+        // Reopening starts from the default rather than from the last choice.
+        sut.onRemoveClick(otherWallet)
+
+        assertEquals(true, sut.uiState.value.keepBackupDataOnRemoval)
+    }
+
+    @Test
+    fun `removeDevice forwards the choice to keep nothing`() = test {
+        whenever { hwWalletRepo.removeDevice("dev1", false) }.thenReturn(Result.success(Unit))
+        val sut = createSut()
+        sut.onRemoveClick(wallet)
+        sut.onKeepBackupDataChange(false)
+
+        sut.removeDevice("dev1")
+        advanceUntilIdle()
+
+        verify(hwWalletRepo).removeDevice("dev1", false)
+    }
+
+    @Test
     fun `removeDevice sends an error toast on failure`() = test {
-        whenever { hwWalletRepo.removeDevice("dev1") }.thenReturn(Result.failure(AppError("nope")))
+        whenever { hwWalletRepo.removeDevice(any(), any()) }.thenReturn(Result.failure(AppError("nope")))
         val sut = createSut()
 
         val toasts = mutableListOf<Toast>()

--- a/app/src/test/java/to/bitkit/ui/screens/wallets/HwWalletViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/wallets/HwWalletViewModelTest.kt
@@ -19,6 +19,7 @@ import to.bitkit.R
 import to.bitkit.models.HwWallet
 import to.bitkit.models.Toast
 import to.bitkit.models.TransportType
+import to.bitkit.repositories.HwBackupDataUnreadableError
 import to.bitkit.repositories.HwWalletRepo
 import to.bitkit.repositories.HwWalletRepo.Companion.DEVICE_LABEL_MAX_LENGTH
 import to.bitkit.test.BaseUnitTest
@@ -63,6 +64,7 @@ class HwWalletViewModelTest : BaseUnitTest() {
         whenever(hwWalletRepo.walletsLoaded).thenReturn(MutableStateFlow(true))
         whenever(context.getString(R.string.common__error)).thenReturn("Error")
         whenever(context.getString(R.string.hardware__remove_error)).thenReturn("Could not remove")
+        whenever(context.getString(R.string.hardware__remove_keep_error)).thenReturn("Could not keep the tags")
         whenever(context.getString(R.string.hardware__rename_error)).thenReturn("Could not rename")
     }
 
@@ -158,6 +160,22 @@ class HwWalletViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         assertEquals(Toast.ToastType.ERROR, toasts.single().type)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `removeDevice explains an unreadable backup data failure`() = test {
+        whenever { hwWalletRepo.removeDevice(any(), any()) }
+            .thenReturn(Result.failure(HwBackupDataUnreadableError(AppError("core unavailable"))))
+        val sut = createSut()
+
+        val toasts = mutableListOf<Toast>()
+        val collectJob = launch { ToastEventBus.events.collect { toasts.add(it) } }
+        sut.removeDevice("dev1")
+        advanceUntilIdle()
+
+        // The generic retry message would hide that removing without keeping the data still works.
+        assertEquals("Could not keep the tags", toasts.single().description)
         collectJob.cancel()
     }
 

--- a/changelog.d/next/1173.added.md
+++ b/changelog.d/next/1173.added.md
@@ -1,0 +1,1 @@
+The name you give a hardware wallet is now included in your backup and comes back when you pair the device again, and removing a hardware wallet asks first whether to keep its name and tags in your backup.


### PR DESCRIPTION
This PR:

1. Backs up the name you give a hardware wallet, and restores it when the device is paired again.
2. Asks, when removing a hardware wallet, whether to keep its name and tags in the backup, defaulting to keeping them.

Follow-up to #1163, which closed #1046 by making hardware wallet tags survive backup and restore.

### Description

#1163 made hardware wallet tags survive a restore: they ride the metadata backup as pre-activity metadata keyed by the Core-derived wallet id, and Core re-attaches them once the device watcher recreates the activities. Two gaps were left behind.

The name itself was never backed up. It lives only in the local device store, so restoring on a new phone and pairing the Trezor again brought the tags back but not the name the user chose. Nothing even marked a backup as required when a name changed, so a rename was invisible to the backup system entirely.

The second gap is the more damaging one. Removing a hardware wallet destroyed its tags in the backup, silently. Core deletes a wallet's activities, its activity tags and its pre-activity metadata in one cascade, which is both of the sources the metadata envelope draws hardware tags from, and the deletion then signals that tags changed, so a metadata envelope without them was uploaded within seconds. The dialog said only that funds are safe and coins will not be deleted; it never mentioned the tags. A full wallet wipe was never affected, because wiping suppresses uploads and leaves the stored backup intact.

The name travels on the same key the tags already use. Core's wallet id derives from a device's account extended public keys, is stable across installs and platforms, and does not depend on the order of those keys, so a name keyed by it survives a restore exactly as well as the tags do.

The name of a paired wallet still lives on its device entry, which is untouched. What is new is a small pending map for the two moments when no device entry exists: a name restored from a backup before the device has been paired again, and a name kept when a wallet was removed. Pairing takes the entry over and consumes it in the same write that stores the entry, so the name is never in both places or in neither, and a failed save leaves it pending rather than losing it.

Removal takes the name and tag snapshot before the cascade and writes the tags back after it, carrying the name in the same store write that forgets the device entries. Splitting those two writes published a device list that still held the wallet being removed, and a watcher reconcile reading it restarted that wallet's watcher, which silently re-created the activities the removal had just deleted. The two kinds of data are kept independently: a wallet that was never renamed still keeps its tags, which is the more common shape by far. Turning the toggle off is the current behaviour made explicit: the tags go, and any name kept from an earlier removal of the same wallet is dropped too.

The watcher cleanup that removes activity scopes without a known device now reads its input under the same lock as the removal, and only considers wallets that still have activities to clear. Core drops a wallet's tag metadata along with its activities whether or not any matched, so cleaning up a wallet that has none is not a no-op: it takes the metadata a removal deliberately kept.

Two failure points are treated differently on purpose, because the cascade sits between them. Failing to read the tags happens before anything is deleted, so the wallet is untouched and the removal is refused with a message naming the way through — retry, or remove without keeping the data. Failing to write them back happens after the activities are already gone and the watchers already stopped, where there is nothing to roll back to and reporting a failed removal would be false, so that one is logged and the removal completes.

One behaviour falls out of this for free: re-pairing a wallet that was removed with the toggle on restores its tags with no restore flow involved at all, because the pre-activity metadata rows survived locally and Core re-attaches them as the watcher recreates the activities.

The envelope is shared with iOS, whose model mirrors it field for field. Swift ignores unknown keys when decoding, so an older iOS build restores this envelope without trouble, but it drops the new field whenever it re-uploads, and it re-uploads often. A user running both apps on one seed would lose their backed-up names until the iOS side ships. Unlike the tags in #1163, which rode a field iOS already knew, this is a new field, so a companion iOS change is needed. A passthrough that decodes and re-encodes the field, with no UI, is enough to close the window.

### Preview

https://github.com/user-attachments/assets/f297506b-a533-4d35-b1fb-6ff94648d0f0


https://github.com/user-attachments/assets/8d42d509-e350-4c05-abc2-ba0479624c6c



https://github.com/user-attachments/assets/7d3b3185-446f-4e82-a805-5427b6291a92



### QA Notes

#### Manual Tests

- [x] **1.** Hardware Wallet → rename the wallet → Settings → Data Backups: Tags shows as synced again.
- [x] **2.** `regression:` Disconnect and reconnect the device without renaming → Settings → Data Backups: Tags is not re-uploaded.
- [x] **3.** Rename a hardware wallet and tag one of its transactions → wipe wallet → restore from seed → pair the device again: the tile shows the custom name and the tagged transaction shows its tags.
- [x] **4a.** Hardware Wallet → Remove with the keep toggle on → pair the device again: name and tags return.
  - [x] **4b.** Remove with the keep toggle off → pair the device again: the wallet comes back under the device's own name with no tags.
  - [x] **4c.** Never-renamed wallet with tagged transactions → Remove with the keep toggle on → pair the device again: the tags return.
- [x] **5.** Settings → Hardware Wallets → trash icon: the same dialog opens, with the toggle on by default.
- [x] **6.** Remove dialog → turn the toggle off → cancel → reopen the dialog: the toggle is on again.
- [x] **7.** Passphrase wallet → Remove with the keep toggle on → pair again with the same passphrase: its own name returns, and the standard wallet's name is unaffected.
- [x] **8.** `regression:` Remove dialog → cancel: the wallet stays paired with its name and tags.


#### Automated Checks

- Unit tests added: cover the envelope and the restore in `BackupRepoTest.kt`, including that a failed name read fails the backup without uploading, that an envelope written before this field never clears stored names, that a failed name write still records the category as restored, and that a rename triggers a metadata backup while a reconnect does not.
- Unit tests added: cover the removal in `HwWalletRepoTest.kt`, pinning that the tag rewrite follows Core's cascade and that the kept name rides the write that forgets the device, plus the toggle-off branch, the default, a wallet keeping its tags without ever having been renamed, a removal surviving a failed rewrite, an unreadable-tags failure leaving the wallet entirely untouched, and a removal deleting a wallet's activities exactly once.
- The watcher-cleanup interleaving behind the double-removal case needs real concurrency and is not reproducible on the test dispatcher, so it is covered by manual test 11 rather than by a unit test. What is unit tested is the resulting rule: only a wallet with activities left behind is cleaned up.
- Unit tests added: cover pairing in `TrezorRepoTest.kt`, covering adopting and consuming a pending name in a single store write, preferring a name set locally, and leaving another identity's name alone.
- Unit tests added: cover the wallet-scoped tag snapshot in `ActivityRepoTest.kt`. It unions the stored and the rendered metadata, because the cascade drops both and only the rendered half can be rebuilt from activity tags.
- Unit tests added: cover the toggle in `HwWalletViewModelTest.kt`, including that it returns to its default when the dialog is reopened, and that an unreadable-tags failure is reported with its own message rather than the generic retry one.
- Local `just compile`, `just test` and `just lint` pass, with no new detekt findings.
