### PR TITLE
docs: add paykit screens to screens map

### DIFF
--- a/docs/screens-map.md
+++ b/docs/screens-map.md
@@ -71,6 +71,7 @@ Frame names are stable across handoff iterations; node ids are not, so the map l
 | Android | Figma |
 | - | - |
 | CreatePaymentRequestScreen.kt | Payment Request (from Receive > Contacts OR Contact profile OR Payment Requests) › Request payment enter amount |
+| IncomingPaymentRequestDetailsScreen.kt | `todo` |
 | PaymentRequestsScreen.kt | Payment Requests › Payment Requests |
 
 ## ui/screens/profile
@@ -115,6 +116,12 @@ Frame names are stable across handoff iterations; node ids are not, so the map l
 | ShopIntroScreen.kt | Shop (Bitrefill & BTCMaps) › Shop Onboarding |
 | shopDiscover/ShopDiscoverScreen.kt | Shop (Bitrefill & BTCMaps) › Shop Discover |
 | shopWebView/ShopWebViewScreen.kt | Shop (Bitrefill & BTCMaps) › Shop Gift Cards |
+
+## ui/screens/subscriptions
+
+| Android | Figma |
+| - | - |
+| SubscriptionsScreen.kt | `todo` |
 
 ## ui/screens/transfer
 


### PR DESCRIPTION
This PR adds the two Paykit screens merged today to the screens map, which fixes the `ScreensMapTest` failure on `master`.

### Description

- Adds `IncomingPaymentRequestDetailsScreen.kt` under `ui/screens/paymentrequests` and `SubscriptionsScreen.kt` under a new `ui/screens/subscriptions` section, both marked `todo` until a handoff frame exists.

### Preview

N/A — no user-visible changes.

### QA Notes
#### Manual Tests
N/A
#### Automated Checks
- `ScreensMapTest.kt` passes locally after the change; it currently fails on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
