### PR TITLE
fix: unblock send sheet after failed hw broadcast

### DIFF
--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/HwSendSignScreen.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/HwSendSignScreen.kt
@@ -1,5 +1,6 @@
 package to.bitkit.ui.screens.wallets.send
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -54,19 +55,23 @@ fun HwSendSignScreen(
         tags = sendUiState.selectedTags,
     )
 
+    val onBackRequest: () -> Unit = { if (!uiState.isSigning && !uiState.isBroadcastUnresolved) onBack() }
+
     LaunchedEffect(walletId) {
         viewModel.warmUp(walletId)
     }
     DisposableEffect(viewModel) {
         onDispose(viewModel::cancel)
     }
+    // Without this the sheet's NavHost pops the route itself, ignoring the guard and skipping onBack
+    BackHandler(onBack = onBackRequest)
 
     HwSendSignContent(
         amountSats = sendUiState.amount,
         address = sendUiState.address,
         isSigning = uiState.isSigning,
         hasPendingBroadcast = uiState.hasPendingBroadcast,
-        onBack = { if (!uiState.isSigning && !uiState.isBroadcastUnresolved) onBack() },
+        onBack = onBackRequest,
         onOpenConnect = { viewModel.signAndBroadcast(request, prepareContactPayment) },
     )
 

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/HwSendViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/HwSendViewModel.kt
@@ -288,8 +288,8 @@ class HwSendViewModel @Inject constructor(
             pendingBroadcast != null &&
                 (error.isBroadcastConnectivityFailure() || error is TimeoutCancellationException) -> ToastEventBus.send(
                 type = Toast.ToastType.WARNING,
-                title = context.getString(R.string.other__connection_issue),
-                description = context.getString(R.string.other__connection_issues_explain),
+                title = context.getString(R.string.hardware__send_broadcast_failed_title),
+                description = context.getString(R.string.hardware__send_broadcast_failed_text),
             )
             error is TimeoutCancellationException -> ToastEventBus.send(
                 type = Toast.ToastType.ERROR,

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/HwSendViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/HwSendViewModel.kt
@@ -267,6 +267,8 @@ class HwSendViewModel @Inject constructor(
     }
 
     private suspend fun handleFailure(error: Throwable, walletId: String) {
+        // A signed transaction stays behind for a retry
+        _uiState.update { it.copy(isBroadcastUnresolved = false) }
         when {
             error.isTrezorUserCancellation() -> {
                 Logger.info("Hardware send cancelled on device for '$walletId'", context = TAG)
@@ -297,12 +299,7 @@ class HwSendViewModel @Inject constructor(
             else -> {
                 if (pendingBroadcast != null) {
                     pendingBroadcast = null
-                    _uiState.update {
-                        it.copy(
-                            hasPendingBroadcast = false,
-                            isBroadcastUnresolved = false,
-                        )
-                    }
+                    _uiState.update { it.copy(hasPendingBroadcast = false) }
                 }
                 ToastEventBus.send(error)
             }

--- a/app/src/main/java/to/bitkit/ui/screens/wallets/send/HwSendViewModel.kt
+++ b/app/src/main/java/to/bitkit/ui/screens/wallets/send/HwSendViewModel.kt
@@ -267,7 +267,6 @@ class HwSendViewModel @Inject constructor(
     }
 
     private suspend fun handleFailure(error: Throwable, walletId: String) {
-        // A signed transaction stays behind for a retry
         _uiState.update { it.copy(isBroadcastUnresolved = false) }
         when {
             error.isTrezorUserCancellation() -> {

--- a/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
+++ b/app/src/main/java/to/bitkit/ui/sheets/SendSheet.kt
@@ -321,7 +321,7 @@ fun SendSheet(
                                 ?.savedStateHandle
                                 ?.set(HARDWARE_SIGN_CANCELLED_RESULT_KEY, true)
                             appViewModel.onHardwareSignCancelled()
-                            navController.popBackStack()
+                            if (!navController.popBackStack()) appViewModel.hideSheet()
                         },
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,8 @@
     <string name="hardware__remove_keep_error">Could not keep this wallet\'s tags in your backup. Try again, or remove it without keeping them.</string>
     <string name="hardware__rename_error">Could not rename the hardware wallet. Please try again.</string>
     <string name="hardware__search_error">Could not search for hardware wallets. Check your connection and try again.</string>
+    <string name="hardware__send_broadcast_failed_text">Check your connection and try again.</string>
+    <string name="hardware__send_broadcast_failed_title">Payment not sent</string>
     <string name="hardware__send_confirm_address">TO ADDRESS (CONFIRM ON DEVICE)</string>
     <string name="hardware__send_onchain_only_text">Trezor can only send to a Bitcoin address from this wallet.</string>
     <string name="hardware__send_onchain_only_title">Bitcoin address required</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,7 +214,7 @@
     <string name="hardware__rename_error">Could not rename the hardware wallet. Please try again.</string>
     <string name="hardware__search_error">Could not search for hardware wallets. Check your connection and try again.</string>
     <string name="hardware__send_broadcast_failed_text">Check your connection and try again.</string>
-    <string name="hardware__send_broadcast_failed_title">Payment not sent</string>
+    <string name="hardware__send_broadcast_failed_title">Payment not confirmed</string>
     <string name="hardware__send_confirm_address">TO ADDRESS (CONFIRM ON DEVICE)</string>
     <string name="hardware__send_onchain_only_text">Trezor can only send to a Bitcoin address from this wallet.</string>
     <string name="hardware__send_onchain_only_title">Bitcoin address required</string>

--- a/app/src/test/java/to/bitkit/ui/screens/wallets/send/HwSendViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/wallets/send/HwSendViewModelTest.kt
@@ -33,6 +33,7 @@ import to.bitkit.ui.shared.toast.ToastEventBus
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HwSendViewModelTest : BaseUnitTest() {
@@ -229,7 +230,8 @@ class HwSendViewModelTest : BaseUnitTest() {
     fun `broadcast timeout unblocks navigation`() = test {
         whenever(context.getString(any())).thenReturn("message")
         val fixture = stubSuccessfulPayment()
-        val timeout = runCatching { withTimeout(0) { Unit } }.exceptionOrNull() as TimeoutCancellationException
+        val timeout = runCatching { withTimeout(Duration.ZERO) { Unit } }
+            .exceptionOrNull() as TimeoutCancellationException
         whenever(hwWalletRepo.broadcastFunding(fixture.signedTx)).thenReturn(Result.failure(timeout))
 
         sut.signAndBroadcast(request())

--- a/app/src/test/java/to/bitkit/ui/screens/wallets/send/HwSendViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/wallets/send/HwSendViewModelTest.kt
@@ -210,6 +210,82 @@ class HwSendViewModelTest : BaseUnitTest() {
         assertFalse(sut.uiState.value.isBroadcastUnresolved)
     }
 
+    @Test
+    fun `broadcast connectivity failure unblocks navigation`() = test {
+        whenever(context.getString(any())).thenReturn("message")
+        val fixture = stubSuccessfulPayment()
+        whenever(hwWalletRepo.broadcastFunding(fixture.signedTx))
+            .thenReturn(Result.failure(BroadcastException.ElectrumException("connection failed")))
+
+        sut.signAndBroadcast(request())
+        advanceUntilIdle()
+
+        assertFalse(sut.uiState.value.isBroadcastUnresolved)
+        assertTrue(sut.uiState.value.hasPendingBroadcast)
+        assertFalse(sut.uiState.value.isSigning)
+    }
+
+    @Test
+    fun `broadcast timeout unblocks navigation`() = test {
+        whenever(context.getString(any())).thenReturn("message")
+        val fixture = stubSuccessfulPayment()
+        val timeout = runCatching { withTimeout(0) { Unit } }.exceptionOrNull() as TimeoutCancellationException
+        whenever(hwWalletRepo.broadcastFunding(fixture.signedTx)).thenReturn(Result.failure(timeout))
+
+        sut.signAndBroadcast(request())
+        advanceUntilIdle()
+
+        assertFalse(sut.uiState.value.isBroadcastUnresolved)
+        assertTrue(sut.uiState.value.hasPendingBroadcast)
+        assertFalse(sut.uiState.value.isSigning)
+    }
+
+    @Test
+    fun `broadcast failure warns the payment was not sent`() = test {
+        val toasts = mutableListOf<Toast>()
+        val toastJob = launch { ToastEventBus.events.collect { toasts.add(it) } }
+        val fixture = stubSuccessfulPayment()
+        whenever(hwWalletRepo.broadcastFunding(fixture.signedTx))
+            .thenReturn(Result.failure(BroadcastException.ElectrumException("connection failed")))
+        whenever(context.getString(R.string.hardware__send_broadcast_failed_title)).thenReturn("Payment not sent")
+        whenever(context.getString(R.string.hardware__send_broadcast_failed_text))
+            .thenReturn("Check your connection and try again.")
+
+        sut.signAndBroadcast(request())
+        advanceUntilIdle()
+        toastJob.cancel()
+
+        assertEquals(Toast.ToastType.WARNING, toasts.single().type)
+        assertEquals("Payment not sent", toasts.single().title)
+        assertEquals("Check your connection and try again.", toasts.single().description)
+    }
+
+    @Test
+    fun `cancel drops the signed transaction after a failed broadcast`() = test {
+        whenever(context.getString(any())).thenReturn("message")
+        val fixture = stubSuccessfulPayment()
+        whenever(hwWalletRepo.disconnectStaleSession(WALLET_ID)).thenReturn(Result.success(Unit))
+        whenever(hwWalletRepo.broadcastFunding(fixture.signedTx)).thenReturn(
+            Result.failure(BroadcastException.ElectrumException("connection failed")),
+            Result.success(fixture.broadcast),
+        )
+
+        sut.signAndBroadcast(request())
+        advanceUntilIdle()
+        assertTrue(sut.uiState.value.hasPendingBroadcast)
+
+        sut.cancel()
+        advanceUntilIdle()
+
+        assertFalse(sut.uiState.value.hasPendingBroadcast)
+        verify(hwWalletRepo).disconnectStaleSession(WALLET_ID)
+
+        sut.signAndBroadcast(request())
+        advanceUntilIdle()
+
+        verify(hwWalletRepo, times(2)).signFunding(WALLET_ID, fixture.funding)
+    }
+
     private suspend fun stubSuccessfulPayment(): PaymentFixture {
         val funding = HwFundingTransaction(
             psbt = "psbt",

--- a/app/src/test/java/to/bitkit/ui/screens/wallets/send/HwSendViewModelTest.kt
+++ b/app/src/test/java/to/bitkit/ui/screens/wallets/send/HwSendViewModelTest.kt
@@ -241,13 +241,13 @@ class HwSendViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `broadcast failure warns the payment was not sent`() = test {
+    fun `broadcast failure warns the payment was not confirmed`() = test {
         val toasts = mutableListOf<Toast>()
         val toastJob = launch { ToastEventBus.events.collect { toasts.add(it) } }
         val fixture = stubSuccessfulPayment()
         whenever(hwWalletRepo.broadcastFunding(fixture.signedTx))
             .thenReturn(Result.failure(BroadcastException.ElectrumException("connection failed")))
-        whenever(context.getString(R.string.hardware__send_broadcast_failed_title)).thenReturn("Payment not sent")
+        whenever(context.getString(R.string.hardware__send_broadcast_failed_title)).thenReturn("Payment not confirmed")
         whenever(context.getString(R.string.hardware__send_broadcast_failed_text))
             .thenReturn("Check your connection and try again.")
 
@@ -256,7 +256,7 @@ class HwSendViewModelTest : BaseUnitTest() {
         toastJob.cancel()
 
         assertEquals(Toast.ToastType.WARNING, toasts.single().type)
-        assertEquals("Payment not sent", toasts.single().title)
+        assertEquals("Payment not confirmed", toasts.single().title)
         assertEquals("Check your connection and try again.", toasts.single().description)
     }
 

--- a/changelog.d/next/1230.fixed.md
+++ b/changelog.d/next/1230.fixed.md
@@ -1,0 +1,1 @@
+A hardware wallet payment whose broadcast fails no longer leaves the send screen and sheet stuck, and Bitkit now says the payment could not be confirmed instead of reporting a generic connection problem.


### PR DESCRIPTION
This PR:
1. Fixes a hardware wallet send whose broadcast fails leaving the whole Send sheet undismissable
2. Routes the system back button through the sign screen's own back handling
3. Replaces the generic connectivity warning with one that names the payment

### Description

When a Trezor has signed a payment but the broadcast fails on connectivity, the sign screen used to
keep the payment marked as unresolved forever. That state blocks the back arrow, the sheet's scrim
and swipe-to-dismiss, so the user was stuck with no way out. Because the send view model lives for
as long as the activity, the block leaked past the sheet: every later Send sheet, hardware wallet or
not, was undismissable too, and only force-stopping the app recovered. The signed transaction was
never broadcast, so no funds moved — but the app was unusable until restarted.

The payment is now released as soon as the attempt ends, whatever the outcome. Retry still works
without asking the device to sign again while the user stays on the screen, and leaving the screen
discards the signed transaction and releases the device session.

System back was a second, independent problem. The Send sheet's own navigation was handling it
before the sheet could, so it popped the sign screen directly and skipped the cancellation the back
arrow performs. That left the review screen's swipe-to-confirm stuck in its confirmed state and, for
Paykit payment requests, left the request marked as being paid. Both back paths now go through the
same handling, and backing out of a sign screen with nothing left to return to closes the sheet
rather than doing nothing.

Finally, the failure was reported with the generic "Internet Connectivity Issues" copy, which says
nothing about the payment. It now reads "Payment not confirmed". The wording is deliberate: this
path also covers a broadcast that timed out, where the transaction may well have reached the
network, so it avoids claiming the payment was not sent. Retrying is safe either way — the core
library treats an already-known transaction as a successful broadcast.

Reviewed but deliberately left alone: the transfer-to-spending flow keeps its signed transaction the
same way, but nothing there gates navigation on it and a mismatched order re-signs, so it has
neither the lockout nor a stale-state trap.

Known follow-up, pre-existing and out of scope here: broadcast errors cannot currently distinguish a
transport failure from a node rejection, because bitkit-core reports both as an Electrum error. A
permanently rejected transaction therefore keeps offering Retry without surfacing the real reason.

### Preview

Same flow recorded twice against the Trezor emulator: sign a 50,000 sat send, drop the network
before the broadcast, then restore it fully before trying to leave. The Trezor Bridge is on device
loopback via `adb reverse`, so airplane mode takes out Electrum without touching signing.


https://github.com/user-attachments/assets/ca03fe91-8acd-40e0-a38a-43ae25af68fb


https://github.com/user-attachments/assets/d90f4183-fa8c-4dc7-80ab-2a76aa55cf24



### QA Notes

#### Manual Tests

Cutting the phone's network right after the device signs is what reproduces this. Stopping the local
Electrum container does not work if the wallet points at a remote Electrum server.

- [x] **1.** Send → Enter Manually → address → Continue → pick the Trezor source → amount →
  Continue → swipe to pay → Open Trezor Connect → approve up to Summary → approve Summary and
  immediately run `adb shell cmd connectivity airplane-mode enable`: a "Payment not confirmed"
  warning shows and the button becomes Retry.
- [x] **2a.** Still on Hardware Send Sign → tap the back arrow: returns to Send Confirm.
  - [x] **2b.** Send Confirm → the swipe-to-confirm control is usable again, not stuck confirmed.
  - [x] **2c.** Hardware Send Sign → system back instead of the arrow: same result as 2a.
- [x] **3a.** After backing out → tap the scrim above the sheet: the sheet closes.
  - [x] **3b.** Swipe the sheet down instead: the sheet closes.

Journey covering the above, as a patch to apply on `master` where it fails at step 2a:

<details>
<summary>send-broadcast-failure-recovery.xml</summary>

```diff
diff --git a/journeys/hardware-wallet/README.md b/journeys/hardware-wallet/README.md
index 7d4e5ae58..2cd0b984c 100644
--- a/journeys/hardware-wallet/README.md
+++ b/journeys/hardware-wallet/README.md
@@ -81,6 +81,7 @@ the other three rely on, and `passphrase-settings-remove.xml` removes it again.
 | `transfer-to-spending-node-warmup.xml` | Transfer started during app/node warm-up; verifies loading recovers into the sign screen |
 | `send-onchain.xml` | Normal Send flow funded by Trezor: source selection, guarded preparation, device signing, broadcast, success, and activity |
 | `receive-onchain.xml` | Trezor Receive tab: current address and QR display plus exact on-device address verification |
+| `send-broadcast-failure-recovery.xml` | Signed send whose broadcast loses connectivity: unconfirmed-payment warning, Retry, and back/dismiss all still work |
 | `passphrase-pairing.xml` | Passphrase button on Paired → Enter Passphrase → Passphrase Funds Found; second home tile, own label, no passphrase in logs |
 | `passphrase-duplicate.xml` | Re-entering a watched passphrase reports "already added" and adds no tile |
 | `passphrase-settings-remove.xml` | Per-identity settings row, rename and delete; removing the hidden wallet keeps the device paired |
diff --git a/journeys/hardware-wallet/send-broadcast-failure-recovery.xml b/journeys/hardware-wallet/send-broadcast-failure-recovery.xml
new file mode 100644
index 000000000..04b748982
--- /dev/null
+++ b/journeys/hardware-wallet/send-broadcast-failure-recovery.xml
@@ -0,0 +1,87 @@
+<journey name="Hardware Wallet Send Broadcast Failure Recovery">
+  <description>
+    Signs an on-chain payment on a paired Trezor and then loses connectivity before the broadcast
+    completes, so the transaction is signed but never confirmed as sent. Verifies the user can leave
+    the sign screen, dismiss the Send sheet, and start a new send afterwards, and that the failure is
+    reported as an unconfirmed payment rather than a generic connectivity problem.
+
+    On master this journey fails: the sign screen keeps the signed transaction "unresolved" forever
+    after a connectivity failure, which blocks the back arrow and the sheet's scrim and swipe-to-
+    dismiss. Because the view model is Activity-scoped, every later Send sheet is undismissable too
+    and only force-stopping the app recovers. Requires a paired Bridge emulator whose native-segwit
+    account holds spendable regtest funds and a valid regtest destination address.
+  </description>
+  <actions>
+    <action>
+      Launch the Bitkit app and go to the wallet home screen
+    </action>
+    <action>
+      Tap the Send button (testTag "Send")
+    </action>
+    <action>
+      If a camera permission dialog appears, dismiss it by choosing "Don't allow"
+    </action>
+    <action>
+      Tap "Enter Manually" (testTag "RecipientManual"), type a valid regtest bitcoin address into
+      the recipient field (testTag "RecipientInput"), then tap Continue (testTag "AddressContinue")
+    </action>
+    <action>
+      Tap the funding-source button (testTag "AssetButton-switch"), waiting for any balance loading
+      to finish between taps, until it shows the paired Trezor name in blue
+    </action>
+    <action>
+      Enter a valid amount smaller than the Trezor AVAILABLE balance with the number pad, then tap
+      Continue (testTag "ContinueAmount")
+    </action>
+    <action>
+      Swipe to confirm the payment and verify the hardware sign screen opens with the "Open Trezor
+      Connect" button (testTag "HardwareSendOpenTrezorConnect")
+    </action>
+    <action>
+      Tap "Open Trezor Connect" and approve the Recipient, Amount and Confirm Locktime prompts on the
+      Bridge emulator, stopping once the device shows the Summary prompt
+    </action>
+    <action>
+      Approve the Summary prompt on the Bridge emulator and immediately afterwards run the next step,
+      so the signature returns over the Bridge but the broadcast cannot reach Electrum
+    </action>
+    <action>
+      adb: adb shell cmd connectivity airplane-mode enable
+    </action>
+    <action>
+      Verify a warning toast reports the payment could not be confirmed and names the payment, rather
+      than showing the generic "Internet Connectivity Issues" text
+    </action>
+    <action>
+      Verify the primary button on the sign screen now reads "Retry"
+      (testTag "HardwareSendOpenTrezorConnect")
+    </action>
+    <action>
+      Tap the back arrow on the sign screen and verify it returns to the Send review screen instead
+      of doing nothing
+    </action>
+    <action>
+      Verify the swipe-to-confirm control on the review screen is usable again rather than stuck in
+      its confirmed state
+    </action>
+    <action>
+      Dismiss the Send sheet by tapping the scrim above it, and verify the sheet closes and the
+      wallet home screen is visible
+    </action>
+    <action>
+      Tap the Send button (testTag "Send") again, then press the system back button and verify this
+      new Send sheet also closes
+    </action>
+    <action>
+      adb: adb shell cmd connectivity airplane-mode disable
+    </action>
+    <action>
+      Wait for connectivity to recover, then repeat the send: Send → Enter Manually → same address →
+      Continue → select the Trezor funding source → same amount → Continue → swipe to confirm
+    </action>
+    <action>
+      Tap "Open Trezor Connect", approve every prompt on the Bridge emulator, and verify the payment
+      broadcasts and the success screen appears (testTag "SendSuccess")
+    </action>
+  </actions>
+</journey>
```

</details>

#### Automated Checks

- Unit tests added: `HwSendViewModelTest.kt` covers the released block on an Electrum failure and on
  a broadcast timeout, that cancelling drops the signed transaction and a later attempt re-signs,
  and that the warning carries the new copy.
- Verified the three state tests genuinely fail against the unfixed view model before the change,
  so they guard the regression rather than restate current behaviour.
- Existing coverage unchanged, including the success-path assertion that the payment stays
  unresolved until acknowledged.
- Local verification: `just compile`, `just test`, `just lint`.
- CI: standard compile, unit test, and detekt checks run by the PR bot.

