### PR TITLE
docs: cap commit subjects at 72 chars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ suspend fun getData(): Result<Data> = withContext(Dispatchers.IO) {
 - Use narrower checks earlier only when they answer an immediate risk, e.g. a single unit test after touching focused business logic or a Kotlin compile after a risky refactor.
 - ALWAYS ask clarifying questions to ensure an optimal plan when encountering functional or technical uncertainties in requests
 - ALWAYS when fixing lint or test failures prefer to do the minimal amount of changes to fix the issues
-- USE single-line commit messages under 50 chars; use conventional commit messages template format: `feat: add something new`
+- USE single-line commit messages under 72 chars; use conventional commit messages template format: `feat: add something new`
 - USE `git diff HEAD sourceFilePath` to diff an uncommitted file against the last commit
 - NEVER capitalize words in commit messages
 - ALWAYS create a `*-backup` branch before performing a rebase


### PR DESCRIPTION
This PR raises the commit subject limit in the agent rules from 50 to 72 characters, the conventional hard limit that GitHub and git tooling wrap at.

### Description

- Changes only the `USE single-line commit messages under N chars` rule in `AGENTS.md`.

### Preview

N/A — no user-visible changes.

### QA Notes

#### Manual Tests

N/A — documentation only.

#### Automated Checks

None; no code changed.
