### PR TITLE
chore: sync 2.4.1 onto master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-08-21
+
+### Changed
+- Bitkit now keeps the Lightning node running a little longer when you briefly leave the app, so quick trips to another app no longer reload the wallet on return. #1146
+
+### Fixed
+- Lightning node teardown now releases native resources deterministically and no longer restarts the node when the app is only briefly backgrounded. #1100
+- Fixed native library compatibility on Android devices using 16 KB memory pages. #1107
+- Lightning node shutdown and peer persistence now complete without native crashes or app hangs. #1122
+- Fixed Pubky authorization links opening Bitkit when the feature is unavailable or no local identity can approve them. #1162
+- Fixed the wallet backup failing repeatedly when Paykit state could not be read. #1092
+- Hardened background task error handling to prevent rare crashes. #1094
+
+### Security
+- Lightning no longer automatically starts from outdated channel monitor data after a storage mismatch. #1155
+- Wallet backups no longer fall back to unauthenticated VSS when LNURL-auth is missing. #1156
+- Shop checkout only accepts Bitrefill payment requests, and payment links wait until the wallet is unlocked. #1158
+- Wallet backups now use VSS 0.5.23, which rejects unauthenticated encryption. #1164
+
 ## [2.4.0] - 2026-07-15
 
 ### Added
@@ -148,7 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - About screen (content merged into Support) #857
 - Standalone General, Security, and Advanced settings screens (merged into tabs) #857
 
-[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/synonymdev/bitkit-android/compare/v2.4.1...HEAD
+[2.4.1]: https://github.com/synonymdev/bitkit-android/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/synonymdev/bitkit-android/compare/v2.3.2...v2.4.0
 [2.3.2]: https://github.com/synonymdev/bitkit-android/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/synonymdev/bitkit-android/compare/v2.3.0...v2.3.1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -186,8 +186,8 @@ android {
         applicationId = "to.bitkit"
         minSdk = 28
         targetSdk = 36
-        versionCode = 187
-        versionName = "2.4.0"
+        versionCode = 188
+        versionName = "2.4.1"
         testInstrumentationRunner = "to.bitkit.test.HiltTestRunner"
         bitkitAndroidTestAnnotation?.let {
             testInstrumentationRunnerArguments["annotation"] = it

--- a/changelog.d/next/1092.fixed.md
+++ b/changelog.d/next/1092.fixed.md
@@ -1,1 +1,0 @@
-Fixed the wallet backup failing repeatedly when Paykit state could not be read.

--- a/changelog.d/next/1094.fixed.md
+++ b/changelog.d/next/1094.fixed.md
@@ -1,1 +1,0 @@
-Hardened background task error handling to prevent rare crashes.

--- a/changelog.d/next/1100.fixed.md
+++ b/changelog.d/next/1100.fixed.md
@@ -1,1 +1,0 @@
-Lightning node teardown now releases native resources deterministically and no longer restarts the node when the app is only briefly backgrounded.

--- a/changelog.d/next/1107.fixed.md
+++ b/changelog.d/next/1107.fixed.md
@@ -1,1 +1,0 @@
-Fixed native library compatibility on Android devices using 16 KB memory pages.

--- a/changelog.d/next/1122.fixed.md
+++ b/changelog.d/next/1122.fixed.md
@@ -1,1 +1,0 @@
-Lightning node shutdown and peer persistence now complete without native crashes or app hangs.

--- a/changelog.d/next/1146.changed.md
+++ b/changelog.d/next/1146.changed.md
@@ -1,1 +1,0 @@
-Bitkit now keeps the Lightning node running a little longer when you briefly leave the app, so quick trips to another app no longer reload the wallet on return.

--- a/changelog.d/next/1155.security.md
+++ b/changelog.d/next/1155.security.md
@@ -1,1 +1,0 @@
-Lightning no longer automatically starts from outdated channel monitor data after a storage mismatch.

--- a/changelog.d/next/1156.security.md
+++ b/changelog.d/next/1156.security.md
@@ -1,1 +1,0 @@
-Wallet backups no longer fall back to unauthenticated VSS when LNURL-auth is missing.

--- a/changelog.d/next/1158.security.md
+++ b/changelog.d/next/1158.security.md
@@ -1,1 +1,0 @@
-Shop checkout only accepts Bitrefill payment requests, and payment links wait until the wallet is unlocked.

--- a/changelog.d/next/1162.fixed.md
+++ b/changelog.d/next/1162.fixed.md
@@ -1,1 +1,0 @@
-Fixed Pubky authorization links opening Bitkit when the feature is unavailable or no local identity can approve them.

--- a/changelog.d/next/1164.security.md
+++ b/changelog.d/next/1164.security.md
@@ -1,1 +1,0 @@
-Wallet backups now use VSS 0.5.23, which rejects unauthenticated encryption.


### PR DESCRIPTION
This PR records the shipped 2.4.1 hotfix on master so the next release does not reuse those changelog entries.

Do not merge `release-2.4.1` (#1174). That branch was cut from `v2.4.0` and already contains later 2.5.0 work on master.

### Description

- Bumps `versionCode` 187 → 188 and `versionName` 2.4.0 → 2.4.1
- Inserts the shipped `## [2.4.1]` changelog section
- Removes consumed `changelog.d/next/` fragments: #1092, #1094, #1100, #1107, #1122, #1146, #1155, #1156, #1158, #1162, #1164

### Preview

N/A

### QA Notes

#### Manual Tests

N/A

#### Automated Checks

N/A

Made with [Cursor](https://cursor.com)