### PR TITLE
docs: refresh screens map with figma refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ suspend fun getData(): Result<Data> = withContext(Dispatchers.IO) {
 - ALWAYS remove unused code after refactors
 - ALWAYS follow Material3 design guidelines for UI components
 - When building from a Figma frame, reuse only scaffolding (sheet host, `SheetTopBar`, buttons, typography); NEVER swap a design-specific illustration/animation for a lookalike. Export the frame's assets via the Figma MCP and read animation timing/easing/direction from prototype reactions (`use_figma` → `node.reactions`)
-- ALWAYS resolve a changed `*Screen.kt` to its Figma frame through `docs/screens-map.md` (`Flow › Frame` on the latest `Bitkit - Handoff vNN` page). When adding or removing a `*Screen.kt`, update its row there; `ScreensMapTest` fails otherwise
+- ALWAYS resolve a changed `*Screen.kt` to its Figma frame through `docs/screens-map.md` (`Flow › Frame` on the latest `Bitkit - Handoff vNN` page). When adding or removing a `*Screen.kt`, add or drop its row there (`todo` when the design does not exist yet); `ScreensMapTest` fails otherwise
 - ALWAYS ensure proper error handling in coroutines
 - ALWAYS acknowledge datastore async operations run synchronously in a suspend context
 - NEVER use `runBlocking` in suspend functions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,7 @@ suspend fun getData(): Result<Data> = withContext(Dispatchers.IO) {
 - ALWAYS remove unused code after refactors
 - ALWAYS follow Material3 design guidelines for UI components
 - When building from a Figma frame, reuse only scaffolding (sheet host, `SheetTopBar`, buttons, typography); NEVER swap a design-specific illustration/animation for a lookalike. Export the frame's assets via the Figma MCP and read animation timing/easing/direction from prototype reactions (`use_figma` → `node.reactions`)
+- ALWAYS resolve a changed `*Screen.kt` to its Figma frame through `docs/screens-map.md` (`Flow › Frame` on the latest `Bitkit - Handoff vNN` page). When adding or removing a `*Screen.kt`, update its row there; `ScreensMapTest` fails otherwise
 - ALWAYS ensure proper error handling in coroutines
 - ALWAYS acknowledge datastore async operations run synchronously in a suspend context
 - NEVER use `runBlocking` in suspend functions

--- a/app/src/test/java/to/bitkit/docs/ScreensMapTest.kt
+++ b/app/src/test/java/to/bitkit/docs/ScreensMapTest.kt
@@ -1,0 +1,43 @@
+package to.bitkit.docs
+
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertTrue
+
+/**
+ * Keeps `docs/screens-map.md` in sync with the `*Screen.kt` files in `app/src/main/java`.
+ */
+class ScreensMapTest {
+    private val projectRoot = generateSequence(File("").absoluteFile) { it.parentFile }
+        .first { File(it, "docs/screens-map.md").isFile }
+    private val screensMap = File(projectRoot, "docs/screens-map.md")
+    private val sourceRoot = File(projectRoot, "app/src/main/java")
+
+    @Test
+    fun `every screen has a map entry and every entry has a screen`() {
+        val screens = sourceRoot.walkTopDown()
+            .filter { it.isFile && it.name.endsWith("Screen.kt") }
+            .map { it.name }
+            .toSet()
+        val entries = SCREEN_ENTRY.findAll(screensMap.readText())
+            .map { it.value }
+            .toSet()
+
+        val missing = (screens - entries).sorted()
+        val stale = (entries - screens).sorted()
+
+        assertTrue(screens.isNotEmpty(), "No *Screen.kt files found under '$sourceRoot'")
+        assertTrue(
+            missing.isEmpty() && stale.isEmpty(),
+            buildString {
+                appendLine("docs/screens-map.md is out of sync with app/src/main/java.")
+                if (missing.isNotEmpty()) appendLine("Screens without a map entry: $missing")
+                if (stale.isNotEmpty()) appendLine("Map entries without a screen: $stale")
+            },
+        )
+    }
+
+    private companion object {
+        val SCREEN_ENTRY = Regex("""\b[A-Z]\w*Screen\.kt\b""")
+    }
+}

--- a/docs/screens-map.md
+++ b/docs/screens-map.md
@@ -1,173 +1,340 @@
-# RN ↔ Android screens mapping
+# Screens map
 
-Legend: RN = React Native screen, Android = Compose screen
+Every `*Screen.kt` under `app/src/main/java`, grouped by feature package, with the frame that renders it on the `Bitkit - Handoff vNN` page of the Bitkit Figma file (`ltqvnKiejWj0JQiqtDf2JJ`, always the highest `vNN`).
 
-## Wallet
-| RN | Android |
+Columns:
+
+- Android: the Compose screen file. Every `*Screen.kt` in the app has exactly one row; `ScreensMapTest` fails when a screen is added or removed without updating this file.
+- Figma: `Flow › Frame`, where Flow is the `SectionTitle` above the frame on the handoff page and Frame is the top-level frame name. `n/a` when the screen has no design (dev tools, debug screens).
+
+Frame names are stable across handoff iterations; node ids are not, so the map lists names only. Sheets, dialogs, and composables without the `Screen` suffix are out of scope.
+
+## appwidget/config
+
+| Android | Figma |
 | - | - |
-| Home.tsx | HomeScreen.kt |
-| ActivitySavings.tsx | SavingsWalletScreen.kt |
-| ActivitySpending.tsx | SpendingWalletScreen.kt |
+| AppWidgetConfigScreen.kt | `n/a` |
 
-## Activity
-| RN | Android |
-| - | - |
-| ActivityFiltered.tsx | AllActivityScreen.kt |
-| ActivityDetail.tsx | ActivityDetailScreen.kt + ActivityExploreScreen.kt |
+## ui
 
-## Send
-| RN | Android |
+| Android | Figma |
 | - | - |
-| Send/Amount.tsx | SendAmountScreen.kt |
-| Recipient.tsx | SendRecipientScreen.kt |
-| Address.tsx | SendAddressScreen.kt |
-| ReviewAndSend.tsx | SendConfirmScreen.kt |
-| FeeRate.tsx | SendFeeRateScreen.kt |
-| FeeCustom.tsx | SendFeeCustomScreen.kt |
-| CoinSelection.tsx | SendCoinSelectionScreen.kt |
-| SendPinPad.tsx | SendPinCheckScreen.kt |
-| Quickpay.tsx | SendQuickPayScreen.kt |
-| Tags.tsx | AddTagScreen.kt |
-| Error.tsx | SendErrorScreen.kt |
-| Pending.tsx | `todo` |
-| Send/Success.tsx | `todo` |
+| NodeInfoScreen.kt | Settings > Advanced › Advanced > Node ID |
 
-## Receive
-| RN | Android |
-| - | - |
-| ReceiveDetails.tsx | EditInvoiceScreen.kt |
-| ReceiveAmount.tsx | ReceiveAmountScreen.kt |
-| ReceiveQR.tsx | ReceiveQrScreen.kt |
-| ReceiveConnect.tsx | ReceiveConfirmScreen.kt |
-| ReceiveGeoBlocked.tsx | LocationBlockScreen.kt |
-| Receive/Liquidity.tsx | ReceiveLiquidityScreen.kt |
+## ui/components
 
-## Scanner
-| RN | Android |
+| Android | Figma |
 | - | - |
-| MainScanner.tsx | QrScanningScreen.kt |
+| AuthCheckScreen.kt | Active user › Enter PIN |
 
-## Transfer
-| RN | Android |
-| - | - |
-| TransferIntro.tsx | TransferIntroScreen.kt |
-| SpendingIntro.tsx | SpendingIntroScreen.kt |
-| SpendingConfirm.tsx | SpendingConfirmScreen.kt |
-| SavingsIntro.tsx | SavingsIntroScreen.kt |
-| SavingsConfirm.tsx | SavingsConfirmScreen.kt |
-| SavingsProgress.tsx | SavingsProgressScreen.kt |
-| SavingsAdvanced.tsx | SavingsAdvancedScreen.kt |
-| SpendingAmount.tsx | SpendingAmountScreen.kt |
-| Funding.tsx | FundingScreen.kt |
-| FundingAdvanced.tsx | FundingAdvancedScreen.kt |
-| SettingUp.tsx | SettingUpScreen.kt |
-| Transfer/Liquidity.tsx | LiquidityScreen.kt |
-| Availability.tsx | SavingsAvailabilityScreen.kt |
+## ui/onboarding
 
-## External Node / LNURL Channel
-| RN | Android |
+| Android | Figma |
 | - | - |
-| Connection.tsx | ExternalConnectionScreen.kt |
-| ExternalNode/Amount.tsx | ExternalAmountScreen.kt |
-| Confirm.tsx | ExternalConfirmScreen.kt |
-| ExternalNode/Success.tsx | ExternalSuccessScreen.kt |
-| LNURLChannel.tsx | LnurlChannelScreen.kt |
+| CreateWalletScreen.kt | New user › Wallet set up |
+| CreateWalletWithPassphraseScreen.kt | New user › Wallet set up advanced |
+| IntroScreen.kt | New user › Intro |
+| OnboardingSlidesScreen.kt | New user › Onboarding Self-Custody / Onboarding Lightning / Onboarding Privacy |
+| RestoreWalletScreen.kt | Restore wallet › Restore wallet |
+| TermsOfUseScreen.kt | New user › Acknowledgements |
+| WarningMultipleDevicesScreen.kt | Multiple Devices › Multiple Devices Warning |
 
-## Lnurl
-| RN | Android |
-| - | - |
-| LNURLWithdraw/Amount.tsx | SendAmountScreen.kt |
-| LNURLWithdraw/Confirm.tsx | WithdrawConfirmScreen.kt |
-| `n/a` | WithdrawErrorScreen.kt |
-| `n/a` | LnurlAuthSheet.kt |
+## ui/screens
 
-## Settings
-| RN | Android |
+| Android | Figma |
 | - | - |
-| Settings/index.tsx | SettingsScreen.kt |
-| General/index.tsx | GeneralSettingsScreen.kt |
-| Currencies/index.tsx | LocalCurrencySettingsScreen.kt |
-| Unit/index.tsx | DefaultUnitSettingsScreen.kt |
-| Tags/index.tsx | TagsSettingsScreen.kt |
-| Advanced/index.tsx | AdvancedSettingsScreen.kt |
-| AddressTypePreference/index.tsx | `n/a` |
-| BitcoinNetworkSelection.tsx | `n/a` |
-| CoinSelectPreference/index.tsx | CoinSelectPreferenceScreen.kt |
-| AddressViewer/index.tsx | AddressViewerScreen.kt |
-| GapLimit/index.tsx | `n/a` |
-| About/index.tsx | AboutScreen.kt |
-| AppStatus/index.tsx | AppStatusScreen.kt |
-| Widgets/index.tsx | AddWidgetsScreen.kt / WidgetsIntroScreen.kt |
-| WebRelay/index.tsx | `n/a` |
-| TransactionSpeed/index.tsx | TransactionSpeedSettingsScreen.kt |
-| CustomFee.tsx | CustomFeeSettingsScreen.kt |
-| QuickpayIntro.tsx | QuickPayIntroScreen.kt |
-| QuickpaySettings.tsx | QuickPaySettingsScreen.kt |
-| RGSServer/index.tsx | RgsServerScreen.kt |
-| SupportSettings/index.tsx | SupportScreen.kt |
-| ReportIssue/index.tsx | ReportIssueScreen.kt |
-| FormSuccess.tsx | ReportIssueResultScreen.kt |
-| DevSettings/index.tsx | DevSettingsScreen.kt |
-| LdkDebug.tsx | `n/a` |
-| Channels.tsx | LightningConnectionsScreen.kt |
-| ChannelDetails.tsx | ChannelDetailScreen.kt |
-| CloseConnection.tsx | CloseConnectionScreen.kt |
-| LightningNodeInfo.tsx | NodeInfoScreen.kt |
-| BackupSettings/index.tsx | BackupSettingsScreen.kt |
+| CriticalUpdateScreen.kt | Update › Forced update |
+| MigrationLoadingScreen.kt | Update › Forced migration |
+| SplashScreen.kt | New user › Splash and loading screen |
 
-## Backup & Recovery
-| RN | Android |
-| - | - |
-| Warning.tsx | WarningScreen.kt |
-| Backup/Success.tsx | SuccessScreen.kt |
-| ShowPassphrase.tsx | ShowPassphraseScreen.kt |
-| ShowMnemonic.tsx | ShowMnemonicScreen.kt |
-| Backup/MultipleDevices.tsx | MultipleDevicesScreen.kt |
-| Metadata.tsx | MetadataScreen.kt |
-| ConfirmPassphrase.tsx | ConfirmPassphraseScreen.kt |
-| ConfirmMnemonic.tsx | ConfirmMnemonicScreen.kt |
-| ResetAndRestore.tsx | ResetAndRestoreScreen.kt |
+## ui/screens/common
 
-## Onboarding
-| RN | Android |
+| Android | Figma |
 | - | - |
-| Welcome.tsx | OnboardingSlidesScreen.kt / IntroScreen.kt |
-| Slideshow.tsx | OnboardingSlidesScreen.kt |
-| Passphrase.tsx | CreateWalletWithPassphraseScreen.kt |
-| RestoreFromSeed.tsx | RestoreWalletScreen.kt |
-| Loading.tsx | InitializingWalletView.kt |
-| Onboarding/MultipleDevices.tsx | WarningMultipleDevicesScreen.kt |
-| TermsOfUse.tsx | TermsOfUseScreen.kt |
-| CreateWallet.tsx | WalletRestoreSuccessView.kt + WalletRestoreErrorView.kt |
+| ComingSoonScreen.kt | Soon › Coming Soon |
 
-## Profile & Contacts
-| RN | Android |
-| - | - |
-| Contacts.tsx | `todo` |
-| Contact.tsx | `todo` |
-| Profile.tsx | ProfileScreen.kt |
-| ProfileEdit.tsx | `n/a` |
-| ProfileOnboarding.tsx | ProfileIntroScreen.kt / PubkyRingAuthScreen.kt |
-| ProfileLink.tsx | `n/a` |
+## ui/screens/contacts
 
-## Widgets
-| RN | Android |
+| Android | Figma |
 | - | - |
-| Widget.tsx | widgets/*Card.kt |
-| WidgetEdit.tsx | widgets/*EditScreen.kt |
-| WidgetsOnboarding.tsx | WidgetsIntroScreen.kt |
-| WidgetsSuggestions.tsx | AddWidgetsScreen.kt |
+| AddContactScreen.kt | Contacts › Add new contact |
+| ContactActivityScreen.kt | Contacts › Contact activity |
+| ContactDetailScreen.kt | Contacts › Contact details |
+| ContactImportOverviewScreen.kt | Profile › Profile Contacts Import |
+| ContactImportSelectScreen.kt | Profile › Profile Contacts Import Select |
+| ContactsIntroScreen.kt | Contacts › My contacts |
+| ContactsScreen.kt | Contacts › My contacts list |
+| EditContactScreen.kt | Contacts › Contact Edit |
 
-## Shop
-| RN | Android |
-| - | - |
-| ShopIntro.tsx | ShopIntroScreen.kt |
-| ShopDiscover.tsx | ShopDiscoverScreen.kt |
-| ShopMain.tsx | ShopWebViewScreen.kt |
+## ui/screens/paymentrequests
 
-## Sheets
-| RN | Android |
+| Android | Figma |
 | - | - |
-| ReceivedTransaction.tsx | NewTransactionSheet.kt |
-| TransferFailed.tsx | todo |
-| AppUpdate.tsx | `todo` |
+| CreatePaymentRequestScreen.kt | Payment Request (from Receive > Contacts OR Contact profile OR Payment Requests) › Request payment enter amount |
+| PaymentRequestsScreen.kt | Payment Requests › Payment Requests |
+
+## ui/screens/profile
+
+| Android | Figma |
+| - | - |
+| CreateProfileScreen.kt | Profile › Profile Create |
+| EditProfileScreen.kt | Profile › Profile Edit |
+| PayContactsScreen.kt | Profile › Pay Contacts Setup |
+| ProfileIntroScreen.kt | Profile › Profile Intro |
+| ProfileScreen.kt | Profile › Profile active |
+| PubkyChoiceScreen.kt | Profile › Profile Create or use existing |
+
+## ui/screens/recovery
+
+| Android | Figma |
+| - | - |
+| RecoveryMnemonicScreen.kt | `n/a` |
+| RecoveryModeScreen.kt | `n/a` |
+
+## ui/screens/scanner
+
+| Android | Figma |
+| - | - |
+| QrScanningScreen.kt | Send (QuickPay) › Scan QR invoice Quickpay |
+
+## ui/screens/settings
+
+| Android | Figma |
+| - | - |
+| DevSettingsScreen.kt | `n/a` |
+| FeeSettingsScreen.kt | `n/a` |
+| LdkDebugScreen.kt | `n/a` |
+| LegacyRnRecoveryScreen.kt | `n/a` |
+| ProbingToolScreen.kt | `n/a` |
+| VssDebugScreen.kt | `n/a` |
+
+## ui/screens/shop
+
+| Android | Figma |
+| - | - |
+| ShopIntroScreen.kt | Shop (Bitrefill & BTCMaps) › Shop Onboarding |
+| shopDiscover/ShopDiscoverScreen.kt | Shop (Bitrefill & BTCMaps) › Shop Discover |
+| shopWebView/ShopWebViewScreen.kt | Shop (Bitrefill & BTCMaps) › Shop Gift Cards |
+
+## ui/screens/transfer
+
+| Android | Figma |
+| - | - |
+| FundingAdvancedScreen.kt | Manual Setup › Lightning Manual Setup |
+| FundingScreen.kt | Lightning Onboarding From Suggestion Card › Lightning onboarding Fund |
+| LiquidityScreen.kt | Transfer to Spending Balance From Savings (Channel Opening) › Transfer to Spending Receiving Capacity |
+| SavingsAdvancedScreen.kt | Transfer to Savings (Channel Closure) › Transfer to savings select funds |
+| SavingsAvailabilityScreen.kt | Transfer to Savings (Channel Closure) › Transfer warning |
+| SavingsConfirmScreen.kt | Transfer to Savings (Channel Closure) › Transfer all funds to savings review |
+| SavingsIntroScreen.kt | Transfer to Savings (Channel Closure) › Transfer to savings |
+| SavingsProgressScreen.kt | Transfer to Savings (Channel Closure) › Transfer to savings progress 2 |
+| SettingUpScreen.kt | Funds In Transfer › Transfer to Spending Progress 1 |
+| SpendingAdvancedScreen.kt | Transfer to Spending Balance From Savings (Channel Opening) › Transfer to Spending Confirm Advanced |
+| SpendingAmountScreen.kt | Transfer to Spending Balance From Savings (Channel Opening) › Transfer to Spending Input |
+| SpendingConfirmScreen.kt | Transfer to Spending Balance From Savings (Channel Opening) › Transfer to Spending Confirm |
+| SpendingIntroScreen.kt | Transfer to Spending Balance From Savings (Channel Opening) › Transfer to Spending Intro |
+| TransferIntroScreen.kt | Lightning Onboarding From Suggestion Card › Lightning onboarding Intro |
+
+## ui/screens/transfer/external
+
+| Android | Figma |
+| - | - |
+| ExternalAmountScreen.kt | Manual Setup › Lightning Manual Setup Input |
+| ExternalConfirmScreen.kt | Manual Setup › Lightning Manual Setup Confirm |
+| ExternalConnectionScreen.kt | Manual Setup › Lightning Manual Setup |
+| ExternalSuccessScreen.kt | Manual Setup › Lightning Manual Done |
+| LnurlChannelScreen.kt | Third-party LSP › LSP LNBIG |
+
+## ui/screens/transfer/hardware
+
+| Android | Figma |
+| - | - |
+| SpendingAmountHwScreen.kt | Transfer to Spending Balance From HW Device › Transfer to Spending Input HW |
+| SpendingHwSignScreen.kt | Transfer to Spending Balance From HW Device › Transfer to Spending Confirm HW |
+| SpendingHwSignedScreen.kt | Transfer to Spending Balance From HW Device › Transfer to Spending Confirmed HW |
+
+## ui/screens/trezor
+
+| Android | Figma |
+| - | - |
+| TrezorScreen.kt | Connect Hardware › Hardware Connect Device |
+
+## ui/screens/wallets
+
+| Android | Figma |
+| - | - |
+| HardwareWalletScreen.kt | Hardware › Wallet Hardware |
+| HomeScreen.kt | Wallet On-chain › Wallet BTC |
+| SavingsWalletScreen.kt | Savings, Spending, Hardware Balances › Savings Populated |
+| SpendingWalletScreen.kt | Savings, Spending, Hardware Balances › Spending Ready |
+
+## ui/screens/wallets/activity
+
+| Android | Figma |
+| - | - |
+| ActivityAssignContactScreen.kt | Wallet Lightning - Transfer to Spending Balance › TX Lightning Assign Contact |
+| ActivityDetailScreen.kt | Transaction Details › TX On-chain Confirmed / TX Lightning |
+| ActivityExploreScreen.kt | Transaction Details › TX On-chain Technical |
+| AllActivityScreen.kt | Activity › Activity |
+
+## ui/screens/wallets/receive
+
+| Android | Figma |
+| - | - |
+| EditInvoiceScreen.kt | Send (Contact) (Lightning) › Edit invoice populated |
+| LocationBlockScreen.kt | Send (Enter Manually) › CJIT Location Block |
+| ReceiveAmountScreen.kt | Receive CJIT Onboarding › CJIT Enter amount |
+| ReceiveConfirmScreen.kt | Send (Enter Manually) › CJIT Fee to connect |
+| ReceiveLiquidityScreen.kt | Send (Hardware Device) (On-chain) › Liquidity fee |
+| ReceiveQrScreen.kt | Receive Lightning Active › Receive Auto (Unified QR) |
+
+## ui/screens/wallets/send
+
+| Android | Figma |
+| - | - |
+| AddTagScreen.kt | Send (Paste) (On-chain) › Tag |
+| HwSendSignScreen.kt | Send (Hardware Device) (On-chain) › Sign with Hardware Device |
+| SendAddressScreen.kt | Send (Paste) (On-chain) › Address and Invoice |
+| SendAmountScreen.kt | Send (Paste) (On-chain) › Set amount |
+| SendCoinSelectionScreen.kt | Send (Paste) (On-chain) › Coin selection |
+| SendConfirmScreen.kt | Send (Paste) (On-chain) › Confirm Send Onchain |
+| SendContactSelectScreen.kt | Send (Contact) (Lightning) › Send to contact |
+| SendErrorScreen.kt | Send (Paste) (On-chain) › Transaction failed |
+| SendFeeCustomScreen.kt | Send (Paste) (On-chain) › Set custom fee |
+| SendFeeRateScreen.kt | Send (Paste) (On-chain) › Speed |
+| SendPendingScreen.kt | Send (Edge cases) › Transaction pending Lightning |
+| SendPinCheckScreen.kt | Active user › Enter PIN |
+| SendQuickPayScreen.kt | Send (QuickPay) › QuickPay Paying |
+| SendRecipientScreen.kt | Send › Send Bitcoin |
+
+## ui/screens/wallets/suggestion
+
+| Android | Figma |
+| - | - |
+| BuyIntroScreen.kt | Buy Bitcoin › Buy Bitcoin |
+
+## ui/screens/wallets/withdraw
+
+| Android | Figma |
+| - | - |
+| WithdrawConfirmScreen.kt | LNURL › LNURL Withdraw |
+| WithdrawErrorScreen.kt | LNURL › LNURL Withdraw Failed |
+
+## ui/screens/widgets
+
+| Android | Figma |
+| - | - |
+| AddWidgetsScreen.kt | Widgets › Add Widgets |
+| WidgetsIntroScreen.kt | Widgets › Widgets onboarding |
+| blocks/BlocksEditScreen.kt | Widgets › Bitcoin Blocks Widget Settings |
+| blocks/BlocksPreviewScreen.kt | Widgets › Bitcoin Blocks wide |
+| calculator/CalculatorPreviewScreen.kt | Widgets › Bitcoin Calculator wide |
+| facts/FactsPreviewScreen.kt | Widgets › Bitcoin Facts wide |
+| headlines/HeadlinesEditScreen.kt | Widgets › Bitcoin Headlines Widget Settings |
+| headlines/HeadlinesPreviewScreen.kt | Widgets › Bitcoin Headlines wide |
+| price/PriceEditScreen.kt | Widgets › Bitcoin Price Widget Feed Default |
+| price/PricePreviewScreen.kt | Widgets › Bitcoin Price wide |
+| suggestions/SuggestionsPreviewScreen.kt | Widgets › Bitcoin Suggestions |
+| weather/WeatherEditScreen.kt | Widgets › Bitcoin Weather Widget Settings |
+| weather/WeatherPreviewScreen.kt | Widgets › Bitcoin Weather wide |
+
+## ui/settings
+
+| Android | Figma |
+| - | - |
+| BackupSettingsScreen.kt | Back up wallet › Data Backups |
+| BlocktankRegtestScreen.kt | `n/a` |
+| ChannelOrdersScreen.kt | `n/a` |
+| LanguageSettingsScreen.kt | Settings > General › Settings Language |
+| LogsScreen.kt | `n/a` |
+| SettingsScreen.kt | Settings Categories › Settings General |
+| SwapsScreen.kt | `n/a` |
+
+## ui/settings/advanced
+
+| Android | Figma |
+| - | - |
+| AddressTypePreferenceScreen.kt | Settings > Advanced › Advanced > Bitcoin address type |
+| AddressViewerScreen.kt | Settings > Advanced › Advanced > Bitcoin UTXOs |
+| CoinSelectPreferenceScreen.kt | Settings > Advanced › Advanced > Coin selection |
+| ElectrumConfigScreen.kt | Settings > Advanced › Advanced > Electrum server |
+| RgsServerScreen.kt | `n/a` |
+| WatchOnlyAccountsScreen.kt | Settings > Advanced › Advanced > Payment Accounts |
+
+## ui/settings/appStatus
+
+| Android | Figma |
+| - | - |
+| AppStatusScreen.kt | Support & App Status › App Status OK |
+
+## ui/settings/backgroundPayments
+
+| Android | Figma |
+| - | - |
+| BackgroundPaymentsIntroScreen.kt | Settings > General › BackgroundPayments Intro |
+
+## ui/settings/backups
+
+| Android | Figma |
+| - | - |
+| BackupIntroScreen.kt | Back up wallet › Backup Intro |
+| ConfirmMnemonicScreen.kt | Back up wallet › Backup Recovery Phrase Confirm |
+| ConfirmPassphraseScreen.kt | Back up wallet › Backup Passphrase Confirm |
+| MetadataScreen.kt | Back up wallet › Bitcoin wallet backup data |
+| MultipleDevicesScreen.kt | Back up wallet › Bitcoin wallet back multidevice |
+| ResetAndRestoreScreen.kt | Back up wallet › Reset wallet |
+| ShowMnemonicScreen.kt | Back up wallet › Backup Recovery Phrase Displayed |
+| ShowPassphraseScreen.kt | Back up wallet › Backup Passphrase |
+| SuccessScreen.kt | Back up wallet › Backup Recovery Phrase Confirmed |
+| WarningScreen.kt | Back up wallet › Backup Passphrase Keep Safe |
+
+## ui/settings/general
+
+| Android | Figma |
+| - | - |
+| DefaultUnitSettingsScreen.kt | Settings > General › Setting Default Unit |
+| HardwareWalletsSettingsScreen.kt | Settings > General › Hardware Wallets |
+| LocalCurrencySettingsScreen.kt | Settings > General › Settings Local Currency |
+| TagsSettingsScreen.kt | Settings > General › Tags |
+| WidgetsSettingsScreen.kt | Settings > General › Widgets |
+
+## ui/settings/lightning
+
+| Android | Figma |
+| - | - |
+| ChannelDetailScreen.kt | Settings > Advanced › Connection details |
+| CloseConnectionScreen.kt | Settings > Advanced › Close connection |
+| LightningConnectionsScreen.kt | Settings > Advanced › Lightning Connections overview |
+
+## ui/settings/pin
+
+| Android | Figma |
+| - | - |
+| PinBiometricsScreen.kt | Security › Use Face ID |
+| PinChooseScreen.kt | Security › Create passcode |
+| PinConfirmScreen.kt | Security › Create passcode |
+| PinManagementScreen.kt | Settings > Security › PIN Enabled |
+| PinPromptScreen.kt | Settings > Security › PIN Change Enter Current |
+| PinResultScreen.kt | Settings > Security › PIN Change Succes |
+
+## ui/settings/quickPay
+
+| Android | Figma |
+| - | - |
+| QuickPayIntroScreen.kt | Settings > General › QuickPay Intro |
+| QuickPaySettingsScreen.kt | Settings > General › QuickPay Settings |
+
+## ui/settings/support
+
+| Android | Figma |
+| - | - |
+| ReportIssueResultScreen.kt | Support & App Status › Support Report Success |
+| ReportIssueScreen.kt | Support & App Status › Support Report |
+| SupportScreen.kt | Support & App Status › Support |
+
+## ui/settings/transactionSpeed
+
+| Android | Figma |
+| - | - |
+| CustomFeeSettingsScreen.kt | Send (Paste) (On-chain) › Set custom fee |
+| TransactionSpeedSettingsScreen.kt | Settings > General › Speed |

--- a/docs/screens-map.md
+++ b/docs/screens-map.md
@@ -4,8 +4,8 @@ Every `*Screen.kt` under `app/src/main/java`, grouped by feature package, with t
 
 Columns:
 
-- Android: the Compose screen file. Every `*Screen.kt` in the app has exactly one row; `ScreensMapTest` fails when a screen is added or removed without updating this file.
-- Figma: `Flow › Frame`, where Flow is the `SectionTitle` above the frame on the handoff page and Frame is the top-level frame name. `n/a` when the screen has no design (dev tools, debug screens).
+- Android: the Compose screen file. Every `*Screen.kt` in the app has exactly one row; `ScreensMapTest` fails when a screen is added or removed without updating this file. A row is the only requirement, a design is not.
+- Figma: `Flow › Frame`, where Flow is the `SectionTitle` above the frame on the handoff page and Frame is the top-level frame name. `todo` when the screen shipped ahead of its design; `n/a` when no design is intended (dev tools, debug screens).
 
 Frame names are stable across handoff iterations; node ids are not, so the map lists names only. Sheets, dialogs, and composables without the `Screen` suffix are out of scope.
 


### PR DESCRIPTION
Closes #1233

This PR:
1. Regenerates `docs/screens-map.md` from the current `*Screen.kt` set, grouped by feature package, with a `Flow › Frame` column pointing at the matching frame on the latest `Bitkit - Handoff vNN` Figma page
2. Drops the React Native column, which only served the migration
3. Adds a unit test that fails when a `*Screen.kt` is added or removed without a map row. A row is the only requirement: `todo` marks a screen shipped ahead of its design, `n/a` a screen with no design by intent
4. Points `AGENTS.md` at the map next to the existing Figma rule

### Description

The map was last touched on 2026-03-06 and had drifted: 68 of 155 screens had no entry and 5 entries pointed at deleted files. Agent-driven reviews use this file to turn a changed Compose screen into a Figma frame, so every screen now has one row and a stable frame name (node ids change between handoff iterations, names do not). Flow names come from the `SectionTitle` above each frame on the handoff page. Screens implemented before a design exists carry `todo`; dev and debug screens carry `n/a`.

### Preview

N/A — no user-visible changes.

### QA Notes
#### Manual Tests
N/A
#### Automated Checks
- Unit test added: `ScreensMapTest.kt` walks `app/src/main/java` for `*Screen.kt` files and compares the set with the file names referenced in `docs/screens-map.md`, reporting missing and stale entries. Verified locally that it passes on this branch and fails when a screen file is moved away.
- Detekt: no findings in the added test; the remaining reported findings are pre-existing on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
