### PR TITLE
chore: use ldk-node rc.63

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.62" }
+ldk-node-android = { module = "com.synonym:ldk-node-android", version = "0.7.0-rc.63" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }


### PR DESCRIPTION
### Description

This PR pins `ldk-node-android` from `0.7.0-rc.62` to `0.7.0-rc.63` so Android master uses the same production Lightning stack as iOS for 2.4.1.

- Drops the `0.2.2-accept-stale-monitors` rust-lightning fork (BITKIT-SEC-004). Stale monitor mismatches fail closed with `DangerousValue`.
- Pin only. `#1155` already removed `setAcceptStaleChannelMonitors`; `ElectrumSyncConfig` already has the extra fields, so no app code change.

Release: https://github.com/synonymdev/ldk-node/releases/tag/v0.7.0-rc.63

Intended for cherry-pick onto `release-2.4.1`.

Companion: https://github.com/synonymdev/bitkit-ios/pull/679

### Preview

N/A — dependency pin only.

### QA Notes

#### Manual Tests

- [x] `regression:` Launch an existing wallet with channels and send to iOS `#679`

#### Automated Checks

- `just compile` (`compileDevDebugKotlin`) succeeded against `com.synonym:ldk-node-android:0.7.0-rc.63`.
- No UDL call-site fallout.
- CI: standard compile, unit test, and detekt checks run by the PR bot.
